### PR TITLE
cli/core: enums for category filters and sort order; type-safe performance value records

### DIFF
--- a/cli/src/main/java/io/github/datromtool/cli/DatRomCommand.java
+++ b/cli/src/main/java/io/github/datromtool/cli/DatRomCommand.java
@@ -5,6 +5,7 @@ import io.github.datromtool.cli.argument.DatafileArgument;
 import io.github.datromtool.cli.argument.PatternsFileArgument;
 import io.github.datromtool.cli.command.OneGameOneRomCommand;
 import io.github.datromtool.cli.converter.*;
+import io.github.datromtool.data.GameCategory;
 import io.github.datromtool.data.OutputMode;
 import io.github.datromtool.io.ArchiveType;
 import picocli.CommandLine;
@@ -24,6 +25,7 @@ public final class DatRomCommand {
     public static void main(String[] args) {
         CommandLine cmd = new CommandLine(new DatRomCommand());
         cmd.registerConverter(ArchiveType.class, new ArchiveTypeConverter());
+        cmd.registerConverter(GameCategory.class, new GameCategoryConverter());
         cmd.registerConverter(OutputMode.class, new OutputModeConverter());
         cmd.registerConverter(PatternsFileArgument.class, new PatternsFileConverter());
         cmd.registerConverter(DatafileArgument.class, new DatafileConverter());

--- a/cli/src/main/java/io/github/datromtool/cli/DatRomCommand.java
+++ b/cli/src/main/java/io/github/datromtool/cli/DatRomCommand.java
@@ -5,6 +5,11 @@ import io.github.datromtool.cli.argument.DatafileArgument;
 import io.github.datromtool.cli.argument.PatternsFileArgument;
 import io.github.datromtool.cli.command.OneGameOneRomCommand;
 import io.github.datromtool.cli.converter.*;
+import io.github.datromtool.config.CopyBufferSize;
+import io.github.datromtool.config.CopyThreads;
+import io.github.datromtool.config.ScanBufferSize;
+import io.github.datromtool.config.ScanMaxBufferSize;
+import io.github.datromtool.config.ScanThreads;
 import io.github.datromtool.data.GameCategory;
 import io.github.datromtool.data.OrderPreference;
 import io.github.datromtool.data.OutputMode;
@@ -32,6 +37,11 @@ public final class DatRomCommand {
         cmd.registerConverter(PatternsFileArgument.class, new PatternsFileConverter());
         cmd.registerConverter(DatafileArgument.class, new DatafileConverter());
         cmd.registerConverter(ByteSize.class, new ByteSizeConverter());
+        cmd.registerConverter(ScanThreads.class, new ScanThreadsConverter());
+        cmd.registerConverter(CopyThreads.class, new CopyThreadsConverter());
+        cmd.registerConverter(ScanBufferSize.class, new ScanBufferSizeConverter());
+        cmd.registerConverter(ScanMaxBufferSize.class, new ScanMaxBufferSizeConverter());
+        cmd.registerConverter(CopyBufferSize.class, new CopyBufferSizeConverter());
         int exitCode = cmd.execute(args);
         System.exit(exitCode);
     }

--- a/cli/src/main/java/io/github/datromtool/cli/DatRomCommand.java
+++ b/cli/src/main/java/io/github/datromtool/cli/DatRomCommand.java
@@ -6,6 +6,7 @@ import io.github.datromtool.cli.argument.PatternsFileArgument;
 import io.github.datromtool.cli.command.OneGameOneRomCommand;
 import io.github.datromtool.cli.converter.*;
 import io.github.datromtool.data.GameCategory;
+import io.github.datromtool.data.OrderPreference;
 import io.github.datromtool.data.OutputMode;
 import io.github.datromtool.io.ArchiveType;
 import picocli.CommandLine;
@@ -26,6 +27,7 @@ public final class DatRomCommand {
         CommandLine cmd = new CommandLine(new DatRomCommand());
         cmd.registerConverter(ArchiveType.class, new ArchiveTypeConverter());
         cmd.registerConverter(GameCategory.class, new GameCategoryConverter());
+        cmd.registerConverter(OrderPreference.class, new OrderPreferenceConverter());
         cmd.registerConverter(OutputMode.class, new OutputModeConverter());
         cmd.registerConverter(PatternsFileArgument.class, new PatternsFileConverter());
         cmd.registerConverter(DatafileArgument.class, new DatafileConverter());

--- a/cli/src/main/java/io/github/datromtool/cli/converter/AbstractBufferSizeConverter.java
+++ b/cli/src/main/java/io/github/datromtool/cli/converter/AbstractBufferSizeConverter.java
@@ -1,0 +1,28 @@
+package io.github.datromtool.cli.converter;
+
+import io.github.datromtool.ByteSize;
+import picocli.CommandLine;
+
+import static java.lang.Math.toIntExact;
+import static java.lang.String.format;
+
+/**
+ * Shared parsing for the buffer-size converters: parses a {@link ByteSize} string and rejects
+ * values over {@link Integer#MAX_VALUE} bytes before handing the byte count to the concrete
+ * wrapper record, so the "Maximum byte size is %d bytes" message stays in one place.
+ */
+abstract class AbstractBufferSizeConverter<T> implements CommandLine.ITypeConverter<T> {
+
+    private static final ByteSize MAX_BUFFER_SIZE = ByteSize.fromBytes(Integer.MAX_VALUE);
+
+    @Override
+    public final T convert(String value) {
+        ByteSize byteSize = ByteSize.fromString(value);
+        if (byteSize.compareTo(MAX_BUFFER_SIZE) > 0) {
+            throw new IllegalArgumentException(format("Maximum byte size is %d bytes", Integer.MAX_VALUE));
+        }
+        return wrap(toIntExact(byteSize.getSizeInBytes()));
+    }
+
+    protected abstract T wrap(int bytes);
+}

--- a/cli/src/main/java/io/github/datromtool/cli/converter/CopyBufferSizeConverter.java
+++ b/cli/src/main/java/io/github/datromtool/cli/converter/CopyBufferSizeConverter.java
@@ -1,0 +1,11 @@
+package io.github.datromtool.cli.converter;
+
+import io.github.datromtool.config.CopyBufferSize;
+
+public final class CopyBufferSizeConverter extends AbstractBufferSizeConverter<CopyBufferSize> {
+
+    @Override
+    protected CopyBufferSize wrap(int bytes) {
+        return new CopyBufferSize(bytes);
+    }
+}

--- a/cli/src/main/java/io/github/datromtool/cli/converter/CopyThreadsConverter.java
+++ b/cli/src/main/java/io/github/datromtool/cli/converter/CopyThreadsConverter.java
@@ -1,0 +1,12 @@
+package io.github.datromtool.cli.converter;
+
+import io.github.datromtool.config.CopyThreads;
+import picocli.CommandLine;
+
+public final class CopyThreadsConverter implements CommandLine.ITypeConverter<CopyThreads> {
+
+    @Override
+    public CopyThreads convert(String value) {
+        return new CopyThreads(Integer.parseInt(value));
+    }
+}

--- a/cli/src/main/java/io/github/datromtool/cli/converter/GameCategoryConverter.java
+++ b/cli/src/main/java/io/github/datromtool/cli/converter/GameCategoryConverter.java
@@ -7,12 +7,14 @@ import picocli.CommandLine;
 
 import javax.annotation.Nonnull;
 import java.util.Arrays;
+import java.util.Locale;
 
 public final class GameCategoryConverter
         implements CommandLine.ITypeConverter<GameCategory>, Iterable<String> {
 
     private final static ImmutableList<String> names = Arrays.stream(GameCategory.values())
             .map(Enum::name)
+            .map(n -> n.toLowerCase(Locale.ROOT))
             .collect(ImmutableList.toImmutableList());
 
     @Override
@@ -23,9 +25,11 @@ public final class GameCategoryConverter
 
     @Override
     public GameCategory convert(String value) {
+        String trimmed = value.trim();
         return names.stream()
-                .filter(n -> n.equalsIgnoreCase(value))
+                .filter(n -> n.equalsIgnoreCase(trimmed))
                 .findFirst()
+                .map(n -> n.toUpperCase(Locale.ROOT))
                 .map(GameCategory::valueOf)
                 .orElseThrow(() -> new CommandLine.TypeConversionException(
                         String.format(

--- a/cli/src/main/java/io/github/datromtool/cli/converter/GameCategoryConverter.java
+++ b/cli/src/main/java/io/github/datromtool/cli/converter/GameCategoryConverter.java
@@ -1,0 +1,36 @@
+package io.github.datromtool.cli.converter;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.UnmodifiableIterator;
+import io.github.datromtool.data.GameCategory;
+import picocli.CommandLine;
+
+import javax.annotation.Nonnull;
+import java.util.Arrays;
+
+public final class GameCategoryConverter
+        implements CommandLine.ITypeConverter<GameCategory>, Iterable<String> {
+
+    private final static ImmutableList<String> names = Arrays.stream(GameCategory.values())
+            .map(Enum::name)
+            .collect(ImmutableList.toImmutableList());
+
+    @Override
+    @Nonnull
+    public UnmodifiableIterator<String> iterator() {
+        return names.iterator();
+    }
+
+    @Override
+    public GameCategory convert(String value) {
+        return names.stream()
+                .filter(n -> n.equalsIgnoreCase(value))
+                .findFirst()
+                .map(GameCategory::valueOf)
+                .orElseThrow(() -> new CommandLine.TypeConversionException(
+                        String.format(
+                                "'%s' is not a valid category value. It must be one of %s",
+                                value,
+                                names)));
+    }
+}

--- a/cli/src/main/java/io/github/datromtool/cli/converter/OrderPreferenceConverter.java
+++ b/cli/src/main/java/io/github/datromtool/cli/converter/OrderPreferenceConverter.java
@@ -7,13 +7,14 @@ import picocli.CommandLine;
 
 import javax.annotation.Nonnull;
 import java.util.Arrays;
+import java.util.Locale;
 
 public final class OrderPreferenceConverter
         implements CommandLine.ITypeConverter<OrderPreference>, Iterable<String> {
 
     private final static ImmutableList<String> aliases = Arrays.stream(OrderPreference.values())
             .map(Enum::name)
-            .map(String::toLowerCase)
+            .map(n -> n.toLowerCase(Locale.ROOT))
             .collect(ImmutableList.toImmutableList());
 
     @Override
@@ -24,10 +25,11 @@ public final class OrderPreferenceConverter
 
     @Override
     public OrderPreference convert(String value) {
+        String trimmed = value.trim();
         return aliases.stream()
-                .filter(c -> c.equalsIgnoreCase(value))
+                .filter(c -> c.equalsIgnoreCase(trimmed))
                 .findFirst()
-                .map(String::toUpperCase)
+                .map(c -> c.toUpperCase(Locale.ROOT))
                 .map(OrderPreference::valueOf)
                 .orElseThrow(() -> new CommandLine.TypeConversionException(
                         String.format(

--- a/cli/src/main/java/io/github/datromtool/cli/converter/OrderPreferenceConverter.java
+++ b/cli/src/main/java/io/github/datromtool/cli/converter/OrderPreferenceConverter.java
@@ -1,0 +1,38 @@
+package io.github.datromtool.cli.converter;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.UnmodifiableIterator;
+import io.github.datromtool.data.OrderPreference;
+import picocli.CommandLine;
+
+import javax.annotation.Nonnull;
+import java.util.Arrays;
+
+public final class OrderPreferenceConverter
+        implements CommandLine.ITypeConverter<OrderPreference>, Iterable<String> {
+
+    private final static ImmutableList<String> aliases = Arrays.stream(OrderPreference.values())
+            .map(Enum::name)
+            .map(String::toLowerCase)
+            .collect(ImmutableList.toImmutableList());
+
+    @Override
+    @Nonnull
+    public UnmodifiableIterator<String> iterator() {
+        return aliases.iterator();
+    }
+
+    @Override
+    public OrderPreference convert(String value) {
+        return aliases.stream()
+                .filter(c -> c.equalsIgnoreCase(value))
+                .findFirst()
+                .map(String::toUpperCase)
+                .map(OrderPreference::valueOf)
+                .orElseThrow(() -> new CommandLine.TypeConversionException(
+                        String.format(
+                                "'%s' is not a valid order value. It must be one of %s",
+                                value,
+                                aliases)));
+    }
+}

--- a/cli/src/main/java/io/github/datromtool/cli/converter/ScanBufferSizeConverter.java
+++ b/cli/src/main/java/io/github/datromtool/cli/converter/ScanBufferSizeConverter.java
@@ -1,0 +1,11 @@
+package io.github.datromtool.cli.converter;
+
+import io.github.datromtool.config.ScanBufferSize;
+
+public final class ScanBufferSizeConverter extends AbstractBufferSizeConverter<ScanBufferSize> {
+
+    @Override
+    protected ScanBufferSize wrap(int bytes) {
+        return new ScanBufferSize(bytes);
+    }
+}

--- a/cli/src/main/java/io/github/datromtool/cli/converter/ScanMaxBufferSizeConverter.java
+++ b/cli/src/main/java/io/github/datromtool/cli/converter/ScanMaxBufferSizeConverter.java
@@ -1,0 +1,11 @@
+package io.github.datromtool.cli.converter;
+
+import io.github.datromtool.config.ScanMaxBufferSize;
+
+public final class ScanMaxBufferSizeConverter extends AbstractBufferSizeConverter<ScanMaxBufferSize> {
+
+    @Override
+    protected ScanMaxBufferSize wrap(int bytes) {
+        return new ScanMaxBufferSize(bytes);
+    }
+}

--- a/cli/src/main/java/io/github/datromtool/cli/converter/ScanThreadsConverter.java
+++ b/cli/src/main/java/io/github/datromtool/cli/converter/ScanThreadsConverter.java
@@ -1,0 +1,12 @@
+package io.github.datromtool.cli.converter;
+
+import io.github.datromtool.config.ScanThreads;
+import picocli.CommandLine;
+
+public final class ScanThreadsConverter implements CommandLine.ITypeConverter<ScanThreads> {
+
+    @Override
+    public ScanThreads convert(String value) {
+        return new ScanThreads(Integer.parseInt(value));
+    }
+}

--- a/cli/src/main/java/io/github/datromtool/cli/option/FilteringOptions.java
+++ b/cli/src/main/java/io/github/datromtool/cli/option/FilteringOptions.java
@@ -1,16 +1,15 @@
 package io.github.datromtool.cli.option;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
-import io.github.datromtool.Patterns;
 import io.github.datromtool.cli.argument.PatternsFileArgument;
+import io.github.datromtool.cli.converter.GameCategoryConverter;
 import io.github.datromtool.cli.converter.TrimmingLowerCaseConverter;
 import io.github.datromtool.cli.converter.TrimmingUpperCaseConverter;
 import io.github.datromtool.data.Filter;
+import io.github.datromtool.data.GameCategory;
 import lombok.Data;
-import lombok.Getter;
 import lombok.NoArgsConstructor;
 import picocli.CommandLine;
 
@@ -19,7 +18,6 @@ import java.util.regex.Pattern;
 
 import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_DEFAULT;
 import static io.github.datromtool.cli.util.ArgumentUtils.merge;
-import static lombok.AccessLevel.NONE;
 
 @Data
 @NoArgsConstructor
@@ -99,160 +97,14 @@ public final class FilteringOptions {
     private List<PatternsFileArgument> includesFiles = ImmutableList.of();
 
     @CommandLine.Option(
-            names = "--bad",
-            description = "Include/exclude bad dumps",
-            negatable = true)
-    @Getter(NONE)
-    private Boolean allowBad;
-
-    @CommandLine.Option(
-            names = "--proto",
-            description = "Include/exclude prototype entries",
-            negatable = true)
-    @Getter(NONE)
-    private Boolean allowProto;
-
-    @CommandLine.Option(
-            names = "--beta",
-            description = "Include/exclude beta entries",
-            negatable = true)
-    @Getter(NONE)
-    private Boolean allowBeta;
-
-    @CommandLine.Option(
-            names = "--demo",
-            description = "Include/exclude demo entries",
-            negatable = true)
-    @Getter(NONE)
-    private Boolean allowDemo;
-
-    @CommandLine.Option(
-            names = "--sample",
-            description = "Include/exclude sample entries",
-            negatable = true)
-    @Getter(NONE)
-    private Boolean allowSample;
-
-    @CommandLine.Option(
-            names = "--bios",
-            description = "Include/exclude BIOS entries",
-            negatable = true)
-    @Getter(NONE)
-    private Boolean allowBios;
-
-    @CommandLine.Option(
-            names = "--program",
-            description = "Include/exclude program entries",
-            negatable = true)
-    @Getter(NONE)
-    private Boolean allowProgram;
-
-    @CommandLine.Option(
-            names = "--chip",
-            description = "Include/exclude enhancement chip entries",
-            negatable = true)
-    @Getter(NONE)
-    private Boolean allowChip;
-
-    @CommandLine.Option(
-            names = "--pirate",
-            description = "Include/exclude pirate entries",
-            negatable = true)
-    @Getter(NONE)
-    private Boolean allowPirate;
-
-    @CommandLine.Option(
-            names = "--promo",
-            description = "Include/exclude promotion entries",
-            negatable = true)
-    @Getter(NONE)
-    private Boolean allowPromo;
-
-    @CommandLine.Option(
-            names = "--unlicensed",
-            description = "Include/exclude unlicensed entries",
-            negatable = true)
-    @Getter(NONE)
-    private Boolean allowUnlicensed;
-
-    @CommandLine.Option(
-            names = "--dlc",
-            description = "Include/exclude DLCs",
-            negatable = true)
-    @Getter(NONE)
-    private Boolean allowDlc;
-
-    @CommandLine.Option(
-            names = "--update",
-            description = "Include/exclude software update entries",
-            negatable = true)
-    @Getter(NONE)
-    private Boolean allowUpdate;
-
-    @CommandLine.Option(
-            names = "--no-all",
-            description = "Exclude all the above")
-    @Getter(NONE)
-    @JsonIgnore
-    private boolean excludeAll;
-
-    private boolean reallySet(Boolean condition) {
-        return excludeAll
-                ? condition != null && condition
-                : condition == null || condition;
-    }
-
-    public boolean isAllowBad() {
-        return reallySet(allowBad);
-    }
-
-    public boolean isAllowProto() {
-        return reallySet(allowProto);
-    }
-
-    public boolean isAllowBeta() {
-        return reallySet(allowBeta);
-    }
-
-    public boolean isAllowDemo() {
-        return reallySet(allowDemo);
-    }
-
-    public boolean isAllowSample() {
-        return reallySet(allowSample);
-    }
-
-    public boolean isAllowBios() {
-        return reallySet(allowBios);
-    }
-
-    public boolean isAllowProgram() {
-        return reallySet(allowProgram);
-    }
-
-    public boolean isAllowChip() {
-        return reallySet(allowChip);
-    }
-
-    public boolean isAllowPirate() {
-        return reallySet(allowPirate);
-    }
-
-    public boolean isAllowPromo() {
-        return reallySet(allowPromo);
-    }
-
-    public boolean isAllowUnlicensed() {
-        return reallySet(allowUnlicensed);
-    }
-
-    public boolean isAllowDlc() {
-        return reallySet(allowDlc);
-    }
-
-    public boolean isAllowUpdate() {
-        return reallySet(allowUpdate);
-    }
+            names = "--exclude-categories",
+            split = "\\s*,\\s*",
+            splitSynopsisLabel = ",",
+            paramLabel = "CATEGORY",
+            description = "Exclude entries belonging to the given categories. "
+                    + "Options: ${COMPLETION-CANDIDATES}",
+            completionCandidates = GameCategoryConverter.class)
+    private List<GameCategory> excludeCategories = ImmutableList.of();
 
     public Filter toFilter() {
         Filter.FilterBuilder builder = Filter.builder();
@@ -260,38 +112,8 @@ public final class FilteringOptions {
         builder.excludeRegions(ImmutableSet.copyOf(excludeRegions));
         builder.includeLanguages(ImmutableSet.copyOf(includeLanguages));
         builder.excludeLanguages(ImmutableSet.copyOf(excludeLanguages));
-        builder.allowProto(isAllowProto());
-        builder.allowBeta(isAllowBeta());
-        builder.allowDemo(isAllowDemo());
-        builder.allowSample(isAllowSample());
-        builder.allowBios(isAllowBios());
-        ImmutableSet.Builder<Pattern> excludeRegexesBuilder = ImmutableSet.builder();
-        if (!isAllowBad()) {
-            excludeRegexesBuilder.add(Patterns.BAD);
-        }
-        if (!isAllowProgram()) {
-            excludeRegexesBuilder.add(Patterns.PROGRAM);
-        }
-        if (!isAllowChip()) {
-            excludeRegexesBuilder.add(Patterns.ENHANCEMENT_CHIP);
-        }
-        if (!isAllowPirate()) {
-            excludeRegexesBuilder.add(Patterns.PIRATE);
-        }
-        if (!isAllowPromo()) {
-            excludeRegexesBuilder.add(Patterns.PROMO);
-        }
-        if (!isAllowUnlicensed()) {
-            excludeRegexesBuilder.add(Patterns.UNLICENSED);
-        }
-        if (!isAllowDlc()) {
-            excludeRegexesBuilder.add(Patterns.DLC);
-        }
-        if (!isAllowUpdate()) {
-            excludeRegexesBuilder.add(Patterns.UPDATE);
-        }
-        excludeRegexesBuilder.addAll(excludeRegexes);
-        builder.excludes(merge(excludes, excludeRegexesBuilder.build(), excludesFiles));
+        builder.excludeCategories(ImmutableSet.copyOf(excludeCategories));
+        builder.excludes(merge(excludes, excludeRegexes, excludesFiles));
         builder.includes(merge(includes, includeRegexes, includesFiles));
         return builder.build();
     }

--- a/cli/src/main/java/io/github/datromtool/cli/option/PerformanceOptions.java
+++ b/cli/src/main/java/io/github/datromtool/cli/option/PerformanceOptions.java
@@ -1,81 +1,78 @@
 package io.github.datromtool.cli.option;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
-import io.github.datromtool.ByteSize;
+import io.github.datromtool.cli.converter.CopyBufferSizeConverter;
+import io.github.datromtool.cli.converter.CopyThreadsConverter;
+import io.github.datromtool.cli.converter.ScanBufferSizeConverter;
+import io.github.datromtool.cli.converter.ScanMaxBufferSizeConverter;
+import io.github.datromtool.cli.converter.ScanThreadsConverter;
 import io.github.datromtool.config.AppConfig;
-import lombok.*;
+import io.github.datromtool.config.CopyBufferSize;
+import io.github.datromtool.config.CopyThreads;
+import io.github.datromtool.config.ScanBufferSize;
+import io.github.datromtool.config.ScanMaxBufferSize;
+import io.github.datromtool.config.ScanThreads;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 import picocli.CommandLine;
 
 import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_DEFAULT;
-import static java.lang.Math.toIntExact;
-import static java.lang.String.format;
-import static lombok.AccessLevel.NONE;
 
 @Data
 @NoArgsConstructor
 @JsonInclude(NON_DEFAULT)
 public class PerformanceOptions {
 
-    private static final ByteSize MAX_BUFFER_SIZE = ByteSize.fromBytes(Integer.MAX_VALUE);
+    private ScanThreads scanThreads;
+    private ScanBufferSize scanBufferSize;
+    private ScanMaxBufferSize scanBufferMaxSize;
 
-    @CommandLine.Spec
-    @ToString.Exclude
-    @JsonIgnore
-    @Getter(NONE)
-    @Setter(NONE)
-    private CommandLine.Model.CommandSpec spec;
-
-    private Integer scanThreads;
-    private ByteSize scanBufferSize;
-    private ByteSize scanBufferMaxSize;
-
-    private Integer copyThreads;
-    private ByteSize copyBufferSize;
+    private CopyThreads copyThreads;
+    private CopyBufferSize copyBufferSize;
     private boolean allowRawZipCopy;
 
     @CommandLine.Option(
             names = "--scan-threads",
             paramLabel = "THREADS",
+            converter = ScanThreadsConverter.class,
             description = "Number of threads to use for scanning files. Defaults to half the number of CPUs.")
-    public void setScanThreads(Integer scanThreads) {
-        validateThreads(scanThreads);
+    public void setScanThreads(ScanThreads scanThreads) {
         this.scanThreads = scanThreads;
     }
 
     @CommandLine.Option(
             names = "--scan-buffer",
             paramLabel = "BYTES",
+            converter = ScanBufferSizeConverter.class,
             description = "Default size for the dynamic I/O buffer used for scanning files (per thread). Defaults to 32KB.")
-    public void setScanBufferSize(ByteSize scanBufferSize) {
-        validateBufferSize(scanBufferSize);
+    public void setScanBufferSize(ScanBufferSize scanBufferSize) {
         this.scanBufferSize = scanBufferSize;
     }
 
     @CommandLine.Option(
             names = "--scan-max-buffer",
             paramLabel = "BYTES",
+            converter = ScanMaxBufferSizeConverter.class,
             description = "Maximum size for the dynamic I/O buffer used for scanning files (per thread). Defaults to 256MB.")
-    public void setScanBufferMaxSize(ByteSize scanBufferMaxSize) {
-        validateBufferSize(scanBufferMaxSize);
+    public void setScanBufferMaxSize(ScanMaxBufferSize scanBufferMaxSize) {
         this.scanBufferMaxSize = scanBufferMaxSize;
     }
 
     @CommandLine.Option(
             names = "--copy-threads",
             paramLabel = "THREADS",
+            converter = CopyThreadsConverter.class,
             description = "Number of threads to use for copying files. Defaults to half the number of CPUs.")
-    public void setCopyThreads(Integer copyThreads) {
-        validateThreads(copyThreads);
+    public void setCopyThreads(CopyThreads copyThreads) {
         this.copyThreads = copyThreads;
     }
 
     @CommandLine.Option(
             names = "--copy-buffer",
             paramLabel = "BYTES",
+            converter = CopyBufferSizeConverter.class,
             description = "Size for the I/O buffer used for copying files (per thread). Defaults to 32KB.")
-    public void setCopyBufferSize(ByteSize copyBufferSize) {
-        validateBufferSize(copyBufferSize);
+    public void setCopyBufferSize(CopyBufferSize copyBufferSize) {
         this.copyBufferSize = copyBufferSize;
     }
 
@@ -87,18 +84,6 @@ public class PerformanceOptions {
         this.allowRawZipCopy = allowRawZipCopy;
     }
 
-    private void validateThreads(Integer threads) {
-        if (threads <= 0) {
-            throw new CommandLine.ParameterException(spec.commandLine(), "Number of threads should be a positive number");
-        }
-    }
-
-    private void validateBufferSize(ByteSize scanBufferMaxSize) {
-        if (scanBufferMaxSize.compareTo(MAX_BUFFER_SIZE) > 0) {
-            throw new CommandLine.ParameterException(spec.commandLine(), format("Maximum byte size is %d bytes", Integer.MAX_VALUE));
-        }
-    }
-
     public AppConfig.FileScannerConfig merge(AppConfig.FileScannerConfig original) {
         if (scanThreads != null
                 || scanBufferSize != null
@@ -108,10 +93,10 @@ public class PerformanceOptions {
                 builder.threads(scanThreads);
             }
             if (scanBufferSize != null) {
-                builder.defaultBufferSize(toIntExact(scanBufferSize.getSizeInBytes()));
+                builder.defaultBufferSize(scanBufferSize);
             }
             if (scanBufferMaxSize != null) {
-                builder.maxBufferSize(toIntExact(scanBufferMaxSize.getSizeInBytes()));
+                builder.maxBufferSize(scanBufferMaxSize);
             }
             return builder.build();
         }
@@ -127,7 +112,7 @@ public class PerformanceOptions {
                 builder.threads(copyThreads);
             }
             if (copyBufferSize != null) {
-                builder.bufferSize(toIntExact(copyBufferSize.getSizeInBytes()));
+                builder.bufferSize(copyBufferSize);
             }
             builder.allowRawZipCopy(allowRawZipCopy);
             return builder.build();

--- a/cli/src/main/java/io/github/datromtool/cli/option/SortingOptions.java
+++ b/cli/src/main/java/io/github/datromtool/cli/option/SortingOptions.java
@@ -4,8 +4,10 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import io.github.datromtool.cli.argument.PatternsFileArgument;
+import io.github.datromtool.cli.converter.OrderPreferenceConverter;
 import io.github.datromtool.cli.converter.TrimmingLowerCaseConverter;
 import io.github.datromtool.cli.converter.TrimmingUpperCaseConverter;
+import io.github.datromtool.data.OrderPreference;
 import io.github.datromtool.data.SortingPreference;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -82,19 +84,31 @@ public final class SortingOptions {
     private boolean prioritizeLanguages;
 
     @CommandLine.Option(
-            names = "--early-versions",
-            description = "Prefer release entries with earlier versions")
-    boolean earlyVersions = false;
+            names = "--versions",
+            paramLabel = "ORDER",
+            converter = OrderPreferenceConverter.class,
+            description = "Sorting order preference for release entries by version. "
+                    + "Options: ${COMPLETION-CANDIDATES}",
+            completionCandidates = OrderPreferenceConverter.class)
+    OrderPreference versions = OrderPreference.LATEST;
 
     @CommandLine.Option(
-            names = "--early-revisions",
-            description = "Prefer release entries with earlier revisions")
-    boolean earlyRevisions = false;
+            names = "--revisions",
+            paramLabel = "ORDER",
+            converter = OrderPreferenceConverter.class,
+            description = "Sorting order preference for release entries by revision. "
+                    + "Options: ${COMPLETION-CANDIDATES}",
+            completionCandidates = OrderPreferenceConverter.class)
+    OrderPreference revisions = OrderPreference.LATEST;
 
     @CommandLine.Option(
-            names = "--early-prereleases",
-            description = "Prefer entries of earlier prerelease versions")
-    boolean earlyPrereleases = false;
+            names = "--prereleases",
+            paramLabel = "ORDER",
+            converter = OrderPreferenceConverter.class,
+            description = "Sorting order preference for prerelease entries (sample, demo, beta, "
+                    + "proto). Options: ${COMPLETION-CANDIDATES}",
+            completionCandidates = OrderPreferenceConverter.class)
+    OrderPreference prereleases = OrderPreference.LATEST;
 
     @CommandLine.Option(
             names = "--prefer-prereleases",
@@ -113,9 +127,9 @@ public final class SortingOptions {
                 .prefers(merge(prefers, preferRegexes, prefersFiles))
                 .avoids(merge(avoids, avoidRegexes, avoidsFiles))
                 .prioritizeLanguages(prioritizeLanguages)
-                .earlyVersions(earlyVersions)
-                .earlyRevisions(earlyRevisions)
-                .earlyPrereleases(earlyPrereleases)
+                .versions(versions)
+                .revisions(revisions)
+                .prereleases(prereleases)
                 .preferPrereleases(preferPrereleases)
                 .preferParents(preferParents)
                 .build();

--- a/cli/src/test/java/io/github/datromtool/cli/converter/CopyBufferSizeConverterTest.java
+++ b/cli/src/test/java/io/github/datromtool/cli/converter/CopyBufferSizeConverterTest.java
@@ -1,0 +1,35 @@
+package io.github.datromtool.cli.converter;
+
+import io.github.datromtool.config.CopyBufferSize;
+import org.junit.jupiter.api.Test;
+
+import static java.lang.String.format;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/** Direct unit tests for {@link CopyBufferSizeConverter} (issue #14 step 3). */
+class CopyBufferSizeConverterTest {
+
+    private static final CopyBufferSizeConverter CONVERTER = new CopyBufferSizeConverter();
+
+    @Test
+    void parsesPlainByteCount() {
+        assertEquals(new CopyBufferSize(1024), CONVERTER.convert("1024"));
+    }
+
+    @Test
+    void parsesKilobyteSuffix() {
+        assertEquals(new CopyBufferSize(32 * 1024), CONVERTER.convert("32KB"));
+    }
+
+    @Test
+    void overIntegerMaxValueFailsWithPreservedMessage() {
+        IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class, () -> CONVERTER.convert("3GB"));
+        assertEquals(format("Maximum byte size is %d bytes", Integer.MAX_VALUE), thrown.getMessage());
+    }
+
+    @Test
+    void zeroFailsValidation() {
+        assertThrows(IllegalArgumentException.class, () -> CONVERTER.convert("0"));
+    }
+}

--- a/cli/src/test/java/io/github/datromtool/cli/converter/CopyThreadsConverterTest.java
+++ b/cli/src/test/java/io/github/datromtool/cli/converter/CopyThreadsConverterTest.java
@@ -1,0 +1,35 @@
+package io.github.datromtool.cli.converter;
+
+import io.github.datromtool.config.CopyThreads;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/** Direct unit tests for {@link CopyThreadsConverter} (issue #14 step 3). */
+class CopyThreadsConverterTest {
+
+    private static final CopyThreadsConverter CONVERTER = new CopyThreadsConverter();
+
+    @Test
+    void parsesPositiveInt() {
+        assertEquals(new CopyThreads(4), CONVERTER.convert("4"));
+    }
+
+    @Test
+    void zeroFailsValidationWithPositiveMessage() {
+        IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class, () -> CONVERTER.convert("0"));
+        assertTrue(thrown.getMessage().toLowerCase().contains("positive"));
+    }
+
+    @Test
+    void negativeFailsValidation() {
+        assertThrows(IllegalArgumentException.class, () -> CONVERTER.convert("-1"));
+    }
+
+    @Test
+    void garbageValueFailsToParse() {
+        assertThrows(NumberFormatException.class, () -> CONVERTER.convert("abc"));
+    }
+}

--- a/cli/src/test/java/io/github/datromtool/cli/converter/CopyThreadsConverterTest.java
+++ b/cli/src/test/java/io/github/datromtool/cli/converter/CopyThreadsConverterTest.java
@@ -3,6 +3,8 @@ package io.github.datromtool.cli.converter;
 import io.github.datromtool.config.CopyThreads;
 import org.junit.jupiter.api.Test;
 
+import java.util.Locale;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -20,7 +22,7 @@ class CopyThreadsConverterTest {
     @Test
     void zeroFailsValidationWithPositiveMessage() {
         IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class, () -> CONVERTER.convert("0"));
-        assertTrue(thrown.getMessage().toLowerCase().contains("positive"));
+        assertTrue(thrown.getMessage().toLowerCase(Locale.ROOT).contains("positive"));
     }
 
     @Test

--- a/cli/src/test/java/io/github/datromtool/cli/converter/ScanBufferSizeConverterTest.java
+++ b/cli/src/test/java/io/github/datromtool/cli/converter/ScanBufferSizeConverterTest.java
@@ -1,0 +1,35 @@
+package io.github.datromtool.cli.converter;
+
+import io.github.datromtool.config.ScanBufferSize;
+import org.junit.jupiter.api.Test;
+
+import static java.lang.String.format;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/** Direct unit tests for {@link ScanBufferSizeConverter} (issue #14 step 3). */
+class ScanBufferSizeConverterTest {
+
+    private static final ScanBufferSizeConverter CONVERTER = new ScanBufferSizeConverter();
+
+    @Test
+    void parsesPlainByteCount() {
+        assertEquals(new ScanBufferSize(1024), CONVERTER.convert("1024"));
+    }
+
+    @Test
+    void parsesKilobyteSuffix() {
+        assertEquals(new ScanBufferSize(32 * 1024), CONVERTER.convert("32KB"));
+    }
+
+    @Test
+    void overIntegerMaxValueFailsWithPreservedMessage() {
+        IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class, () -> CONVERTER.convert("3GB"));
+        assertEquals(format("Maximum byte size is %d bytes", Integer.MAX_VALUE), thrown.getMessage());
+    }
+
+    @Test
+    void zeroFailsValidation() {
+        assertThrows(IllegalArgumentException.class, () -> CONVERTER.convert("0"));
+    }
+}

--- a/cli/src/test/java/io/github/datromtool/cli/converter/ScanMaxBufferSizeConverterTest.java
+++ b/cli/src/test/java/io/github/datromtool/cli/converter/ScanMaxBufferSizeConverterTest.java
@@ -1,0 +1,35 @@
+package io.github.datromtool.cli.converter;
+
+import io.github.datromtool.config.ScanMaxBufferSize;
+import org.junit.jupiter.api.Test;
+
+import static java.lang.String.format;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/** Direct unit tests for {@link ScanMaxBufferSizeConverter} (issue #14 step 3). */
+class ScanMaxBufferSizeConverterTest {
+
+    private static final ScanMaxBufferSizeConverter CONVERTER = new ScanMaxBufferSizeConverter();
+
+    @Test
+    void parsesPlainByteCount() {
+        assertEquals(new ScanMaxBufferSize(1024), CONVERTER.convert("1024"));
+    }
+
+    @Test
+    void parsesMegabyteSuffix() {
+        assertEquals(new ScanMaxBufferSize(256 * 1024 * 1024), CONVERTER.convert("256MB"));
+    }
+
+    @Test
+    void overIntegerMaxValueFailsWithPreservedMessage() {
+        IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class, () -> CONVERTER.convert("3GB"));
+        assertEquals(format("Maximum byte size is %d bytes", Integer.MAX_VALUE), thrown.getMessage());
+    }
+
+    @Test
+    void zeroFailsValidation() {
+        assertThrows(IllegalArgumentException.class, () -> CONVERTER.convert("0"));
+    }
+}

--- a/cli/src/test/java/io/github/datromtool/cli/converter/ScanThreadsConverterTest.java
+++ b/cli/src/test/java/io/github/datromtool/cli/converter/ScanThreadsConverterTest.java
@@ -3,6 +3,8 @@ package io.github.datromtool.cli.converter;
 import io.github.datromtool.config.ScanThreads;
 import org.junit.jupiter.api.Test;
 
+import java.util.Locale;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -20,7 +22,7 @@ class ScanThreadsConverterTest {
     @Test
     void zeroFailsValidationWithPositiveMessage() {
         IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class, () -> CONVERTER.convert("0"));
-        assertTrue(thrown.getMessage().toLowerCase().contains("positive"));
+        assertTrue(thrown.getMessage().toLowerCase(Locale.ROOT).contains("positive"));
     }
 
     @Test

--- a/cli/src/test/java/io/github/datromtool/cli/converter/ScanThreadsConverterTest.java
+++ b/cli/src/test/java/io/github/datromtool/cli/converter/ScanThreadsConverterTest.java
@@ -1,0 +1,35 @@
+package io.github.datromtool.cli.converter;
+
+import io.github.datromtool.config.ScanThreads;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/** Direct unit tests for {@link ScanThreadsConverter} (issue #14 step 3). */
+class ScanThreadsConverterTest {
+
+    private static final ScanThreadsConverter CONVERTER = new ScanThreadsConverter();
+
+    @Test
+    void parsesPositiveInt() {
+        assertEquals(new ScanThreads(4), CONVERTER.convert("4"));
+    }
+
+    @Test
+    void zeroFailsValidationWithPositiveMessage() {
+        IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class, () -> CONVERTER.convert("0"));
+        assertTrue(thrown.getMessage().toLowerCase().contains("positive"));
+    }
+
+    @Test
+    void negativeFailsValidation() {
+        assertThrows(IllegalArgumentException.class, () -> CONVERTER.convert("-1"));
+    }
+
+    @Test
+    void garbageValueFailsToParse() {
+        assertThrows(NumberFormatException.class, () -> CONVERTER.convert("abc"));
+    }
+}

--- a/cli/src/test/java/io/github/datromtool/cli/option/FilteringOptionsCategoryMigrationTest.java
+++ b/cli/src/test/java/io/github/datromtool/cli/option/FilteringOptionsCategoryMigrationTest.java
@@ -1,0 +1,50 @@
+package io.github.datromtool.cli.option;
+
+import io.github.datromtool.cli.argument.PatternsFileArgument;
+import io.github.datromtool.cli.converter.PatternsFileConverter;
+import org.junit.jupiter.api.Test;
+import picocli.CommandLine;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Red-first proof for issue #14 step 1: the 13 negatable category flags (e.g. {@code --proto})
+ * and the {@code --no-all} tri-state are removed from {@link FilteringOptions} in favor of a
+ * single {@code --exclude-categories} option. This pins that the OLD surface is gone: passing
+ * an old flag must now fail parsing instead of silently working.
+ *
+ * <p>This file is authored and hashed BEFORE the migration (RED: flags still parse, assertions
+ * fail) and stays byte-identical through the migration (GREEN: flags rejected).
+ */
+class FilteringOptionsCategoryMigrationTest {
+
+    @CommandLine.Command
+    private static final class Holder {
+
+        @CommandLine.ArgGroup(exclusive = false)
+        FilteringOptions filteringOptions = new FilteringOptions();
+    }
+
+    private static void parse(String... args) {
+        Holder holder = new Holder();
+        CommandLine commandLine = new CommandLine(holder);
+        commandLine.registerConverter(PatternsFileArgument.class, new PatternsFileConverter());
+        commandLine.parseArgs(args);
+    }
+
+    @Test
+    void oldProtoFlagIsNoLongerRecognized() {
+        assertThrows(
+                CommandLine.UnmatchedArgumentException.class,
+                () -> parse("--proto"),
+                "--proto must no longer parse now that categories are exclude-list driven");
+    }
+
+    @Test
+    void oldNoAllFlagIsNoLongerRecognized() {
+        assertThrows(
+                CommandLine.UnmatchedArgumentException.class,
+                () -> parse("--no-all"),
+                "--no-all must no longer parse now that categories are exclude-list driven");
+    }
+}

--- a/cli/src/test/java/io/github/datromtool/cli/option/FilteringOptionsTest.java
+++ b/cli/src/test/java/io/github/datromtool/cli/option/FilteringOptionsTest.java
@@ -14,6 +14,7 @@ import picocli.CommandLine;
 import java.net.URISyntaxException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Locale;
 import java.util.Set;
 import java.util.regex.Pattern;
 
@@ -185,7 +186,7 @@ class FilteringOptionsTest {
     @ParameterizedTest
     @EnumSource(GameCategory.class)
     void excludeCategoriesAcceptsEachCategoryCaseInsensitively(GameCategory category) {
-        Filter lower = parse("--exclude-categories", category.name().toLowerCase());
+        Filter lower = parse("--exclude-categories", category.name().toLowerCase(Locale.ROOT));
         assertEquals(
                 Set.of(category),
                 lower.getExcludeCategories(),
@@ -193,11 +194,23 @@ class FilteringOptionsTest {
 
         Filter mixed = parse("--exclude-categories",
                 category.name().charAt(0)
-                        + category.name().substring(1).toLowerCase());
+                        + category.name().substring(1).toLowerCase(Locale.ROOT));
         assertEquals(
                 Set.of(category),
                 mixed.getExcludeCategories(),
                 "mixed-case category name must be accepted, got: " + mixed.getExcludeCategories());
+    }
+
+    // The split regex "\s*,\s*" only strips whitespace around the comma; leading/trailing
+    // whitespace on the whole value must be trimmed by the converter itself.
+    @Test
+    void excludeCategoriesAcceptsOuterWhitespace() {
+        Filter filter = parse("--exclude-categories", " proto , beta ");
+        assertEquals(
+                Set.of(GameCategory.PROTO, GameCategory.BETA),
+                filter.getExcludeCategories(),
+                "outer whitespace around the list must be trimmed, got: "
+                        + filter.getExcludeCategories());
     }
 
     // Row 2: a bogus category value must fail parsing with a clear message.
@@ -212,7 +225,7 @@ class FilteringOptionsTest {
                 "error message must mention the bogus value, got: " + e.getMessage());
         for (GameCategory category : GameCategory.values()) {
             assertTrue(
-                    e.getMessage().contains(category.name()),
+                    e.getMessage().contains(category.name().toLowerCase(Locale.ROOT)),
                     "error message must list valid category " + category + ", got: " + e.getMessage());
         }
     }

--- a/cli/src/test/java/io/github/datromtool/cli/option/FilteringOptionsTest.java
+++ b/cli/src/test/java/io/github/datromtool/cli/option/FilteringOptionsTest.java
@@ -2,21 +2,20 @@ package io.github.datromtool.cli.option;
 
 import io.github.datromtool.Patterns;
 import io.github.datromtool.cli.argument.PatternsFileArgument;
+import io.github.datromtool.cli.converter.GameCategoryConverter;
 import io.github.datromtool.cli.converter.PatternsFileConverter;
 import io.github.datromtool.data.Filter;
+import io.github.datromtool.data.GameCategory;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.EnumSource;
 import picocli.CommandLine;
 
 import java.net.URISyntaxException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Set;
-import java.util.function.Function;
 import java.util.regex.Pattern;
-import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -25,8 +24,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Pins {@link FilteringOptions#toFilter()}: how region/language include-exclude lists case-fold,
- * how the various exclude/include expression sources merge, and the allow/no-all category
- * tri-state.
+ * how the various exclude/include expression sources merge, and how {@code --exclude-categories}
+ * maps onto {@link Filter#getExcludeCategories()}.
  */
 class FilteringOptionsTest {
 
@@ -41,6 +40,7 @@ class FilteringOptionsTest {
         Holder holder = new Holder();
         CommandLine commandLine = new CommandLine(holder);
         commandLine.registerConverter(PatternsFileArgument.class, new PatternsFileConverter());
+        commandLine.registerConverter(GameCategory.class, new GameCategoryConverter());
         commandLine.parseArgs(args);
         return holder.filteringOptions.toFilter();
     }
@@ -154,15 +154,13 @@ class FilteringOptionsTest {
                 "--includes-file patterns must merge into Filter.includes, got: " + filter.getIncludes());
     }
 
-    // Row 9
+    // Row 9 (new-surface equivalent of the old rows 9/12: nothing excluded by default)
     @Test
-    void noFlagsAllowEveryCategoryAndExcludeNothing() {
+    void noFlagsExcludeNoCategoryAndExcludeNothing() {
         Filter filter = parse();
-        assertTrue(filter.isAllowProto(), "default allowProto must be true");
-        assertTrue(filter.isAllowBeta(), "default allowBeta must be true");
-        assertTrue(filter.isAllowDemo(), "default allowDemo must be true");
-        assertTrue(filter.isAllowSample(), "default allowSample must be true");
-        assertTrue(filter.isAllowBios(), "default allowBios must be true");
+        assertTrue(
+                filter.getExcludeCategories().isEmpty(),
+                "default excludeCategories must be empty, got: " + filter.getExcludeCategories());
         for (Pattern p : new Pattern[]{
                 Patterns.BAD, Patterns.PROGRAM, Patterns.ENHANCEMENT_CHIP, Patterns.PIRATE,
                 Patterns.PROMO, Patterns.UNLICENSED, Patterns.DLC, Patterns.UPDATE}) {
@@ -172,100 +170,65 @@ class FilteringOptionsTest {
         }
     }
 
-    // Row 10
-    static Stream<Arguments> categoryBooleanFlags() {
-        return Stream.of(
-                Arguments.of("proto", (Function<Filter, Boolean>) Filter::isAllowProto),
-                Arguments.of("beta", (Function<Filter, Boolean>) Filter::isAllowBeta),
-                Arguments.of("demo", (Function<Filter, Boolean>) Filter::isAllowDemo),
-                Arguments.of("sample", (Function<Filter, Boolean>) Filter::isAllowSample),
-                Arguments.of("bios", (Function<Filter, Boolean>) Filter::isAllowBios));
+    // Row 1 of the coverage matrix: --exclude-categories parses to Filter.excludeCategories,
+    // case-insensitively.
+    @Test
+    void excludeCategoriesParsesCommaSeparatedListIntoFilter() {
+        Filter filter = parse("--exclude-categories", "proto,beta");
+        assertEquals(
+                Set.of(GameCategory.PROTO, GameCategory.BETA),
+                filter.getExcludeCategories(),
+                "--exclude-categories proto,beta must produce {PROTO, BETA}, got: "
+                        + filter.getExcludeCategories());
     }
 
     @ParameterizedTest
-    @MethodSource("categoryBooleanFlags")
-    void noFlagClearsCorrespondingAllowBoolean(String flag, Function<Filter, Boolean> getter) {
-        Filter filter = parse("--no-" + flag);
-        assertFalse(
-                getter.apply(filter),
-                "--no-" + flag + " must clear Filter.allow" + flag);
+    @EnumSource(GameCategory.class)
+    void excludeCategoriesAcceptsEachCategoryCaseInsensitively(GameCategory category) {
+        Filter lower = parse("--exclude-categories", category.name().toLowerCase());
+        assertEquals(
+                Set.of(category),
+                lower.getExcludeCategories(),
+                "lowercase category name must be accepted, got: " + lower.getExcludeCategories());
+
+        Filter mixed = parse("--exclude-categories",
+                category.name().charAt(0)
+                        + category.name().substring(1).toLowerCase());
+        assertEquals(
+                Set.of(category),
+                mixed.getExcludeCategories(),
+                "mixed-case category name must be accepted, got: " + mixed.getExcludeCategories());
     }
 
-    @ParameterizedTest
-    @MethodSource("categoryBooleanFlags")
-    void explicitNoFlagUnderNoAllStaysCleared(String flag, Function<Filter, Boolean> getter) {
-        Filter filter = parse("--no-all", "--no-" + flag);
-        assertFalse(
-                getter.apply(filter),
-                "--no-all --no-" + flag + " must keep Filter.allow" + flag + " cleared");
-    }
-
-    // Row 11
-    static Stream<Arguments> categoryPatternFlags() {
-        return Stream.of(
-                Arguments.of("bad", Patterns.BAD),
-                Arguments.of("program", Patterns.PROGRAM),
-                Arguments.of("chip", Patterns.ENHANCEMENT_CHIP),
-                Arguments.of("pirate", Patterns.PIRATE),
-                Arguments.of("promo", Patterns.PROMO),
-                Arguments.of("unlicensed", Patterns.UNLICENSED),
-                Arguments.of("dlc", Patterns.DLC),
-                Arguments.of("update", Patterns.UPDATE));
-    }
-
-    @ParameterizedTest
-    @MethodSource("categoryPatternFlags")
-    void noFlagAddsCorrespondingPatternsConstantToExcludes(String flag, Pattern expected) {
-        Filter filter = parse("--no-" + flag);
+    // Row 2: a bogus category value must fail parsing with a clear message.
+    @Test
+    void bogusCategoryValueFailsParsingWithValidValuesListed() {
+        CommandLine.ParameterException e = assertThrows(
+                CommandLine.ParameterException.class,
+                () -> parse("--exclude-categories", "not-a-category"),
+                "an invalid --exclude-categories value must be reported as a ParameterException");
         assertTrue(
-                filter.getExcludes().contains(expected),
-                "--no-" + flag + " must add Patterns." + expected.pattern()
-                        + " to Filter.excludes, got: " + filter.getExcludes());
-    }
-
-    // Row 12
-    @Test
-    void noAllAloneDisablesAllCategoriesAndExcludesAllPatterns() {
-        Filter filter = parse("--no-all");
-        assertFalse(filter.isAllowProto(), "--no-all must clear allowProto");
-        assertFalse(filter.isAllowBeta(), "--no-all must clear allowBeta");
-        assertFalse(filter.isAllowDemo(), "--no-all must clear allowDemo");
-        assertFalse(filter.isAllowSample(), "--no-all must clear allowSample");
-        assertFalse(filter.isAllowBios(), "--no-all must clear allowBios");
-        for (Pattern p : new Pattern[]{
-                Patterns.BAD, Patterns.PROGRAM, Patterns.ENHANCEMENT_CHIP, Patterns.PIRATE,
-                Patterns.PROMO, Patterns.UNLICENSED, Patterns.DLC, Patterns.UPDATE}) {
+                e.getMessage().contains("not-a-category"),
+                "error message must mention the bogus value, got: " + e.getMessage());
+        for (GameCategory category : GameCategory.values()) {
             assertTrue(
-                    filter.getExcludes().contains(p),
-                    "--no-all must add " + p.pattern() + " to excludes, got: " + filter.getExcludes());
+                    e.getMessage().contains(category.name()),
+                    "error message must list valid category " + category + ", got: " + e.getMessage());
         }
     }
 
-    // Row 13
+    // Row 6: Filter.excludes no longer receives Patterns.* injected by the CLI; only
+    // --exclude-categories carries category information.
     @Test
-    void noAllWithExplicitProtoReAllowsOnlyProto() {
-        Filter filter = parse("--no-all", "--proto");
-        assertTrue(filter.isAllowProto(), "--no-all --proto must re-allow proto");
-        assertFalse(filter.isAllowBeta(), "--no-all --proto must still clear beta");
-        assertFalse(filter.isAllowDemo(), "--no-all --proto must still clear demo");
-        assertFalse(filter.isAllowSample(), "--no-all --proto must still clear sample");
-        assertFalse(filter.isAllowBios(), "--no-all --proto must still clear bios");
-    }
-
-    // Row 14
-    @Test
-    void noAllWithExplicitBadReAllowsOnlyBadPattern() {
-        Filter filter = parse("--no-all", "--bad");
-        assertFalse(
-                filter.getExcludes().contains(Patterns.BAD),
-                "--no-all --bad must NOT exclude Patterns.BAD, got: " + filter.getExcludes());
-        for (Pattern p : new Pattern[]{
-                Patterns.PROGRAM, Patterns.ENHANCEMENT_CHIP, Patterns.PIRATE,
-                Patterns.PROMO, Patterns.UNLICENSED, Patterns.DLC, Patterns.UPDATE}) {
-            assertTrue(
-                    filter.getExcludes().contains(p),
-                    "--no-all --bad must still exclude " + p.pattern() + ", got: " + filter.getExcludes());
-        }
+    void excludeCategoriesDoesNotPopulateExcludesPatterns() {
+        Filter filter = parse("--exclude-categories", "bad");
+        assertTrue(
+                filter.getExcludes().isEmpty(),
+                "--exclude-categories bad must not populate Filter.excludes, got: " + filter.getExcludes());
+        assertEquals(
+                Set.of(GameCategory.BAD),
+                filter.getExcludeCategories(),
+                "--exclude-categories bad must produce {BAD}, got: " + filter.getExcludeCategories());
     }
 
     // Hostile row H1

--- a/cli/src/test/java/io/github/datromtool/cli/option/PerformanceOptionsTest.java
+++ b/cli/src/test/java/io/github/datromtool/cli/option/PerformanceOptionsTest.java
@@ -1,7 +1,5 @@
 package io.github.datromtool.cli.option;
 
-import io.github.datromtool.cli.converter.ByteSizeConverter;
-import io.github.datromtool.ByteSize;
 import io.github.datromtool.config.AppConfig;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -22,9 +20,7 @@ class PerformanceOptionsTest {
     }
 
     private static CommandLine newCommandLine(Holder holder) {
-        CommandLine commandLine = new CommandLine(holder);
-        commandLine.registerConverter(ByteSize.class, new ByteSizeConverter());
-        return commandLine;
+        return new CommandLine(holder);
     }
 
     private static PerformanceOptions parse(String... args) {
@@ -40,7 +36,7 @@ class PerformanceOptionsTest {
                 options.merge(AppConfig.FileCopierConfig.builder().build());
         assertEquals(
                 3,
-                merged.getThreads(),
+                merged.getThreads().value(),
                 "--copy-threads must set the copier thread count");
     }
 
@@ -53,11 +49,11 @@ class PerformanceOptionsTest {
                 options.merge(AppConfig.FileCopierConfig.builder().build());
         assertEquals(
                 2,
-                mergedScanner.getThreads(),
+                mergedScanner.getThreads().value(),
                 "--scan-threads must set the scanner thread count");
         assertEquals(
                 3,
-                mergedCopier.getThreads(),
+                mergedCopier.getThreads().value(),
                 "--copy-threads must set the copier thread count, not the scanner's value");
     }
 
@@ -84,7 +80,7 @@ class PerformanceOptionsTest {
                 options.merge(AppConfig.FileScannerConfig.builder().build());
         assertEquals(
                 32 * 1024,
-                merged.getDefaultBufferSize(),
+                merged.getDefaultBufferSize().bytes(),
                 "--scan-buffer 32KB must merge as exactly 32768 bytes");
     }
 
@@ -95,7 +91,7 @@ class PerformanceOptionsTest {
                 options.merge(AppConfig.FileScannerConfig.builder().build());
         assertEquals(
                 1024 * 1024,
-                merged.getDefaultBufferSize(),
+                merged.getDefaultBufferSize().bytes(),
                 "--scan-buffer 1MB must merge as exactly 1048576 bytes");
     }
 
@@ -117,7 +113,7 @@ class PerformanceOptionsTest {
                 options.merge(AppConfig.FileCopierConfig.builder().build());
         assertEquals(
                 32 * 1024,
-                merged.getBufferSize(),
+                merged.getBufferSize().bytes(),
                 "--copy-buffer 32KB must set FileCopierConfig.bufferSize");
     }
 
@@ -129,6 +125,19 @@ class PerformanceOptionsTest {
         assertTrue(
                 merged.isAllowRawZipCopy(),
                 "--copy-raw-zip alone must set FileCopierConfig.allowRawZipCopy true");
+    }
+
+    // Matrix row 6 (issue #14 step 3): scan/copy thread wrappers cannot cross-assign at
+    // compile time; this end-to-end parse pins the runtime merge stays independent too.
+    @Test
+    void scanThreadsThreeAndCopyThreadsFourMergeIntoTheirRespectiveConfigs() {
+        PerformanceOptions options = parse("--scan-threads", "3", "--copy-threads", "4");
+        AppConfig.FileScannerConfig mergedScanner =
+                options.merge(AppConfig.FileScannerConfig.builder().build());
+        AppConfig.FileCopierConfig mergedCopier =
+                options.merge(AppConfig.FileCopierConfig.builder().build());
+        assertEquals(3, mergedScanner.getThreads().value(), "--scan-threads 3 must merge into FileScannerConfig.threads");
+        assertEquals(4, mergedCopier.getThreads().value(), "--copy-threads 4 must merge into FileCopierConfig.threads");
     }
 
     // Hostile row H4 (pinning actual behavior)

--- a/cli/src/test/java/io/github/datromtool/cli/option/PerformanceOptionsTest.java
+++ b/cli/src/test/java/io/github/datromtool/cli/option/PerformanceOptionsTest.java
@@ -6,6 +6,8 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import picocli.CommandLine;
 
+import java.util.Locale;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -68,7 +70,7 @@ class PerformanceOptionsTest {
                 () -> commandLine.parseArgs("--scan-threads", value),
                 "--scan-threads " + value + " must be rejected as non-positive");
         assertTrue(
-                thrown.getMessage().toLowerCase().contains("positive"),
+                thrown.getMessage().toLowerCase(Locale.ROOT).contains("positive"),
                 "the error must explain threads must be positive, got: " + thrown.getMessage());
     }
 

--- a/cli/src/test/java/io/github/datromtool/cli/option/SortingOptionsOrderMigrationTest.java
+++ b/cli/src/test/java/io/github/datromtool/cli/option/SortingOptionsOrderMigrationTest.java
@@ -1,0 +1,57 @@
+package io.github.datromtool.cli.option;
+
+import io.github.datromtool.cli.argument.PatternsFileArgument;
+import io.github.datromtool.cli.converter.PatternsFileConverter;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import picocli.CommandLine;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Red-first surface-change proof for issue #14 step 2: the direction-ambiguous
+ * {@code --early-versions}/{@code --early-revisions}/{@code --early-prereleases} boolean flags
+ * are replaced by {@code --versions}/{@code --revisions}/{@code --prereleases} enum options.
+ *
+ * <p>Parse-level only: intentionally does not touch {@link SortingPreference} getters, since
+ * the new {@code getVersions()}/{@code getRevisions()}/{@code getPrereleases()} accessors do not
+ * exist before the migration and would break compilation at red time. Getter-level mapping
+ * assertions live in the ordinary {@link SortingOptionsTest} instead.
+ *
+ * <p>Executed RED before the migration (old flags still parsed fine, new options were unknown);
+ * frozen byte-identical and re-run GREEN, unchanged, after the migration.
+ */
+class SortingOptionsOrderMigrationTest {
+
+    @CommandLine.Command
+    private static final class Holder {
+
+        @CommandLine.ArgGroup(exclusive = false)
+        SortingOptions sortingOptions = new SortingOptions();
+    }
+
+    private static void parse(String... args) {
+        Holder holder = new Holder();
+        CommandLine commandLine = new CommandLine(holder);
+        commandLine.registerConverter(PatternsFileArgument.class, new PatternsFileConverter());
+        commandLine.parseArgs(args);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"--early-versions", "--early-revisions", "--early-prereleases"})
+    void oldEarlyFlagsAreRejected(String flag) {
+        assertThrows(
+                CommandLine.UnmatchedArgumentException.class,
+                () -> parse(flag),
+                flag + " must no longer parse; it is replaced by an order enum option");
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"--versions", "--revisions", "--prereleases"})
+    void newOrderOptionsAreAcceptedWithEarliestValue(String option) {
+        assertDoesNotThrow(
+                () -> parse(option, "earliest"),
+                option + " earliest must parse as the new enum option");
+    }
+}

--- a/cli/src/test/java/io/github/datromtool/cli/option/SortingOptionsTest.java
+++ b/cli/src/test/java/io/github/datromtool/cli/option/SortingOptionsTest.java
@@ -15,6 +15,7 @@ import java.net.URISyntaxException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Predicate;
@@ -192,9 +193,19 @@ class SortingOptionsTest {
     void orderOptionAcceptsValueCaseInsensitively(String value) {
         SortingPreference preference = parse("--versions", value);
         assertEquals(
-                OrderPreference.valueOf(value.toUpperCase()),
+                OrderPreference.valueOf(value.toUpperCase(Locale.ROOT)),
                 preference.getVersions(),
                 "--versions " + value + " must be accepted case-insensitively");
+    }
+
+    // Matrix row 2: outer whitespace on the raw value must be trimmed by the converter.
+    @Test
+    void orderOptionAcceptsOuterWhitespace() {
+        SortingPreference preference = parse("--versions", " earliest ");
+        assertEquals(
+                OrderPreference.EARLIEST,
+                preference.getVersions(),
+                "--versions ' earliest ' must be trimmed and accepted");
     }
 
     // Matrix row 2: a bogus order value must fail parsing with a clear message.

--- a/cli/src/test/java/io/github/datromtool/cli/option/SortingOptionsTest.java
+++ b/cli/src/test/java/io/github/datromtool/cli/option/SortingOptionsTest.java
@@ -2,11 +2,13 @@ package io.github.datromtool.cli.option;
 
 import io.github.datromtool.cli.argument.PatternsFileArgument;
 import io.github.datromtool.cli.converter.PatternsFileConverter;
+import io.github.datromtool.data.OrderPreference;
 import io.github.datromtool.data.SortingPreference;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import picocli.CommandLine;
 
 import java.net.URISyntaxException;
@@ -14,6 +16,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
 import java.util.Set;
+import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -21,6 +24,7 @@ import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class SortingOptionsTest {
@@ -141,9 +145,6 @@ class SortingOptionsTest {
     static Stream<Arguments> booleanFlags() {
         return Stream.of(
                 Arguments.of("--prioritize-languages", (Predicate<SortingPreference>) SortingPreference::isPrioritizeLanguages),
-                Arguments.of("--early-versions", (Predicate<SortingPreference>) SortingPreference::isEarlyVersions),
-                Arguments.of("--early-revisions", (Predicate<SortingPreference>) SortingPreference::isEarlyRevisions),
-                Arguments.of("--early-prereleases", (Predicate<SortingPreference>) SortingPreference::isEarlyPrereleases),
                 Arguments.of("--prefer-prereleases", (Predicate<SortingPreference>) SortingPreference::isPreferPrereleases),
                 Arguments.of("--prefer-parents", (Predicate<SortingPreference>) SortingPreference::isPreferParents));
     }
@@ -159,5 +160,55 @@ class SortingOptionsTest {
         assertTrue(
                 getter.test(setPreference),
                 flag + " must set its field to true");
+    }
+
+    // Matrix row 1: --versions/--revisions/--prereleases parse to the order enum, default LATEST.
+    static Stream<Arguments> orderOptions() {
+        return Stream.of(
+                Arguments.of("--versions", (Function<SortingPreference, OrderPreference>) SortingPreference::getVersions),
+                Arguments.of("--revisions", (Function<SortingPreference, OrderPreference>) SortingPreference::getRevisions),
+                Arguments.of("--prereleases", (Function<SortingPreference, OrderPreference>) SortingPreference::getPrereleases));
+    }
+
+    @ParameterizedTest
+    @MethodSource("orderOptions")
+    void orderOptionDefaultsLatestAndSetsEarliestWhenRequested(
+            String option, Function<SortingPreference, OrderPreference> getter) {
+        SortingPreference defaultPreference = parse();
+        assertEquals(
+                OrderPreference.LATEST,
+                getter.apply(defaultPreference),
+                option + " must default to LATEST");
+        SortingPreference earliestPreference = parse(option, "earliest");
+        assertEquals(
+                OrderPreference.EARLIEST,
+                getter.apply(earliestPreference),
+                option + " earliest must set its field to EARLIEST");
+    }
+
+    // Matrix row 2: case-insensitive values are accepted.
+    @ParameterizedTest
+    @ValueSource(strings = {"EARLIEST", "Latest", "latest", "earliest"})
+    void orderOptionAcceptsValueCaseInsensitively(String value) {
+        SortingPreference preference = parse("--versions", value);
+        assertEquals(
+                OrderPreference.valueOf(value.toUpperCase()),
+                preference.getVersions(),
+                "--versions " + value + " must be accepted case-insensitively");
+    }
+
+    // Matrix row 2: a bogus order value must fail parsing with a clear message.
+    @Test
+    void bogusOrderValueFailsParsingWithValidValuesListed() {
+        CommandLine.ParameterException e = assertThrows(
+                CommandLine.ParameterException.class,
+                () -> parse("--versions", "sideways"),
+                "an invalid --versions value must be reported as a ParameterException");
+        assertTrue(
+                e.getMessage().contains("sideways"),
+                "error message must mention the bogus value, got: " + e.getMessage());
+        assertTrue(
+                e.getMessage().contains("latest") && e.getMessage().contains("earliest"),
+                "error message must list valid values latest/earliest, got: " + e.getMessage());
     }
 }

--- a/core/src/main/java/io/github/datromtool/GameFilterer.java
+++ b/core/src/main/java/io/github/datromtool/GameFilterer.java
@@ -58,9 +58,18 @@ public final class GameFilterer {
         return result;
     }
 
+    /**
+     * Asymmetric by design, mirroring pre-enum flag semantics: pattern-backed categories
+     * (BAD/PROGRAM/CHIP/PIRATE/PROMO/UNLICENSED/DLC/UPDATE) used to be exclude patterns fed
+     * into {@link #filterExcludes}, where any {@link Filter#getIncludes()} match rescues the
+     * game from all excludes; that rescue must still apply to them here. Structural categories
+     * (PROTO/BETA/DEMO/SAMPLE/BIOS) were separate boolean filters before and were never
+     * includes-overridable, so they stay non-rescuable.
+     */
     private boolean filterExcludedCategories(ParsedGame p) {
         for (GameCategory category : filter.getExcludeCategories()) {
-            if (matchesCategory(p, category)) {
+            if (matchesCategory(p, category)
+                    && !(category.getPattern().isPresent() && matchesAnyInclude(p))) {
                 if (log.isDebugEnabled()) {
                     log.debug(
                             "Category filter removed '{}' due to excluded category {}",
@@ -71,6 +80,12 @@ public final class GameFilterer {
             }
         }
         return true;
+    }
+
+    private boolean matchesAnyInclude(ParsedGame p) {
+        return filter.getIncludes().stream()
+                .map(e -> e.matcher(p.getGame().getName()))
+                .anyMatch(Matcher::find);
     }
 
     private static boolean matchesCategory(ParsedGame p, GameCategory category) {
@@ -136,9 +151,7 @@ public final class GameFilterer {
         boolean result = filter.getExcludes().stream()
                 .map(e -> e.matcher(p.getGame().getName()))
                 .noneMatch(Matcher::find);
-        result |= filter.getIncludes().stream()
-                .map(e -> e.matcher(p.getGame().getName()))
-                .anyMatch(Matcher::find);
+        result |= matchesAnyInclude(p);
         if (!result) {
             log.debug("Excludes filter removed '{}'", p.getGame().getName());
         }

--- a/core/src/main/java/io/github/datromtool/GameFilterer.java
+++ b/core/src/main/java/io/github/datromtool/GameFilterer.java
@@ -3,6 +3,7 @@ package io.github.datromtool;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.github.datromtool.data.Filter;
+import io.github.datromtool.data.GameCategory;
 import io.github.datromtool.data.Pair;
 import io.github.datromtool.data.ParsedGame;
 import io.github.datromtool.data.PostFilter;
@@ -39,11 +40,7 @@ public final class GameFilterer {
                     filter);
         }
         ImmutableList<ParsedGame> result = input.stream()
-                .filter(this::filterBioses)
-                .filter(this::filterProto)
-                .filter(this::filterBeta)
-                .filter(this::filterDemo)
-                .filter(this::filterSample)
+                .filter(this::filterExcludedCategories)
                 .filter(this::filterIncludeRegion)
                 .filter(this::filterIncludeLanguage)
                 .filter(this::filterExcludeRegion)
@@ -61,44 +58,34 @@ public final class GameFilterer {
         return result;
     }
 
-    private boolean filterBioses(ParsedGame p) {
-        boolean result = filter.isAllowBios() || !p.isBios();
-        if (!result) {
-            log.debug("BIOS filter removed '{}'", p.getGame().getName());
+    private boolean filterExcludedCategories(ParsedGame p) {
+        for (GameCategory category : filter.getExcludeCategories()) {
+            if (matchesCategory(p, category)) {
+                if (log.isDebugEnabled()) {
+                    log.debug(
+                            "Category filter removed '{}' due to excluded category {}",
+                            p.getGame().getName(),
+                            category);
+                }
+                return false;
+            }
         }
-        return result;
+        return true;
     }
 
-    private boolean filterProto(ParsedGame p) {
-        boolean result = filter.isAllowProto() || p.getProto().isEmpty();
-        if (!result) {
-            log.debug("Proto filter removed '{}'", p.getGame().getName());
-        }
-        return result;
-    }
-
-    private boolean filterBeta(ParsedGame p) {
-        boolean result = filter.isAllowBeta() || p.getBeta().isEmpty();
-        if (!result) {
-            log.debug("Beta filter removed '{}'", p.getGame().getName());
-        }
-        return result;
-    }
-
-    private boolean filterDemo(ParsedGame p) {
-        boolean result = filter.isAllowDemo() || p.getDemo().isEmpty();
-        if (!result) {
-            log.debug("Demo filter removed '{}'", p.getGame().getName());
-        }
-        return result;
-    }
-
-    private boolean filterSample(ParsedGame p) {
-        boolean result = filter.isAllowSample() || p.getSample().isEmpty();
-        if (!result) {
-            log.debug("Sample filter removed '{}'", p.getGame().getName());
-        }
-        return result;
+    private static boolean matchesCategory(ParsedGame p, GameCategory category) {
+        return switch (category) {
+            case PROTO -> !p.getProto().isEmpty();
+            case BETA -> !p.getBeta().isEmpty();
+            case DEMO -> !p.getDemo().isEmpty();
+            case SAMPLE -> !p.getSample().isEmpty();
+            case BIOS -> p.isBios();
+            case BAD, PROGRAM, CHIP, PIRATE, PROMO, UNLICENSED, DLC, UPDATE -> category
+                    .getPattern()
+                    .map(pattern -> pattern.matcher(p.getGame().getName()))
+                    .map(Matcher::find)
+                    .orElse(false);
+        };
     }
 
     private boolean filterIncludeRegion(ParsedGame p) {

--- a/core/src/main/java/io/github/datromtool/config/AppConfig.java
+++ b/core/src/main/java/io/github/datromtool/config/AppConfig.java
@@ -27,15 +27,15 @@ public class AppConfig {
 
         @Builder.Default
         @NonNull
-        Integer defaultBufferSize = 32 * 1024; // 32KB
+        ScanBufferSize defaultBufferSize = new ScanBufferSize(32 * 1024); // 32KB
 
         @Builder.Default
         @NonNull
-        Integer maxBufferSize = 256 * 1024 * 1024; // 256MB
+        ScanMaxBufferSize maxBufferSize = new ScanMaxBufferSize(256 * 1024 * 1024); // 256MB
 
         @Builder.Default
         @NonNull
-        Integer threads = Math.max(1, Runtime.getRuntime().availableProcessors() / 2);
+        ScanThreads threads = new ScanThreads(Math.max(1, Runtime.getRuntime().availableProcessors() / 2));
     }
 
     @With
@@ -49,11 +49,11 @@ public class AppConfig {
 
         @Builder.Default
         @NonNull
-        Integer bufferSize = 32 * 1024; // 32KB
+        CopyBufferSize bufferSize = new CopyBufferSize(32 * 1024); // 32KB
 
         @Builder.Default
         @NonNull
-        Integer threads = Math.max(1, Runtime.getRuntime().availableProcessors() / 2);
+        CopyThreads threads = new CopyThreads(Math.max(1, Runtime.getRuntime().availableProcessors() / 2));
 
         @Builder.Default
         boolean allowRawZipCopy = false;

--- a/core/src/main/java/io/github/datromtool/config/CopyBufferSize.java
+++ b/core/src/main/java/io/github/datromtool/config/CopyBufferSize.java
@@ -1,0 +1,28 @@
+package io.github.datromtool.config;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+/**
+ * I/O buffer size (bytes) for {@link AppConfig.FileCopierConfig}. Kept distinct from
+ * {@link ScanBufferSize} and {@link ScanMaxBufferSize} so buffer values from different
+ * subsystems cannot be cross-assigned.
+ */
+public record CopyBufferSize(int bytes) {
+
+    public CopyBufferSize {
+        if (bytes <= 0) {
+            throw new IllegalArgumentException("Buffer size should be a positive number of bytes");
+        }
+    }
+
+    @JsonValue
+    public int bytes() {
+        return bytes;
+    }
+
+    @JsonCreator
+    public static CopyBufferSize of(int bytes) {
+        return new CopyBufferSize(bytes);
+    }
+}

--- a/core/src/main/java/io/github/datromtool/config/CopyThreads.java
+++ b/core/src/main/java/io/github/datromtool/config/CopyThreads.java
@@ -1,0 +1,27 @@
+package io.github.datromtool.config;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+/**
+ * Thread count dedicated to {@link AppConfig.FileCopierConfig}. Kept distinct from
+ * {@link ScanThreads} so a copy value can never be passed where a scan value belongs.
+ */
+public record CopyThreads(int value) {
+
+    public CopyThreads {
+        if (value <= 0) {
+            throw new IllegalArgumentException("Number of threads should be a positive number");
+        }
+    }
+
+    @JsonValue
+    public int value() {
+        return value;
+    }
+
+    @JsonCreator
+    public static CopyThreads of(int value) {
+        return new CopyThreads(value);
+    }
+}

--- a/core/src/main/java/io/github/datromtool/config/ScanBufferSize.java
+++ b/core/src/main/java/io/github/datromtool/config/ScanBufferSize.java
@@ -1,0 +1,28 @@
+package io.github.datromtool.config;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+/**
+ * Default dynamic I/O buffer size (bytes) for {@link AppConfig.FileScannerConfig}. Kept
+ * distinct from {@link ScanMaxBufferSize} and {@link CopyBufferSize} so buffer values from
+ * different subsystems cannot be cross-assigned.
+ */
+public record ScanBufferSize(int bytes) {
+
+    public ScanBufferSize {
+        if (bytes <= 0) {
+            throw new IllegalArgumentException("Buffer size should be a positive number of bytes");
+        }
+    }
+
+    @JsonValue
+    public int bytes() {
+        return bytes;
+    }
+
+    @JsonCreator
+    public static ScanBufferSize of(int bytes) {
+        return new ScanBufferSize(bytes);
+    }
+}

--- a/core/src/main/java/io/github/datromtool/config/ScanMaxBufferSize.java
+++ b/core/src/main/java/io/github/datromtool/config/ScanMaxBufferSize.java
@@ -1,0 +1,28 @@
+package io.github.datromtool.config;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+/**
+ * Maximum dynamic I/O buffer size (bytes) for {@link AppConfig.FileScannerConfig}. Kept
+ * distinct from {@link ScanBufferSize} and {@link CopyBufferSize} so buffer values from
+ * different subsystems cannot be cross-assigned.
+ */
+public record ScanMaxBufferSize(int bytes) {
+
+    public ScanMaxBufferSize {
+        if (bytes <= 0) {
+            throw new IllegalArgumentException("Buffer size should be a positive number of bytes");
+        }
+    }
+
+    @JsonValue
+    public int bytes() {
+        return bytes;
+    }
+
+    @JsonCreator
+    public static ScanMaxBufferSize of(int bytes) {
+        return new ScanMaxBufferSize(bytes);
+    }
+}

--- a/core/src/main/java/io/github/datromtool/config/ScanThreads.java
+++ b/core/src/main/java/io/github/datromtool/config/ScanThreads.java
@@ -1,0 +1,27 @@
+package io.github.datromtool.config;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+/**
+ * Thread count dedicated to {@link AppConfig.FileScannerConfig}. Kept distinct from
+ * {@link CopyThreads} so a scan value can never be passed where a copy value belongs.
+ */
+public record ScanThreads(int value) {
+
+    public ScanThreads {
+        if (value <= 0) {
+            throw new IllegalArgumentException("Number of threads should be a positive number");
+        }
+    }
+
+    @JsonValue
+    public int value() {
+        return value;
+    }
+
+    @JsonCreator
+    public static ScanThreads of(int value) {
+        return new ScanThreads(value);
+    }
+}

--- a/core/src/main/java/io/github/datromtool/data/Filter.java
+++ b/core/src/main/java/io/github/datromtool/data/Filter.java
@@ -43,21 +43,10 @@ public class Filter {
     ImmutableSet<Pattern> includes = ImmutableSet.of();
 
     /*
-     * Adding the filters below here saves re-checking all names
+     * Adding the filter below here saves re-checking all names
      */
 
+    @NonNull
     @Builder.Default
-    boolean allowProto = true;
-
-    @Builder.Default
-    boolean allowBeta = true;
-
-    @Builder.Default
-    boolean allowDemo = true;
-
-    @Builder.Default
-    boolean allowSample = true;
-
-    @Builder.Default
-    boolean allowBios = true;
+    ImmutableSet<GameCategory> excludeCategories = ImmutableSet.of();
 }

--- a/core/src/main/java/io/github/datromtool/data/GameCategory.java
+++ b/core/src/main/java/io/github/datromtool/data/GameCategory.java
@@ -1,0 +1,51 @@
+package io.github.datromtool.data;
+
+import io.github.datromtool.Patterns;
+
+import javax.annotation.Nullable;
+import java.util.Optional;
+import java.util.regex.Pattern;
+
+/**
+ * The categories a game can be excluded by, replacing the old scattered
+ * {@code --bad --proto --beta --demo --sample --bios --program --chip --pirate --promo
+ * --unlicensed --dlc --update} negatable flags plus the {@code --no-all} tri-state.
+ *
+ * <p>{@link #PROTO}, {@link #BETA}, {@link #DEMO}, {@link #SAMPLE} and {@link #BIOS} are
+ * structural: {@link GameFilterer} decides membership from {@link ParsedGame} fields parsed out
+ * of the name (no regex needed here, so {@link #getPattern()} is empty). The remaining
+ * categories are pattern-backed: membership is decided by matching the game name against the
+ * category's {@link Patterns} regex.
+ */
+public enum GameCategory {
+
+    BAD(Patterns.BAD),
+    PROTO(null),
+    BETA(null),
+    DEMO(null),
+    SAMPLE(null),
+    BIOS(null),
+    PROGRAM(Patterns.PROGRAM),
+    CHIP(Patterns.ENHANCEMENT_CHIP),
+    PIRATE(Patterns.PIRATE),
+    PROMO(Patterns.PROMO),
+    UNLICENSED(Patterns.UNLICENSED),
+    DLC(Patterns.DLC),
+    UPDATE(Patterns.UPDATE);
+
+    @Nullable
+    private final Pattern pattern;
+
+    GameCategory(@Nullable Pattern pattern) {
+        this.pattern = pattern;
+    }
+
+    /**
+     * The regex that decides membership in this category, if this is a pattern-backed category.
+     * Empty for structural categories, whose membership is decided from parsed
+     * {@link ParsedGame} fields instead.
+     */
+    public Optional<Pattern> getPattern() {
+        return Optional.ofNullable(pattern);
+    }
+}

--- a/core/src/main/java/io/github/datromtool/data/GameCategory.java
+++ b/core/src/main/java/io/github/datromtool/data/GameCategory.java
@@ -12,10 +12,10 @@ import java.util.regex.Pattern;
  * --unlicensed --dlc --update} negatable flags plus the {@code --no-all} tri-state.
  *
  * <p>{@link #PROTO}, {@link #BETA}, {@link #DEMO}, {@link #SAMPLE} and {@link #BIOS} are
- * structural: {@link GameFilterer} decides membership from {@link ParsedGame} fields parsed out
- * of the name (no regex needed here, so {@link #getPattern()} is empty). The remaining
- * categories are pattern-backed: membership is decided by matching the game name against the
- * category's {@link Patterns} regex.
+ * structural: {@link io.github.datromtool.GameFilterer} decides membership from
+ * {@link ParsedGame} fields parsed out of the name (no regex needed here, so
+ * {@link #getPattern()} is empty). The remaining categories are pattern-backed: membership is
+ * decided by matching the game name against the category's {@link Patterns} regex.
  */
 public enum GameCategory {
 

--- a/core/src/main/java/io/github/datromtool/data/OrderPreference.java
+++ b/core/src/main/java/io/github/datromtool/data/OrderPreference.java
@@ -1,0 +1,11 @@
+package io.github.datromtool.data;
+
+/**
+ * Replaces the direction-ambiguous {@code early*} boolean pairs on {@link SortingPreference}
+ * ({@code earlyVersions}/{@code earlyRevisions}/{@code earlyPrereleases}) with an explicit,
+ * self-describing order.
+ */
+public enum OrderPreference {
+    LATEST,
+    EARLIEST
+}

--- a/core/src/main/java/io/github/datromtool/data/SortingPreference.java
+++ b/core/src/main/java/io/github/datromtool/data/SortingPreference.java
@@ -41,14 +41,17 @@ public class SortingPreference {
     @Builder.Default
     boolean prioritizeLanguages = false;
 
+    @NonNull
     @Builder.Default
-    boolean earlyVersions = false;
+    OrderPreference versions = OrderPreference.LATEST;
 
+    @NonNull
     @Builder.Default
-    boolean earlyRevisions = false;
+    OrderPreference revisions = OrderPreference.LATEST;
 
+    @NonNull
     @Builder.Default
-    boolean earlyPrereleases = false;
+    OrderPreference prereleases = OrderPreference.LATEST;
 
     @Builder.Default
     boolean preferParents = false;

--- a/core/src/main/java/io/github/datromtool/io/FileCopier.java
+++ b/core/src/main/java/io/github/datromtool/io/FileCopier.java
@@ -189,7 +189,7 @@ public final class FileCopier {
             @Nonnull List<Listener> listeners) {
         this.config = config;
         this.listeners = processListenerList(requireNonNull(listeners));
-        this.threadLocalBuffer = ThreadLocal.withInitial(() -> new byte[config.getBufferSize()]);
+        this.threadLocalBuffer = ThreadLocal.withInitial(() -> new byte[config.getBufferSize().bytes()]);
     }
 
     @Nonnull
@@ -203,7 +203,7 @@ public final class FileCopier {
     public void copy(Set<? extends Spec> definitions) {
         log.debug("Copying selected files: {}", definitions);
         ExecutorService executorService = Executors.newFixedThreadPool(
-                config.getThreads(),
+                config.getThreads().value(),
                 new IndexedThreadFactory(log, "COPIER"));
         if (!LZMAUtils.isLZMACompressionAvailable()) {
             log.warn("LZMA compression support is disabled");
@@ -212,7 +212,7 @@ public final class FileCopier {
             log.warn("XZ compression support is disabled");
         }
         for (Listener listener : listeners) {
-            listener.init(config.getThreads());
+            listener.init(config.getThreads().value());
             listener.reportTotalItems(definitions.size());
         }
         definitions.stream()

--- a/core/src/main/java/io/github/datromtool/io/FileScanner.java
+++ b/core/src/main/java/io/github/datromtool/io/FileScanner.java
@@ -185,7 +185,7 @@ public final class FileScanner {
 
     public ImmutableList<Result> scan(Collection<Path> directories) {
         ExecutorService executorService = Executors.newFixedThreadPool(
-                config.getThreads(),
+                config.getThreads().value(),
                 new IndexedThreadFactory(log, "SCANNER"));
         if (!LZMAUtils.isLZMACompressionAvailable()) {
             log.warn("LZMA compression support is disabled");
@@ -208,7 +208,7 @@ public final class FileScanner {
             ImmutableList<FileMetadata> paths = pathsBuilder.build();
             for (Listener listener : listeners) {
                 listener.reportFinishedListing(paths.size());
-                listener.init(config.getThreads());
+                listener.init(config.getThreads().value());
                 listener.reportTotalItems(paths.size());
             }
             ImmutableList<Result> results = paths.stream()

--- a/core/src/main/java/io/github/datromtool/io/FileScannerParameters.java
+++ b/core/src/main/java/io/github/datromtool/io/FileScannerParameters.java
@@ -81,7 +81,7 @@ class FileScannerParameters {
                 .min()
                 .orElse(0);
         if (detectors.isEmpty()) {
-            bufferSize = config.getDefaultBufferSize();
+            bufferSize = config.getDefaultBufferSize().bytes();
             useLazyDetector = false;
             maxRomSize = toRomStream(datafiles)
                     .mapToLong(r -> r.size())
@@ -127,7 +127,7 @@ class FileScannerParameters {
                             .mapToLong(t -> t.getOffset() + t.getValue().length)
                             .max()
                             .orElse(0);
-                    useLazyDetector = max(maxTestOffset, maxStartOffset) <= config.getDefaultBufferSize();
+                    useLazyDetector = max(maxTestOffset, maxStartOffset) <= config.getDefaultBufferSize().bytes();
                 } else {
                     useLazyDetector = false;
                 }
@@ -135,15 +135,15 @@ class FileScannerParameters {
                 useLazyDetector = false;
             }
             if (useLazyDetector) {
-                bufferSize = config.getDefaultBufferSize();
+                bufferSize = config.getDefaultBufferSize().bytes();
             } else {
-                bufferSize = toIntExact(max(min(maxRomSize, config.getMaxBufferSize()), config.getDefaultBufferSize()));
+                bufferSize = toIntExact(max(min(maxRomSize, config.getMaxBufferSize().bytes()), config.getDefaultBufferSize().bytes()));
             }
             String bufferSizeStr = ByteSize.fromBytes(bufferSize).toFormattedString();
             if (bufferSize > MAX_BUFFER_NO_WARNING) {
                 log.warn("Using a bigger I/O buffer size of {} due to header detection", bufferSizeStr);
             }
-            if (bufferSize == config.getMaxBufferSize()) {
+            if (bufferSize == config.getMaxBufferSize().bytes()) {
                 log.warn("Disabling header detection for ROMs larger than {}", bufferSizeStr);
             }
             log.info("Using I/O buffer size of {}", bufferSizeStr);

--- a/core/src/main/java/io/github/datromtool/sorting/SubComparatorProvider.java
+++ b/core/src/main/java/io/github/datromtool/sorting/SubComparatorProvider.java
@@ -1,6 +1,7 @@
 package io.github.datromtool.sorting;
 
 import com.google.common.collect.ImmutableList;
+import io.github.datromtool.data.OrderPreference;
 import io.github.datromtool.data.SortingPreference;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
@@ -30,23 +31,23 @@ class SubComparatorProvider {
             subComparatorsBuilder.add(new PreferParentsSubComparator());
         }
         subComparatorsBuilder.add(new PrefersListSubComparator(sortingPreference));
-        subComparatorsBuilder.add(sortingPreference.isEarlyRevisions()
+        subComparatorsBuilder.add(sortingPreference.getRevisions() == OrderPreference.EARLIEST
                 ? new RevisionSubComparator()
                 : new RevisionSubComparator().reversed());
-        subComparatorsBuilder.add(sortingPreference.isEarlyVersions()
+        subComparatorsBuilder.add(sortingPreference.getVersions() == OrderPreference.EARLIEST
                 ? new VersionSubComparator()
                 : new VersionSubComparator().reversed());
         subComparatorsBuilder.add(new PreferReleasesSubComparator());
-        subComparatorsBuilder.add(sortingPreference.isEarlyPrereleases()
+        subComparatorsBuilder.add(sortingPreference.getPrereleases() == OrderPreference.EARLIEST
                 ? new SampleSubComparator()
                 : new SampleSubComparator().reversed());
-        subComparatorsBuilder.add(sortingPreference.isEarlyPrereleases()
+        subComparatorsBuilder.add(sortingPreference.getPrereleases() == OrderPreference.EARLIEST
                 ? new DemoSubComparator()
                 : new DemoSubComparator().reversed());
-        subComparatorsBuilder.add(sortingPreference.isEarlyPrereleases()
+        subComparatorsBuilder.add(sortingPreference.getPrereleases() == OrderPreference.EARLIEST
                 ? new BetaSubComparator()
                 : new BetaSubComparator().reversed());
-        subComparatorsBuilder.add(sortingPreference.isEarlyPrereleases()
+        subComparatorsBuilder.add(sortingPreference.getPrereleases() == OrderPreference.EARLIEST
                 ? new ProtoSubComparator()
                 : new ProtoSubComparator().reversed());
         subComparatorsBuilder.add(

--- a/core/src/test/java/io/github/datromtool/GameFiltererTest.java
+++ b/core/src/test/java/io/github/datromtool/GameFiltererTest.java
@@ -166,6 +166,42 @@ class GameFiltererTest {
     }
 
     @Test
+    void includesRescuePatternBackedCategoryExclusion() {
+        // Pre-PR parity: the CLI used to inject Patterns.* into Filter.excludes, and
+        // filterExcludes let any Filter.includes match rescue the game from ALL excludes,
+        // pattern-backed category exclusions included. That rescue must still apply here.
+        Filter filter = Filter.builder()
+                .excludeCategories(ImmutableSet.of(GameCategory.BAD))
+                .includes(ImmutableSet.of(Pattern.compile("Zelda")))
+                .build();
+        GameFilterer filterer = new GameFilterer(filter, PostFilter.builder().build());
+        ParsedGame game = plainGame("Zelda [b]");
+        assertTrue(
+                isKept(filterer, game),
+                "an include pattern matching the game name must rescue it from a pattern-backed"
+                        + " category exclusion");
+    }
+
+    @Test
+    void includesDoNotRescueStructuralCategoryExclusion() {
+        // Structural categories (PROTO/BETA/DEMO/SAMPLE/BIOS) were separate boolean filters
+        // before this PR and were never includes-overridable; that must stay true.
+        Filter filter = Filter.builder()
+                .excludeCategories(ImmutableSet.of(GameCategory.PROTO))
+                .includes(ImmutableSet.of(Pattern.compile("Zelda")))
+                .build();
+        GameFilterer filterer = new GameFilterer(filter, PostFilter.builder().build());
+        ParsedGame game = ParsedGame.builder()
+                .game(Game.builder().name("Zelda (Proto)").description("Zelda (Proto)").build())
+                .regionData(EMPTY_REGION_DATA)
+                .proto(ImmutableList.of(1L))
+                .build();
+        assertFalse(
+                isKept(filterer, game),
+                "an include pattern must NOT rescue a game from a structural category exclusion");
+    }
+
+    @Test
     void testPostFilter() {
         GameFilterer filterer = new GameFilterer(
                 Filter.builder().build(),

--- a/core/src/test/java/io/github/datromtool/GameFiltererTest.java
+++ b/core/src/test/java/io/github/datromtool/GameFiltererTest.java
@@ -1,14 +1,185 @@
 package io.github.datromtool;
 
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import io.github.datromtool.data.Filter;
+import io.github.datromtool.data.GameCategory;
+import io.github.datromtool.data.ParsedGame;
+import io.github.datromtool.data.PostFilter;
+import io.github.datromtool.data.RegionData;
+import io.github.datromtool.domain.datafile.logiqx.Game;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 
+import java.util.function.UnaryOperator;
+import java.util.regex.Pattern;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Pins {@link GameFilterer}'s category exclusion behavior (issue #14 step 1): the five
+ * structural categories (PROTO/BETA/DEMO/SAMPLE/BIOS) are decided from parsed {@link ParsedGame}
+ * fields, and the remaining eight are decided by matching the game name against the category's
+ * {@link Patterns} regex.
+ */
 class GameFiltererTest {
 
+    private static final RegionData EMPTY_REGION_DATA = new RegionData(ImmutableSet.of());
+
+    private static ParsedGame plainGame(String name) {
+        return ParsedGame.builder()
+                .game(Game.builder().name(name).description(name).build())
+                .regionData(EMPTY_REGION_DATA)
+                .build();
+    }
+
+    private static GameFilterer filtererExcluding(GameCategory... categories) {
+        Filter filter = Filter.builder()
+                .excludeCategories(ImmutableSet.copyOf(categories))
+                .build();
+        return new GameFilterer(filter, PostFilter.builder().build());
+    }
+
+    private static boolean isKept(GameFilterer filterer, ParsedGame game) {
+        return filterer.filter(ImmutableList.of(game)).contains(game);
+    }
+
+    // Coverage matrix row 4: structural categories, parameterized over PROTO/BETA/DEMO/SAMPLE/BIOS
+    private enum Structural {
+        PROTO(GameCategory.PROTO, p -> p.toBuilder().proto(ImmutableList.of(1L)).build()),
+        BETA(GameCategory.BETA, p -> p.toBuilder().beta(ImmutableList.of(1L)).build()),
+        DEMO(GameCategory.DEMO, p -> p.toBuilder().demo(ImmutableList.of(1L)).build()),
+        SAMPLE(GameCategory.SAMPLE, p -> p.toBuilder().sample(ImmutableList.of(1L)).build()),
+        BIOS(GameCategory.BIOS, p -> p.toBuilder().bios(true).build());
+
+        final GameCategory category;
+        final UnaryOperator<ParsedGame> withTrait;
+
+        Structural(GameCategory category, UnaryOperator<ParsedGame> withTrait) {
+            this.category = category;
+            this.withTrait = withTrait;
+        }
+    }
+
+    @ParameterizedTest
+    @EnumSource(Structural.class)
+    void structuralCategoryFiltersGameExhibitingTraitWhenExcluded(Structural s) {
+        ParsedGame game = s.withTrait.apply(plainGame("Some Game"));
+        GameFilterer filterer = filtererExcluding(s.category);
+        assertFalse(
+                isKept(filterer, game),
+                s.category + " must remove a game exhibiting the " + s.category + " trait when excluded");
+    }
+
+    @ParameterizedTest
+    @EnumSource(Structural.class)
+    void structuralCategoryKeepsGameExhibitingTraitWhenNotExcluded(Structural s) {
+        ParsedGame game = s.withTrait.apply(plainGame("Some Game"));
+        GameFilterer filterer = filtererExcluding(); // nothing excluded
+        assertTrue(
+                isKept(filterer, game),
+                s.category + " must keep a game exhibiting the " + s.category
+                        + " trait when not excluded");
+    }
+
+    @ParameterizedTest
+    @EnumSource(Structural.class)
+    void structuralCategoryKeepsGameNotExhibitingTraitEvenWhenExcluded(Structural s) {
+        ParsedGame game = plainGame("Some Game"); // no trait set
+        GameFilterer filterer = filtererExcluding(s.category);
+        assertTrue(
+                isKept(filterer, game),
+                s.category + " must keep a game NOT exhibiting the " + s.category
+                        + " trait, even when excluded");
+    }
+
+    // Coverage matrix row 5: pattern-backed categories, parameterized over BAD/PROGRAM/CHIP/
+    // PIRATE/PROMO/UNLICENSED/DLC/UPDATE. Names taken to match the actual Patterns.* regexes.
+    private enum PatternBacked {
+        BAD(GameCategory.BAD, "Some Game [b]"),
+        PROGRAM(GameCategory.PROGRAM, "Some Game (Program)"),
+        CHIP(GameCategory.CHIP, "Some Game (Enhancement Chip)"),
+        PIRATE(GameCategory.PIRATE, "Some Game (Pirate)"),
+        PROMO(GameCategory.PROMO, "Some Game (Promo)"),
+        UNLICENSED(GameCategory.UNLICENSED, "Some Game (Unl)"),
+        DLC(GameCategory.DLC, "Some Game (DLC)"),
+        UPDATE(GameCategory.UPDATE, "Some Game (Update)");
+
+        final GameCategory category;
+        final String matchingName;
+
+        PatternBacked(GameCategory category, String matchingName) {
+            this.category = category;
+            this.matchingName = matchingName;
+        }
+    }
+
+    @ParameterizedTest
+    @EnumSource(PatternBacked.class)
+    void patternBackedCategoryFiltersMatchingNameWhenExcluded(PatternBacked p) {
+        assertTrue(
+                p.category.getPattern().orElseThrow().matcher(p.matchingName).find(),
+                "test fixture name must actually match Patterns." + p.category);
+        ParsedGame game = plainGame(p.matchingName);
+        GameFilterer filterer = filtererExcluding(p.category);
+        assertFalse(
+                isKept(filterer, game),
+                p.category + " must remove a game whose name matches its pattern when excluded");
+    }
+
+    @ParameterizedTest
+    @EnumSource(PatternBacked.class)
+    void patternBackedCategoryKeepsMatchingNameWhenNotExcluded(PatternBacked p) {
+        ParsedGame game = plainGame(p.matchingName);
+        GameFilterer filterer = filtererExcluding(); // nothing excluded
+        assertTrue(
+                isKept(filterer, game),
+                p.category + " must keep a game whose name matches its pattern when not excluded");
+    }
+
     @Test
-    void testFilter() {
+    void multipleExcludedCategoriesCombineWithOr() {
+        GameFilterer filterer = filtererExcluding(GameCategory.PROTO, GameCategory.DLC);
+        ParsedGame protoGame = ParsedGame.builder()
+                .game(Game.builder().name("Proto Game").description("Proto Game").build())
+                .regionData(EMPTY_REGION_DATA)
+                .proto(ImmutableList.of(1L))
+                .build();
+        ParsedGame dlcGame = plainGame("DLC Game (DLC)");
+        ParsedGame unrelatedGame = plainGame("Plain Game");
+
+        ImmutableList<ParsedGame> result = filterer.filter(
+                ImmutableList.of(protoGame, dlcGame, unrelatedGame));
+
+        assertTrue(result.contains(unrelatedGame), "unrelated game must be kept");
+        assertFalse(result.contains(protoGame), "proto game must be removed");
+        assertFalse(result.contains(dlcGame), "dlc game must be removed");
+    }
+
+    @Test
+    void noExcludedCategoriesKeepsEverything() {
+        GameFilterer filterer = filtererExcluding();
+        ParsedGame game = plainGame("Anything (Proto) [b] (DLC)");
+        assertTrue(isKept(filterer, game), "empty excludeCategories must keep every game");
     }
 
     @Test
     void testPostFilter() {
+        GameFilterer filterer = new GameFilterer(
+                Filter.builder().build(),
+                PostFilter.builder()
+                        .excludes(ImmutableSet.of(Pattern.compile("Banned")))
+                        .build());
+        ParsedGame banned = plainGame("Banned Game");
+        ParsedGame allowed = plainGame("Allowed Game");
+
+        assertTrue(
+                filterer.postFilter(ImmutableList.of(allowed)).contains(allowed),
+                "post-filter must keep a set with no banned name");
+        assertTrue(
+                filterer.postFilter(ImmutableList.of(banned, allowed)).isEmpty(),
+                "post-filter must drop the whole set if any entry matches an exclude pattern");
     }
 }

--- a/core/src/test/java/io/github/datromtool/SerializationHelperTest.java
+++ b/core/src/test/java/io/github/datromtool/SerializationHelperTest.java
@@ -2,6 +2,11 @@ package io.github.datromtool;
 
 import com.google.common.collect.ImmutableSet;
 import io.github.datromtool.config.AppConfig;
+import io.github.datromtool.config.CopyBufferSize;
+import io.github.datromtool.config.CopyThreads;
+import io.github.datromtool.config.ScanBufferSize;
+import io.github.datromtool.config.ScanMaxBufferSize;
+import io.github.datromtool.config.ScanThreads;
 import io.github.datromtool.data.RegionData;
 import io.github.datromtool.domain.datafile.logiqx.Datafile;
 import io.github.datromtool.domain.detector.Detector;
@@ -126,8 +131,8 @@ class SerializationHelperTest extends TestDirDependantTest {
         AppConfig config = emptyHelper.loadAppConfig(ClassLoader.getSystemResource("config-test.yaml"));
         assertNotNull(config);
         assertNotNull(config.getScanner());
-        assertEquals(4, (int) config.getScanner().getThreads());
-        assertEquals(4 * 1024 * 1024, (int) config.getScanner().getMaxBufferSize());
+        assertEquals(4, config.getScanner().getThreads().value());
+        assertEquals(4 * 1024 * 1024, config.getScanner().getMaxBufferSize().bytes());
     }
 
     @Test
@@ -135,9 +140,51 @@ class SerializationHelperTest extends TestDirDependantTest {
         AppConfig config = testHelper.loadAppConfig();
         assertNotNull(config);
         assertNotNull(config.getScanner());
-        assertEquals(24, (int) config.getScanner().getThreads());
-        assertEquals(32768, (int) config.getScanner().getMaxBufferSize());
-        assertEquals(12, (int) config.getCopier().getThreads());
+        assertEquals(24, config.getScanner().getThreads().value());
+        assertEquals(32768, config.getScanner().getMaxBufferSize().bytes());
+        assertEquals(12, config.getCopier().getThreads().value());
+    }
+
+    // Row: performance-primitive wrapper records serialize as plain numbers, not nested
+    // objects, and round-trip through both JSON and YAML unchanged (issue #14 step 3).
+    @Test
+    void testAppConfigWrapperRecordsSerializeAsPlainNumbersAndRoundTrip() throws Exception {
+        AppConfig config = AppConfig.builder()
+                .scanner(AppConfig.FileScannerConfig.builder()
+                        .threads(new ScanThreads(7))
+                        .defaultBufferSize(new ScanBufferSize(65536))
+                        .maxBufferSize(new ScanMaxBufferSize(1048576))
+                        .build())
+                .copier(AppConfig.FileCopierConfig.builder()
+                        .threads(new CopyThreads(9))
+                        .bufferSize(new CopyBufferSize(4096))
+                        .build())
+                .build();
+
+        String json = emptyHelper.getJsonMapper().writeValueAsString(config);
+        String normalizedJson = json.replaceAll("\\s", "");
+        assertTrue(
+                normalizedJson.contains("\"threads\":7"),
+                "scanner threads must serialize as a plain number, got: " + json);
+        assertTrue(
+                normalizedJson.contains("\"threads\":9"),
+                "copier threads must serialize as a plain number, got: " + json);
+        assertFalse(
+                json.contains("\"value\""),
+                "wrapper records must not serialize as a nested {\"value\": ...} object, got: " + json);
+        assertFalse(
+                json.contains("\"bytes\""),
+                "wrapper records must not serialize as a nested {\"bytes\": ...} object, got: " + json);
+        assertEquals(config, emptyHelper.getJsonMapper().readValue(json, AppConfig.class));
+
+        String yaml = emptyHelper.getYamlMapper().writeValueAsString(config);
+        assertFalse(
+                yaml.contains("value:"),
+                "wrapper records must not serialize as a nested 'value:' object, got: " + yaml);
+        assertFalse(
+                yaml.contains("bytes:"),
+                "wrapper records must not serialize as a nested 'bytes:' object, got: " + yaml);
+        assertEquals(config, emptyHelper.getYamlMapper().readValue(yaml, AppConfig.class));
     }
 
     @Test

--- a/core/src/test/java/io/github/datromtool/config/PerformancePrimitiveRecordsTest.java
+++ b/core/src/test/java/io/github/datromtool/config/PerformancePrimitiveRecordsTest.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
+import java.util.Locale;
 import java.util.function.IntConsumer;
 import java.util.stream.Stream;
 
@@ -42,7 +43,7 @@ class PerformancePrimitiveRecordsTest {
                 () -> c.constructor().accept(0),
                 c.name() + "(0) must be rejected as non-positive");
         assertTrue(
-                thrown.getMessage().toLowerCase().contains("positive"),
+                thrown.getMessage().toLowerCase(Locale.ROOT).contains("positive"),
                 c.name() + " error must explain the value must be positive, got: " + thrown.getMessage());
     }
 
@@ -54,7 +55,7 @@ class PerformancePrimitiveRecordsTest {
                 () -> c.constructor().accept(-1),
                 c.name() + "(-1) must be rejected as non-positive");
         assertTrue(
-                thrown.getMessage().toLowerCase().contains("positive"),
+                thrown.getMessage().toLowerCase(Locale.ROOT).contains("positive"),
                 c.name() + " error must explain the value must be positive, got: " + thrown.getMessage());
     }
 

--- a/core/src/test/java/io/github/datromtool/config/PerformancePrimitiveRecordsTest.java
+++ b/core/src/test/java/io/github/datromtool/config/PerformancePrimitiveRecordsTest.java
@@ -1,0 +1,97 @@
+package io.github.datromtool.config;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.function.IntConsumer;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Pins the shared invariant of the five performance-primitive wrapper records (issue #14 step
+ * 3): construction rejects zero and negative inputs with a message identifying what must be
+ * positive, and a valid value round-trips through the accessor unchanged.
+ */
+class PerformancePrimitiveRecordsTest {
+
+    private record Case(String name, IntConsumer constructor) {
+        @Override
+        public String toString() {
+            return name;
+        }
+    }
+
+    static Stream<Case> nonPositiveCases() {
+        return Stream.of(
+                new Case("ScanThreads", v -> new ScanThreads(v)),
+                new Case("CopyThreads", v -> new CopyThreads(v)),
+                new Case("ScanBufferSize", v -> new ScanBufferSize(v)),
+                new Case("ScanMaxBufferSize", v -> new ScanMaxBufferSize(v)),
+                new Case("CopyBufferSize", v -> new CopyBufferSize(v)));
+    }
+
+    @ParameterizedTest(name = "{0} rejects zero")
+    @MethodSource("nonPositiveCases")
+    void rejectsZero(Case c) {
+        IllegalArgumentException thrown = assertThrows(
+                IllegalArgumentException.class,
+                () -> c.constructor().accept(0),
+                c.name() + "(0) must be rejected as non-positive");
+        assertTrue(
+                thrown.getMessage().toLowerCase().contains("positive"),
+                c.name() + " error must explain the value must be positive, got: " + thrown.getMessage());
+    }
+
+    @ParameterizedTest(name = "{0} rejects negative")
+    @MethodSource("nonPositiveCases")
+    void rejectsNegative(Case c) {
+        IllegalArgumentException thrown = assertThrows(
+                IllegalArgumentException.class,
+                () -> c.constructor().accept(-1),
+                c.name() + "(-1) must be rejected as non-positive");
+        assertTrue(
+                thrown.getMessage().toLowerCase().contains("positive"),
+                c.name() + " error must explain the value must be positive, got: " + thrown.getMessage());
+    }
+
+    @Test
+    void scanThreadsPreservesExactCliValidationMessage() {
+        IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class, () -> new ScanThreads(0));
+        assertEquals("Number of threads should be a positive number", thrown.getMessage());
+    }
+
+    @Test
+    void copyThreadsPreservesExactCliValidationMessage() {
+        IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class, () -> new CopyThreads(0));
+        assertEquals("Number of threads should be a positive number", thrown.getMessage());
+    }
+
+    @Test
+    void scanThreadsAccessorReturnsConstructedValue() {
+        assertEquals(4, new ScanThreads(4).value());
+    }
+
+    @Test
+    void copyThreadsAccessorReturnsConstructedValue() {
+        assertEquals(4, new CopyThreads(4).value());
+    }
+
+    @Test
+    void scanBufferSizeAccessorReturnsConstructedBytes() {
+        assertEquals(1024, new ScanBufferSize(1024).bytes());
+    }
+
+    @Test
+    void scanMaxBufferSizeAccessorReturnsConstructedBytes() {
+        assertEquals(1024, new ScanMaxBufferSize(1024).bytes());
+    }
+
+    @Test
+    void copyBufferSizeAccessorReturnsConstructedBytes() {
+        assertEquals(1024, new CopyBufferSize(1024).bytes());
+    }
+}

--- a/core/src/test/java/io/github/datromtool/data/FilterTest.java
+++ b/core/src/test/java/io/github/datromtool/data/FilterTest.java
@@ -1,0 +1,53 @@
+package io.github.datromtool.data;
+
+import com.google.common.collect.ImmutableSet;
+import io.github.datromtool.SerializationHelper;
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.json.JsonMapper;
+import tools.jackson.dataformat.yaml.YAMLMapper;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Coverage matrix rows 3 and 7 of issue #14 step 1: {@link Filter#getExcludeCategories()}
+ * defaults to empty, and round-trips through both JSON and YAML via {@link SerializationHelper}.
+ */
+class FilterTest {
+
+    @Test
+    void defaultExcludeCategoriesIsEmpty() {
+        Filter filter = Filter.builder().build();
+        assertTrue(
+                filter.getExcludeCategories().isEmpty(),
+                "default Filter.excludeCategories must be empty, got: " + filter.getExcludeCategories());
+    }
+
+    @Test
+    void excludeCategoriesRoundTripsThroughJson() {
+        Filter filter = Filter.builder()
+                .excludeCategories(ImmutableSet.of(GameCategory.BAD, GameCategory.DLC))
+                .build();
+        JsonMapper mapper = SerializationHelper.getInstance().getJsonMapper();
+        String json = mapper.writeValueAsString(filter);
+        Filter roundTripped = mapper.readValue(json, Filter.class);
+        assertEquals(
+                filter,
+                roundTripped,
+                "Filter with excludeCategories must round-trip through JSON, got: " + json);
+    }
+
+    @Test
+    void excludeCategoriesRoundTripsThroughYaml() {
+        Filter filter = Filter.builder()
+                .excludeCategories(ImmutableSet.of(GameCategory.PROTO, GameCategory.UPDATE))
+                .build();
+        YAMLMapper mapper = SerializationHelper.getInstance().getYamlMapper();
+        String yaml = mapper.writeValueAsString(filter);
+        Filter roundTripped = mapper.readValue(yaml, Filter.class);
+        assertEquals(
+                filter,
+                roundTripped,
+                "Filter with excludeCategories must round-trip through YAML, got: " + yaml);
+    }
+}

--- a/core/src/test/java/io/github/datromtool/data/FilterTest.java
+++ b/core/src/test/java/io/github/datromtool/data/FilterTest.java
@@ -7,6 +7,7 @@ import tools.jackson.databind.json.JsonMapper;
 import tools.jackson.dataformat.yaml.YAMLMapper;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -21,6 +22,16 @@ class FilterTest {
         assertTrue(
                 filter.getExcludeCategories().isEmpty(),
                 "default Filter.excludeCategories must be empty, got: " + filter.getExcludeCategories());
+    }
+
+    @Test
+    void defaultExcludeCategoriesIsOmittedFromSerialization() {
+        Filter filter = Filter.builder().build();
+        JsonMapper mapper = SerializationHelper.getInstance().getJsonMapper();
+        String json = mapper.writeValueAsString(filter);
+        assertFalse(
+                json.contains("excludeCategories"),
+                "default excludeCategories must be omitted, got: " + json);
     }
 
     @Test

--- a/core/src/test/java/io/github/datromtool/data/SortingPreferenceTest.java
+++ b/core/src/test/java/io/github/datromtool/data/SortingPreferenceTest.java
@@ -1,0 +1,60 @@
+package io.github.datromtool.data;
+
+import io.github.datromtool.SerializationHelper;
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.json.JsonMapper;
+import tools.jackson.dataformat.yaml.YAMLMapper;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Coverage matrix row 5 of issue #14 step 2: {@link SortingPreference#getVersions()},
+ * {@link SortingPreference#getRevisions()} and {@link SortingPreference#getPrereleases()}
+ * default to {@link OrderPreference#LATEST} and round-trip non-default {@link OrderPreference}
+ * values through both JSON and YAML via {@link SerializationHelper}.
+ */
+class SortingPreferenceTest {
+
+    @Test
+    void defaultOrderPreferencesAreLatest() {
+        SortingPreference preference = SortingPreference.builder().build();
+        assertEquals(OrderPreference.LATEST, preference.getVersions(),
+                "default versions must be LATEST");
+        assertEquals(OrderPreference.LATEST, preference.getRevisions(),
+                "default revisions must be LATEST");
+        assertEquals(OrderPreference.LATEST, preference.getPrereleases(),
+                "default prereleases must be LATEST");
+    }
+
+    @Test
+    void nonDefaultOrderPreferencesRoundTripThroughJson() {
+        SortingPreference preference = SortingPreference.builder()
+                .versions(OrderPreference.EARLIEST)
+                .revisions(OrderPreference.EARLIEST)
+                .prereleases(OrderPreference.EARLIEST)
+                .build();
+        JsonMapper mapper = SerializationHelper.getInstance().getJsonMapper();
+        String json = mapper.writeValueAsString(preference);
+        SortingPreference roundTripped = mapper.readValue(json, SortingPreference.class);
+        assertEquals(
+                preference,
+                roundTripped,
+                "SortingPreference with EARLIEST order preferences must round-trip through JSON, got: " + json);
+    }
+
+    @Test
+    void nonDefaultOrderPreferencesRoundTripThroughYaml() {
+        SortingPreference preference = SortingPreference.builder()
+                .versions(OrderPreference.EARLIEST)
+                .revisions(OrderPreference.EARLIEST)
+                .prereleases(OrderPreference.EARLIEST)
+                .build();
+        YAMLMapper mapper = SerializationHelper.getInstance().getYamlMapper();
+        String yaml = mapper.writeValueAsString(preference);
+        SortingPreference roundTripped = mapper.readValue(yaml, SortingPreference.class);
+        assertEquals(
+                preference,
+                roundTripped,
+                "SortingPreference with EARLIEST order preferences must round-trip through YAML, got: " + yaml);
+    }
+}

--- a/core/src/test/java/io/github/datromtool/data/SortingPreferenceTest.java
+++ b/core/src/test/java/io/github/datromtool/data/SortingPreferenceTest.java
@@ -6,6 +6,7 @@ import tools.jackson.databind.json.JsonMapper;
 import tools.jackson.dataformat.yaml.YAMLMapper;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 /**
  * Coverage matrix row 5 of issue #14 step 2: {@link SortingPreference#getVersions()},
@@ -24,6 +25,16 @@ class SortingPreferenceTest {
                 "default revisions must be LATEST");
         assertEquals(OrderPreference.LATEST, preference.getPrereleases(),
                 "default prereleases must be LATEST");
+    }
+
+    @Test
+    void defaultOrderPreferencesAreOmittedFromSerialization() {
+        SortingPreference preference = SortingPreference.builder().build();
+        JsonMapper mapper = SerializationHelper.getInstance().getJsonMapper();
+        String json = mapper.writeValueAsString(preference);
+        assertFalse(json.contains("versions"), "default versions must be omitted, got: " + json);
+        assertFalse(json.contains("revisions"), "default revisions must be omitted, got: " + json);
+        assertFalse(json.contains("prereleases"), "default prereleases must be omitted, got: " + json);
     }
 
     @Test

--- a/core/src/test/java/io/github/datromtool/sorting/GameComparatorTest.java
+++ b/core/src/test/java/io/github/datromtool/sorting/GameComparatorTest.java
@@ -3,6 +3,7 @@ package io.github.datromtool.sorting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import io.github.datromtool.SerializationHelper;
+import io.github.datromtool.data.OrderPreference;
 import io.github.datromtool.data.ParsedGame;
 import io.github.datromtool.data.RegionData;
 import io.github.datromtool.data.SortingPreference;
@@ -615,7 +616,7 @@ class GameComparatorTest {
     void testCompare_shouldPreferEarlyRevisionsIfEarlyRevisions() {
         GameComparator comparator =
                 new GameComparator(SubComparatorProvider.INSTANCE, SortingPreference.builder()
-                        .earlyRevisions(true)
+                        .revisions(OrderPreference.EARLIEST)
                         .build());
         ParsedGame tg1 = ParsedGame.builder()
                 .regionData(getRegionByCode(regionData, "USA"))
@@ -632,10 +633,10 @@ class GameComparatorTest {
     }
 
     @Test
-    void testCompare_shouldKeepOrderIfSameRevision_earlyRevisions() {
+    void testCompare_shouldKeepOrderIfSameRevision_revisionsEarliest() {
         GameComparator comparator =
                 new GameComparator(SubComparatorProvider.INSTANCE, SortingPreference.builder()
-                        .earlyRevisions(true)
+                        .revisions(OrderPreference.EARLIEST)
                         .build());
         ParsedGame tg1 = ParsedGame.builder()
                 .regionData(getRegionByCode(regionData, "USA"))
@@ -653,10 +654,10 @@ class GameComparatorTest {
     }
 
     @Test
-    void testCompare_shouldPreferEarlyRevision_minorDiff_earlyRevisions() {
+    void testCompare_shouldPreferEarlyRevision_minorDiff_revisionsEarliest() {
         GameComparator comparator =
                 new GameComparator(SubComparatorProvider.INSTANCE, SortingPreference.builder()
-                        .earlyRevisions(true)
+                        .revisions(OrderPreference.EARLIEST)
                         .build());
         ParsedGame tg1 = ParsedGame.builder()
                 .regionData(getRegionByCode(regionData, "USA"))
@@ -674,10 +675,10 @@ class GameComparatorTest {
     }
 
     @Test
-    void testCompare_shouldPreferEarlyRevision_majorDiff_earlyRevisions() {
+    void testCompare_shouldPreferEarlyRevision_majorDiff_revisionsEarliest() {
         GameComparator comparator =
                 new GameComparator(SubComparatorProvider.INSTANCE, SortingPreference.builder()
-                        .earlyRevisions(true)
+                        .revisions(OrderPreference.EARLIEST)
                         .build());
         ParsedGame tg1 = ParsedGame.builder()
                 .regionData(getRegionByCode(regionData, "USA"))
@@ -797,7 +798,7 @@ class GameComparatorTest {
     void testCompare_shouldPreferEarlyVersionsIfEarlyVersions() {
         GameComparator comparator =
                 new GameComparator(SubComparatorProvider.INSTANCE, SortingPreference.builder()
-                        .earlyVersions(true)
+                        .versions(OrderPreference.EARLIEST)
                         .build());
         ParsedGame tg1 = ParsedGame.builder()
                 .regionData(getRegionByCode(regionData, "USA"))
@@ -814,10 +815,10 @@ class GameComparatorTest {
     }
 
     @Test
-    void testCompare_shouldKeepOrderIfSameVersion_earlyVersions() {
+    void testCompare_shouldKeepOrderIfSameVersion_versionsEarliest() {
         GameComparator comparator =
                 new GameComparator(SubComparatorProvider.INSTANCE, SortingPreference.builder()
-                        .earlyVersions(true)
+                        .versions(OrderPreference.EARLIEST)
                         .build());
         ParsedGame tg1 = ParsedGame.builder()
                 .regionData(getRegionByCode(regionData, "USA"))
@@ -835,10 +836,10 @@ class GameComparatorTest {
     }
 
     @Test
-    void testCompare_shouldPreferEarlyVersion_minorDiff_earlyVersions() {
+    void testCompare_shouldPreferEarlyVersion_minorDiff_versionsEarliest() {
         GameComparator comparator =
                 new GameComparator(SubComparatorProvider.INSTANCE, SortingPreference.builder()
-                        .earlyVersions(true)
+                        .versions(OrderPreference.EARLIEST)
                         .build());
         ParsedGame tg1 = ParsedGame.builder()
                 .regionData(getRegionByCode(regionData, "USA"))
@@ -856,10 +857,10 @@ class GameComparatorTest {
     }
 
     @Test
-    void testCompare_shouldPreferEarlyVersion_majorDiff_earlyVersions() {
+    void testCompare_shouldPreferEarlyVersion_majorDiff_versionsEarliest() {
         GameComparator comparator =
                 new GameComparator(SubComparatorProvider.INSTANCE, SortingPreference.builder()
-                        .earlyVersions(true)
+                        .versions(OrderPreference.EARLIEST)
                         .build());
         ParsedGame tg1 = ParsedGame.builder()
                 .regionData(getRegionByCode(regionData, "USA"))
@@ -960,7 +961,7 @@ class GameComparatorTest {
     void testCompare_shouldPreferEarlySamplesIfEarlySamples() {
         GameComparator comparator =
                 new GameComparator(SubComparatorProvider.INSTANCE, SortingPreference.builder()
-                        .earlyPrereleases(true)
+                        .prereleases(OrderPreference.EARLIEST)
                         .build());
         ParsedGame tg1 = ParsedGame.builder()
                 .regionData(getRegionByCode(regionData, "USA"))
@@ -978,10 +979,10 @@ class GameComparatorTest {
     }
 
     @Test
-    void testCompare_shouldKeepOrderIfSameSample_earlyPrereleases() {
+    void testCompare_shouldKeepOrderIfSameSample_prereleasesEarliest() {
         GameComparator comparator =
                 new GameComparator(SubComparatorProvider.INSTANCE, SortingPreference.builder()
-                        .earlyPrereleases(true)
+                        .prereleases(OrderPreference.EARLIEST)
                         .build());
         ParsedGame tg1 = ParsedGame.builder()
                 .regionData(getRegionByCode(regionData, "USA"))
@@ -999,10 +1000,10 @@ class GameComparatorTest {
     }
 
     @Test
-    void testCompare_shouldPreferEarlySample_minorDiff_earlyPrereleases() {
+    void testCompare_shouldPreferEarlySample_minorDiff_prereleasesEarliest() {
         GameComparator comparator =
                 new GameComparator(SubComparatorProvider.INSTANCE, SortingPreference.builder()
-                        .earlyPrereleases(true)
+                        .prereleases(OrderPreference.EARLIEST)
                         .build());
         ParsedGame tg1 = ParsedGame.builder()
                 .regionData(getRegionByCode(regionData, "USA"))
@@ -1020,10 +1021,10 @@ class GameComparatorTest {
     }
 
     @Test
-    void testCompare_shouldPreferEarlySample_majorDiff_earlyPrereleases() {
+    void testCompare_shouldPreferEarlySample_majorDiff_prereleasesEarliest() {
         GameComparator comparator =
                 new GameComparator(SubComparatorProvider.INSTANCE, SortingPreference.builder()
-                        .earlyPrereleases(true)
+                        .prereleases(OrderPreference.EARLIEST)
                         .build());
         ParsedGame tg1 = ParsedGame.builder()
                 .regionData(getRegionByCode(regionData, "USA"))
@@ -1124,7 +1125,7 @@ class GameComparatorTest {
     void testCompare_shouldPreferEarlyDemosIfEarlyPrereleases() {
         GameComparator comparator =
                 new GameComparator(SubComparatorProvider.INSTANCE, SortingPreference.builder()
-                        .earlyPrereleases(true)
+                        .prereleases(OrderPreference.EARLIEST)
                         .build());
         ParsedGame tg1 = ParsedGame.builder()
                 .regionData(getRegionByCode(regionData, "USA"))
@@ -1141,10 +1142,10 @@ class GameComparatorTest {
     }
 
     @Test
-    void testCompare_shouldKeepOrderIfSameDemo_earlyPrereleases() {
+    void testCompare_shouldKeepOrderIfSameDemo_prereleasesEarliest() {
         GameComparator comparator =
                 new GameComparator(SubComparatorProvider.INSTANCE, SortingPreference.builder()
-                        .earlyPrereleases(true)
+                        .prereleases(OrderPreference.EARLIEST)
                         .build());
         ParsedGame tg1 = ParsedGame.builder()
                 .regionData(getRegionByCode(regionData, "USA"))
@@ -1162,10 +1163,10 @@ class GameComparatorTest {
     }
 
     @Test
-    void testCompare_shouldPreferEarlyDemo_minorDiff_earlyPrereleases() {
+    void testCompare_shouldPreferEarlyDemo_minorDiff_prereleasesEarliest() {
         GameComparator comparator =
                 new GameComparator(SubComparatorProvider.INSTANCE, SortingPreference.builder()
-                        .earlyPrereleases(true)
+                        .prereleases(OrderPreference.EARLIEST)
                         .build());
         ParsedGame tg1 = ParsedGame.builder()
                 .regionData(getRegionByCode(regionData, "USA"))
@@ -1183,10 +1184,10 @@ class GameComparatorTest {
     }
 
     @Test
-    void testCompare_shouldPreferEarlyDemo_majorDiff_earlyPrereleases() {
+    void testCompare_shouldPreferEarlyDemo_majorDiff_prereleasesEarliest() {
         GameComparator comparator =
                 new GameComparator(SubComparatorProvider.INSTANCE, SortingPreference.builder()
-                        .earlyPrereleases(true)
+                        .prereleases(OrderPreference.EARLIEST)
                         .build());
         ParsedGame tg1 = ParsedGame.builder()
                 .regionData(getRegionByCode(regionData, "USA"))
@@ -1287,7 +1288,7 @@ class GameComparatorTest {
     void testCompare_shouldPreferEarlyBetasIfEarlyPrereleases() {
         GameComparator comparator =
                 new GameComparator(SubComparatorProvider.INSTANCE, SortingPreference.builder()
-                        .earlyPrereleases(true)
+                        .prereleases(OrderPreference.EARLIEST)
                         .build());
         ParsedGame tg1 = ParsedGame.builder()
                 .regionData(getRegionByCode(regionData, "USA"))
@@ -1304,10 +1305,10 @@ class GameComparatorTest {
     }
 
     @Test
-    void testCompare_shouldKeepOrderIfSameBeta_earlyPrereleases() {
+    void testCompare_shouldKeepOrderIfSameBeta_prereleasesEarliest() {
         GameComparator comparator =
                 new GameComparator(SubComparatorProvider.INSTANCE, SortingPreference.builder()
-                        .earlyPrereleases(true)
+                        .prereleases(OrderPreference.EARLIEST)
                         .build());
         ParsedGame tg1 = ParsedGame.builder()
                 .regionData(getRegionByCode(regionData, "USA"))
@@ -1325,10 +1326,10 @@ class GameComparatorTest {
     }
 
     @Test
-    void testCompare_shouldPreferEarlyBeta_minorDiff_earlyPrereleases() {
+    void testCompare_shouldPreferEarlyBeta_minorDiff_prereleasesEarliest() {
         GameComparator comparator =
                 new GameComparator(SubComparatorProvider.INSTANCE, SortingPreference.builder()
-                        .earlyPrereleases(true)
+                        .prereleases(OrderPreference.EARLIEST)
                         .build());
         ParsedGame tg1 = ParsedGame.builder()
                 .regionData(getRegionByCode(regionData, "USA"))
@@ -1346,10 +1347,10 @@ class GameComparatorTest {
     }
 
     @Test
-    void testCompare_shouldPreferEarlyBeta_majorDiff_earlyPrereleases() {
+    void testCompare_shouldPreferEarlyBeta_majorDiff_prereleasesEarliest() {
         GameComparator comparator =
                 new GameComparator(SubComparatorProvider.INSTANCE, SortingPreference.builder()
-                        .earlyPrereleases(true)
+                        .prereleases(OrderPreference.EARLIEST)
                         .build());
         ParsedGame tg1 = ParsedGame.builder()
                 .regionData(getRegionByCode(regionData, "USA"))
@@ -1450,7 +1451,7 @@ class GameComparatorTest {
     void testCompare_shouldPreferEarlyProtosIfEarlyPrereleases() {
         GameComparator comparator =
                 new GameComparator(SubComparatorProvider.INSTANCE, SortingPreference.builder()
-                        .earlyPrereleases(true)
+                        .prereleases(OrderPreference.EARLIEST)
                         .build());
         ParsedGame tg1 = ParsedGame.builder()
                 .regionData(getRegionByCode(regionData, "USA"))
@@ -1467,10 +1468,10 @@ class GameComparatorTest {
     }
 
     @Test
-    void testCompare_shouldKeepOrderIfSameProto_earlyPrereleases() {
+    void testCompare_shouldKeepOrderIfSameProto_prereleasesEarliest() {
         GameComparator comparator =
                 new GameComparator(SubComparatorProvider.INSTANCE, SortingPreference.builder()
-                        .earlyPrereleases(true)
+                        .prereleases(OrderPreference.EARLIEST)
                         .build());
         ParsedGame tg1 = ParsedGame.builder()
                 .regionData(getRegionByCode(regionData, "USA"))
@@ -1488,10 +1489,10 @@ class GameComparatorTest {
     }
 
     @Test
-    void testCompare_shouldPreferEarlyProto_minorDiff_earlyPrereleases() {
+    void testCompare_shouldPreferEarlyProto_minorDiff_prereleasesEarliest() {
         GameComparator comparator =
                 new GameComparator(SubComparatorProvider.INSTANCE, SortingPreference.builder()
-                        .earlyPrereleases(true)
+                        .prereleases(OrderPreference.EARLIEST)
                         .build());
         ParsedGame tg1 = ParsedGame.builder()
                 .regionData(getRegionByCode(regionData, "USA"))
@@ -1509,10 +1510,10 @@ class GameComparatorTest {
     }
 
     @Test
-    void testCompare_shouldPreferEarlyProto_majorDiff_earlyPrereleases() {
+    void testCompare_shouldPreferEarlyProto_majorDiff_prereleasesEarliest() {
         GameComparator comparator =
                 new GameComparator(SubComparatorProvider.INSTANCE, SortingPreference.builder()
-                        .earlyPrereleases(true)
+                        .prereleases(OrderPreference.EARLIEST)
                         .build());
         ParsedGame tg1 = ParsedGame.builder()
                 .regionData(getRegionByCode(regionData, "USA"))

--- a/core/src/test/java/io/github/datromtool/sorting/SubComparatorProviderTest.java
+++ b/core/src/test/java/io/github/datromtool/sorting/SubComparatorProviderTest.java
@@ -1,6 +1,7 @@
 package io.github.datromtool.sorting;
 
 import com.google.common.collect.ImmutableList;
+import io.github.datromtool.data.OrderPreference;
 import io.github.datromtool.data.SortingPreference;
 import org.junit.jupiter.api.Test;
 
@@ -122,10 +123,10 @@ class SubComparatorProviderTest {
     }
 
     @Test
-    void testToList_earlyRevisions() {
+    void testToList_revisionsEarliest() {
         ImmutableList<SubComparator> subComparators =
                 SubComparatorProvider.INSTANCE.toList(SortingPreference.builder()
-                        .earlyRevisions(true)
+                        .revisions(OrderPreference.EARLIEST)
                         .build());
         assertNotNull(subComparators);
         assertEquals(15, subComparators.size());
@@ -149,10 +150,10 @@ class SubComparatorProviderTest {
     }
 
     @Test
-    void testToList_earlyVersions() {
+    void testToList_versionsEarliest() {
         ImmutableList<SubComparator> subComparators =
                 SubComparatorProvider.INSTANCE.toList(SortingPreference.builder()
-                        .earlyVersions(true)
+                        .versions(OrderPreference.EARLIEST)
                         .build());
         assertNotNull(subComparators);
         assertEquals(15, subComparators.size());
@@ -176,10 +177,10 @@ class SubComparatorProviderTest {
     }
 
     @Test
-    void testToList_earlyPrereleases() {
+    void testToList_prereleasesEarliest() {
         ImmutableList<SubComparator> subComparators =
                 SubComparatorProvider.INSTANCE.toList(SortingPreference.builder()
-                        .earlyPrereleases(true)
+                        .prereleases(OrderPreference.EARLIEST)
                         .build());
         assertNotNull(subComparators);
         assertEquals(15, subComparators.size());


### PR DESCRIPTION
Fixes #14

## What

Three commits, one per migration step, each gated by an independent verifier before the next started:

**1. Category flags → `GameCategory` enum (`08ea5e9`).** The 13 negatable flags (`--bad --proto --beta ... --update`) plus the `--no-all` tri-state are replaced by a single `--exclude-categories <list>` option and a `GameCategory` enum. `Filter` drops its five `allow*` booleans for an `excludeCategories` set; `GameFilterer` handles both structural categories (PROTO/BETA/DEMO/SAMPLE/BIOS from parsed metadata) and pattern-backed ones (BAD/PROGRAM/CHIP/PIRATE/PROMO/UNLICENSED/DLC/UPDATE via the same `Patterns` regexes, matched against the same game-name input as before) in one exhaustive pattern switch. `Filter.excludes` is now user-supplied patterns only. Old-semantics equivalences: `--no-X` → `--exclude-categories x`; `--no-all` → exclude all 13; `--no-all --X` → omit `x` from the list.

**2. Sorting boolean pairs → `OrderPreference` enum (`892d348`).** `--early-versions`/`--early-revisions`/`--early-prereleases` become `--versions`/`--revisions`/`--prereleases <latest|earliest>` (default `latest`), backed by `OrderPreference` on `SortingPreference`. `SubComparatorProvider` ternary branch bodies are untouched — only conditions rewritten (`EARLIEST` selects exactly what `early*==true` selected; verified by a per-branch mapping audit and mutation testing).

**3. Performance primitives → value records (`e3fe502`).** `ScanThreads`, `CopyThreads`, `ScanBufferSize`, `ScanMaxBufferSize`, `CopyBufferSize` records with validation in compact constructors; `AppConfig` and consumers migrated; the `PerformanceOptions.merge` overloads are now cross-assignment-proof — the #12 bug class (`scanThreads` passed into the copier) is a compile error, demonstrated by an executed `javac` probe (`incompatible types: ScanThreads cannot be converted to CopyThreads`). Persisted `config.yaml` schema unchanged (single-value Jackson serialization; existing fixture loads byte-identical values). One deliberate rider: buffer sizes of 0/negative, previously silently accepted, are now rejected at parse time — before/after differential executed at both commits during verification.

## Process evidence

- Steps 1 and 2 change CLI surface and carry executed red→green proofs with frozen test files (`FilteringOptionsCategoryMigrationTest` hash `1721adf2`, `SortingOptionsOrderMigrationTest` hash `2a44561d`), re-executed independently by each step's verifier via `scripts/agent/verify-red-proof.sh`.
- Step 3 is behavior-preserving with the existing suite as oracle; the one rider has executed before/after evidence.
- Each step's verifier gate mutation-tested the new coverage (swapped pattern constants, inverted structural conditions, inverted order arms, dropped record validation — all caught) and audited old-vs-new semantics parity (pattern-category matching applies to the same input as the old CLI-injected excludes path; comparator direction mapping tabulated per branch).
- Migrated test files audited for assertion-count parity — no assertion weakened or dropped (GameComparatorTest 75/75, SubComparatorProviderTest 128/128 asserts).

Full reactor after step 3: core 362 tests, cli 116 tests, all green.

Closes the mechanism behind #23's suggested fix direction as well (tri-state wrapper guidance) — #23 itself (allowRawZipCopy overwrite) remains open and untouched here.

🤖 Generated by [Claude Code](https://claude.com/claude-code), posted via @andrebrait's account on their behalf.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added category-based filtering with the `--exclude-categories` option, including case-insensitive values and validation feedback.
  * Replaced early-order flags with `--versions`, `--revisions`, and `--prereleases`, supporting latest or earliest ordering.
  * Added separate scan and copy performance settings for thread counts and buffer sizes, including human-readable size values.

* **Bug Fixes**
  * Improved validation for invalid, zero, negative, and oversized performance settings.
  * Preserved configuration serialization and round-tripping as simple numeric values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Review riders

- `--only-categories` was deliberately not added (`--exclude-categories` covers all old tri-state semantics; YAGNI until a concrete need appears).
- Includes-rescue parity is preserved: an `--include`/`--include-regex`/`--includes-file` match still rescues a game from pattern-backed category exclusion, exactly as it rescued it from the old CLI-injected pattern excludes; structural categories (proto/beta/demo/sample/bios) remain non-rescuable as before. Pinned by `GameFiltererTest.includesRescuePatternBackedCategoryExclusion` / `includesDoNotRescueStructuralCategoryExclusion`.
