### PR TITLE
build: update dependencies to latest stable releases

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,34 +33,34 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.release>25</maven.compiler.release>
-        <junit.version>6.1.0</junit.version>
+        <junit.version>6.1.2</junit.version>
         <junit.jupiter.pioneer.version>2.3.0</junit.jupiter.pioneer.version>
         <lombok.version>1.18.46</lombok.version>
         <commons-compress.version>1.28.0</commons-compress.version>
         <commons-lang3.version>3.20.0</commons-lang3.version>
         <commons-codec.version>1.22.0</commons-codec.version>
         <picocli.version>4.7.7</picocli.version>
-        <slf4j-api.version>2.0.16</slf4j-api.version>
-        <logback.version>1.5.33</logback.version>
+        <slf4j-api.version>2.0.18</slf4j-api.version>
+        <logback.version>1.6.0</logback.version>
         <guava.version>33.6.0-jre</guava.version>
-        <jackson.version>3.1.3</jackson.version>
-        <xz.version>1.9</xz.version>
+        <jackson.version>3.2.1</jackson.version>
+        <xz.version>1.12</xz.version>
         <junrar.version>8.0.0</junrar.version>
-        <git-commit-id-maven-plugin.version>9.0.1</git-commit-id-maven-plugin.version>
+        <git-commit-id-maven-plugin.version>10.0.0</git-commit-id-maven-plugin.version>
         <mockito-core.version>5.23.0</mockito-core.version>
-        <jline.version>3.30.13</jline.version>
+        <jline.version>3.30.16</jline.version>
         <jansi.version>2.4.3</jansi.version>
-        <versions-maven-plugin.version>2.17.1</versions-maven-plugin.version>
+        <versions-maven-plugin.version>2.21.0</versions-maven-plugin.version>
         <maven-scm-provider-gitexe.version>2.2.1</maven-scm-provider-gitexe.version>
         <maven-scm-api.version>2.2.1</maven-scm-api.version>
         <!-- Maven plugins -->
         <maven-compiler-plugin.version>3.13.0</maven-compiler-plugin.version>
-        <maven-surefire-plugin.version>3.5.2</maven-surefire-plugin.version>
-        <maven-assembly-plugin.version>3.7.1</maven-assembly-plugin.version>
+        <maven-surefire-plugin.version>3.5.6</maven-surefire-plugin.version>
+        <maven-assembly-plugin.version>3.8.0</maven-assembly-plugin.version>
         <maven-jar-plugin.version>3.4.2</maven-jar-plugin.version>
         <maven-install-plugin.version>3.1.3</maven-install-plugin.version>
         <maven-deploy-plugin.version>3.1.3</maven-deploy-plugin.version>
-        <maven-release-plugin.version>3.1.1</maven-release-plugin.version>
+        <maven-release-plugin.version>3.3.1</maven-release-plugin.version>
         <jsr305.version>3.0.2</jsr305.version>
     </properties>
 


### PR DESCRIPTION
Fixes #20

## What

Bumps 11 version properties in the root POM to their latest stable releases:

| Property | From | To |
|---|---|---|
| junit | 6.1.0 | 6.1.2 |
| slf4j-api | 2.0.16 | 2.0.18 |
| logback | 1.5.33 | 1.6.0 |
| jackson (tools.jackson) | 3.1.3 | 3.2.1 |
| xz | 1.9 | 1.12 |
| jline | 3.30.13 | 3.30.16 |
| git-commit-id-maven-plugin | 9.0.1 | 10.0.0 |
| versions-maven-plugin | 2.17.1 | 2.21.0 |
| maven-surefire-plugin | 3.5.2 | 3.5.6 |
| maven-assembly-plugin | 3.7.1 | 3.8.0 |
| maven-release-plugin | 3.1.1 | 3.3.1 |

Deliberately skipped (not stable): maven-compiler/deploy/install/jar `4.0.0-beta-*`, surefire `3.6.0-M1`, slf4j `2.1.0-alpha1`, jackson-annotations `3.0-rc*` (unpinned/transitive anyway). Everything else already at latest stable (picocli 4.7.7, guava 33.6.0-jre, commons-*, lombok, mockito, junrar, jansi, junit-pioneer, maven-scm 2.2.1).

## Verification

- `mvn -B clean verify` green across the reactor (core 306 tests, cli 2 tests) with the new versions.
- git-commit-id-maven-plugin 10.0.0 (major bump): probed the packaged CLI jar — `git.properties` still generated and embedded, `--version` output intact.
- Probed logback startup status lines on stdout: identical output rebuilt with 1.5.33 — pre-existing behavior, not introduced by the 1.6.0 bump.

Behavior-preserving change: the existing suite is the oracle (green before and after; no new behavior to pin per the repo test policy's behaviour-preserving exception).

🤖 Generated by [Claude Code](https://claude.com/claude-code), posted via @andrebrait's account on their behalf.
