### PR TITLE
cli: fix --avoid-regex patterns being dropped from avoids

### DIFF
--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -69,6 +69,11 @@
             <artifactId>lombok</artifactId>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/cli/src/main/java/io/github/datromtool/cli/option/SortingOptions.java
+++ b/cli/src/main/java/io/github/datromtool/cli/option/SortingOptions.java
@@ -111,7 +111,7 @@ public final class SortingOptions {
                 .regions(ImmutableSet.copyOf(regions))
                 .languages(ImmutableSet.copyOf(languages))
                 .prefers(merge(prefers, preferRegexes, prefersFiles))
-                .avoids(merge(avoids, preferRegexes, avoidsFiles))
+                .avoids(merge(avoids, avoidRegexes, avoidsFiles))
                 .prioritizeLanguages(prioritizeLanguages)
                 .earlyVersions(earlyVersions)
                 .earlyRevisions(earlyRevisions)

--- a/cli/src/test/java/io/github/datromtool/cli/option/SortingOptionsTest.java
+++ b/cli/src/test/java/io/github/datromtool/cli/option/SortingOptionsTest.java
@@ -1,0 +1,56 @@
+package io.github.datromtool.cli.option;
+
+import io.github.datromtool.data.SortingPreference;
+import org.junit.jupiter.api.Test;
+import picocli.CommandLine;
+
+import java.util.Set;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class SortingOptionsTest {
+
+    @CommandLine.Command
+    private static final class Holder {
+
+        @CommandLine.ArgGroup(exclusive = false)
+        SortingOptions sortingOptions = new SortingOptions();
+    }
+
+    private static SortingPreference parse(String... args) {
+        Holder holder = new Holder();
+        new CommandLine(holder).parseArgs(args);
+        return holder.sortingOptions.toSortingPreference();
+    }
+
+    private static Set<String> patternsOf(Set<Pattern> patterns) {
+        return patterns.stream().map(Pattern::pattern).collect(Collectors.toSet());
+    }
+
+    @Test
+    void avoidRegexPopulatesAvoids() {
+        SortingPreference preference = parse("--avoid-regex", "Rev [AB]");
+        assertEquals(
+                Set.of("Rev [AB]"),
+                patternsOf(preference.getAvoids()),
+                "--avoid-regex expressions must land in the avoids set");
+        assertTrue(
+                preference.getPrefers().isEmpty(),
+                "--avoid-regex must not affect prefers, but got: " + preference.getPrefers());
+    }
+
+    @Test
+    void preferRegexPopulatesPrefersOnly() {
+        SortingPreference preference = parse("--prefer-regex", "Virtual Console");
+        assertEquals(
+                Set.of("Virtual Console"),
+                patternsOf(preference.getPrefers()),
+                "--prefer-regex expressions must land in the prefers set");
+        assertTrue(
+                preference.getAvoids().isEmpty(),
+                "--prefer-regex must not leak into avoids, but got: " + preference.getAvoids());
+    }
+}


### PR DESCRIPTION
Fixes #11

## What

`SortingOptions.toSortingPreference()` built the avoids set with `merge(avoids, preferRegexes, avoidsFiles)` — the wrong regex list. `--avoid-regex` was silently ignored, and any `--prefer-regex` pattern was additionally treated as an avoid, inverting the user's preference.

One-line fix: `preferRegexes` → `avoidRegexes` at `SortingOptions.java:114`. Also introduces the first test in the `cli` module (parse-level test on the prefers/avoids mapping) plus the `junit-jupiter` test dependency in `cli/pom.xml`.

## Red→green proof

Reproduction test executed RED on untouched code (both failures for the exact defect):

```
SortingOptionsTest.avoidRegexPopulatesAvoids:36 --avoid-regex expressions must land in the avoids set ==> expected: <[Rev [AB]]> but was: <[]>
SortingOptionsTest.preferRegexPopulatesPrefersOnly:52 --prefer-regex must not leak into avoids, but got: [Virtual Console] ==> expected: <true> but was: <false>
```

Test file frozen at `git hash-object` `adfa601ea160eb4938c9d0b6edb8030021b7f749` before the fix; hash identical at the GREEN run (zero edits):

```
Tests run: 2, Failures: 0, Errors: 0, Skipped: 0
```

Full `mvn verify` green across the reactor (domain/logging/core/cli).

🤖 Generated by [Claude Code](https://claude.com/claude-code), posted via @andrebrait's account on their behalf.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed command-line sorting so `--avoid-regex` expressions are correctly applied to exclusions.
  * Prevented avoidance and preference regular expressions from being mixed up.

* **Tests**
  * Added coverage confirming that `--avoid-regex` and `--prefer-regex` populate only their respective sorting options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->