### PR TITLE
cli: fix --copy-threads applying the scan thread count to the copier

### DIFF
--- a/cli/src/main/java/io/github/datromtool/cli/option/PerformanceOptions.java
+++ b/cli/src/main/java/io/github/datromtool/cli/option/PerformanceOptions.java
@@ -124,7 +124,7 @@ public class PerformanceOptions {
                 || allowRawZipCopy) {
             AppConfig.FileCopierConfig.FileCopierConfigBuilder builder = original.toBuilder();
             if (copyThreads != null) {
-                builder.threads(scanThreads);
+                builder.threads(copyThreads);
             }
             if (copyBufferSize != null) {
                 builder.bufferSize(toIntExact(copyBufferSize.getSizeInBytes()));

--- a/cli/src/test/java/io/github/datromtool/cli/option/PerformanceOptionsTest.java
+++ b/cli/src/test/java/io/github/datromtool/cli/option/PerformanceOptionsTest.java
@@ -1,0 +1,51 @@
+package io.github.datromtool.cli.option;
+
+import io.github.datromtool.config.AppConfig;
+import org.junit.jupiter.api.Test;
+import picocli.CommandLine;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class PerformanceOptionsTest {
+
+    @CommandLine.Command
+    private static final class Holder {
+
+        @CommandLine.ArgGroup(exclusive = false)
+        PerformanceOptions performanceOptions = new PerformanceOptions();
+    }
+
+    private static PerformanceOptions parse(String... args) {
+        Holder holder = new Holder();
+        new CommandLine(holder).parseArgs(args);
+        return holder.performanceOptions;
+    }
+
+    @Test
+    void copyThreadsAloneConfiguresTheCopier() {
+        PerformanceOptions options = parse("--copy-threads", "3");
+        AppConfig.FileCopierConfig merged =
+                options.merge(AppConfig.FileCopierConfig.builder().build());
+        assertEquals(
+                3,
+                merged.getThreads(),
+                "--copy-threads must set the copier thread count");
+    }
+
+    @Test
+    void scanAndCopyThreadCountsStayIndependent() {
+        PerformanceOptions options = parse("--scan-threads", "2", "--copy-threads", "3");
+        AppConfig.FileScannerConfig mergedScanner =
+                options.merge(AppConfig.FileScannerConfig.builder().build());
+        AppConfig.FileCopierConfig mergedCopier =
+                options.merge(AppConfig.FileCopierConfig.builder().build());
+        assertEquals(
+                2,
+                mergedScanner.getThreads(),
+                "--scan-threads must set the scanner thread count");
+        assertEquals(
+                3,
+                mergedCopier.getThreads(),
+                "--copy-threads must set the copier thread count, not the scanner's value");
+    }
+}


### PR DESCRIPTION
Fixes #12

## What

`PerformanceOptions.merge(FileCopierConfig)` passed `scanThreads` into the copier builder instead of `copyThreads` (`PerformanceOptions.java:127`). Consequences:

- `--copy-threads N` alone: NPE — `threads is marked non-null but is null` (null `scanThreads` into the `@NonNull` builder field).
- `--copy-threads N --scan-threads M`: copier silently ran with M threads.

One-line fix: `scanThreads` → `copyThreads`. Ships with parse-level tests pinning scanner/copier thread-count independence.

## Red→green proof

Reproduction tests executed RED on untouched code, both for the exact defect:

```
PerformanceOptionsTest.copyThreadsAloneConfiguresTheCopier:28 » NullPointer threads is marked non-null but is null
    at io.github.datromtool.cli.option.PerformanceOptions.merge(PerformanceOptions.java:127)
PerformanceOptionsTest.scanAndCopyThreadCountsStayIndependent:46 --copy-threads must set the copier thread count, not the scanner's value ==> expected: <3> but was: <2>
```

Test file frozen at `git hash-object` `49c3afcae9bb8f916e649d399c3da467c0423c9a` before the fix; hash identical at the GREEN run (zero edits):

```
Tests run: 2, Failures: 0, Errors: 0, Skipped: 0
```

Full `mvn verify` green across the reactor.

🤖 Generated by [Claude Code](https://claude.com/claude-code), posted via @andrebrait's account on their behalf.