### PR TITLE
test: assert RAR5 timestamps in UTC to fix timezone-dependent CI failure

### DIFF
--- a/core/src/test/java/io/github/datromtool/io/copy/archive/impl/RarArchiveSourceSpecTest.java
+++ b/core/src/test/java/io/github/datromtool/io/copy/archive/impl/RarArchiveSourceSpecTest.java
@@ -27,12 +27,17 @@ class RarArchiveSourceSpecTest extends ArchiveContentsDependantTest {
     /**
      * junrar (>= 8.0.0) reads RAR5 natively, so a RAR5 archive opens and operates exactly like
      * a real unrar would: same entries, same contents, in physical order.
+     *
+     * <p>RAR5 stores modification times as absolute UTC (unlike RAR4's timezone-less MS-DOS
+     * local time), so the times are asserted against the absolute UTC expectations — no
+     * timezone conversion — exactly like the Zip and 7z source specs. Asserting the DOS-local
+     * variant made this test pass only under a UTC+1 default timezone and fail under UTC (CI).
      */
     @Test
     void testReadRar5Contents() throws IOException {
         try (RarArchiveSourceSpec spec = new RarArchiveSourceSpec(rar5File)) {
-            assertIsLoremIpsum(spec.getNextInternalSpec(), true);
-            assertIsShortText(spec.getNextInternalSpec(), true);
+            assertIsLoremIpsum(spec.getNextInternalSpec());
+            assertIsShortText(spec.getNextInternalSpec());
             assertNull(spec.getNextInternalSpec());
         }
     }


### PR DESCRIPTION
## Problem

CI is red on `master` (and was already failing before the agent-guidance commit). The RAR5
source-spec test is timezone-dependent:

```
RarArchiveSourceSpecTest.testReadRar5Contents
expected: <2022-02-23T10:25:55.206205Z> but was: <2022-02-23T09:25:55.206205Z>
```

Exactly one hour off, on a non-DST February date.

## Root cause

RAR5 stores modification times as **absolute UTC** (unlike RAR4's timezone-less MS-DOS local
time). But `testReadRar5Contents` asserted the RAR4 DOS-local variant
(`assertIsLoremIpsum(spec, true)`) with **no** `@DefaultTimeZone` pin. That expectation is
"wall-clock 10:25:55 interpreted in the JVM default timezone", so it only matched the file's
true instant (`09:25:55Z` = 10:25:55 CET) when the default zone was UTC+1 — the maintainer's
local zone. On CI (UTC) it fails by one hour.

The sibling Zip and 7z source-spec tests already assert the absolute UTC expectations
(`convertTimeZone = false`) and pass on CI; RAR5 is the same kind of format and should match.

## Fix (test-only)

Assert the absolute UTC expectations for RAR5, exactly like Zip/7z. Production code
(`RarArchiveSourceInternalSpec`) was already correct — it faithfully returns junrar's decoded
UTC instant.

## Evidence

- **RED** reproduced locally under `-Duser.timezone=UTC` — the exact CI failure at line 34.
- **GREEN** after the fix across `UTC`, `Europe/Amsterdam` (UTC+1), and `Asia/Kolkata`
  (UTC+5:30): `Tests run: 10, Failures: 0, Errors: 0`.
- Full reactor `mvn -B verify -Duser.timezone=UTC`: **BUILD SUCCESS**, zero failures — no
  other timezone-masked failures were hiding behind the aborted CI matrix.

🤖 Generated by [Claude Code](https://claude.com/claude-code), posted via @andrebrait's account on their behalf.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated RAR5 archive timestamp expectations to reflect absolute UTC modification times.
  * Simplified related test assertions for archive entry content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->