### PR TITLE
core/cli: shared profile contract — NameMatcher entries, Profile aggregate, --profile/--dump-profile

### DIFF
--- a/cli/src/main/java/io/github/datromtool/cli/command/DumpProfileFormat.java
+++ b/cli/src/main/java/io/github/datromtool/cli/command/DumpProfileFormat.java
@@ -1,0 +1,12 @@
+package io.github.datromtool.cli.command;
+
+/**
+ * The two serialization formats {@code --dump-profile} can emit. XML is intentionally not a
+ * member: {@link io.github.datromtool.config.Profile} is a settings contract, not a DAT-file
+ * representation, so only the two formats {@code SerializationHelper#loadJsonOrYaml} dispatches
+ * on are offered here.
+ */
+public enum DumpProfileFormat {
+    JSON,
+    YAML
+}

--- a/cli/src/main/java/io/github/datromtool/cli/command/OneGameOneRomCommand.java
+++ b/cli/src/main/java/io/github/datromtool/cli/command/OneGameOneRomCommand.java
@@ -8,6 +8,8 @@ import com.google.common.collect.ImmutableList;
 import io.github.datromtool.SerializationHelper;
 import io.github.datromtool.cli.GitVersionProvider;
 import io.github.datromtool.cli.argument.DatafileArgument;
+import io.github.datromtool.cli.converter.DumpProfileFormatConverter;
+import io.github.datromtool.cli.converter.ExistingFileConverter;
 import io.github.datromtool.cli.option.DiagnosticOptions;
 import io.github.datromtool.cli.option.FilteringOptions;
 import io.github.datromtool.cli.option.InputOptions;
@@ -15,9 +17,12 @@ import io.github.datromtool.cli.option.OutputOptions;
 import io.github.datromtool.cli.option.PerformanceOptions;
 import io.github.datromtool.cli.option.PostFilteringOptions;
 import io.github.datromtool.cli.option.SortingOptions;
+import io.github.datromtool.cli.profile.ProfileBinder;
 import io.github.datromtool.cli.progressbar.CommandLineProgressBar;
 import io.github.datromtool.command.OneGameOneRom;
 import io.github.datromtool.config.AppConfig;
+import io.github.datromtool.config.Profile;
+import io.github.datromtool.data.FileOutputOptions;
 import io.github.datromtool.data.Filter;
 import io.github.datromtool.data.PostFilter;
 import io.github.datromtool.data.SortingPreference;
@@ -40,6 +45,7 @@ import org.jline.terminal.Terminal;
 import org.jline.terminal.TerminalBuilder;
 import org.slf4j.LoggerFactory;
 import picocli.CommandLine;
+import tools.jackson.core.JacksonException;
 
 import javax.annotation.Nullable;
 import java.io.IOException;
@@ -52,6 +58,28 @@ import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_DEFAULT;
 import static java.lang.String.format;
 import static lombok.AccessLevel.NONE;
 
+/**
+ * Issue #15 step 3 wires the {@link Profile} contract into this command via {@code --profile}
+ * (repeatable, layered by {@link SerializationHelper#loadProfiles}) and {@code --dump-profile}.
+ * Precedence (built-in defaults &lt; profile file(s) &lt; explicit flags) is resolved by
+ * {@link ProfileBinder}, field by field, after a single ordinary parse — <b>not</b> by a picocli
+ * {@link CommandLine.IDefaultValueProvider}. That was probed first and rejected: an
+ * {@code IDefaultValueProvider} only supplies a single default-value string per option, which
+ * {@code picocli} splits into multiple elements only when the option itself declares a
+ * {@code split} regex. None of the free-form expression options that feed
+ * {@link Filter#getExcludes()}/{@link Filter#getIncludes()}/{@link PostFilter#getExcludes()}/
+ * {@code SortingPreference}'s {@code prefers}/{@code avoids} (e.g. {@code --exclude},
+ * {@code --exclude-regex}, {@code --prefer-regex}, ...) declare one, and joining arbitrary
+ * literal/regex values on a delimiter is inherently unsafe (a regex can itself contain the
+ * delimiter). Verified empirically: a provider returning {@code "foo,bar"} for an undeclared-split
+ * {@code List<String>} option binds as the single element {@code "foo,bar"}, not two elements.
+ * Since most of this command's sections are built from exactly these expression options, a
+ * uniform field-overlay mechanism (this one) was chosen over mixing two precedence mechanisms
+ * for different option shapes. A useful side effect: resolving precedence after parsing (rather
+ * than needing the profile file's content before picocli resolves defaults) avoids the two-pass
+ * parse an {@code IDefaultValueProvider} would have required to read {@code --profile} ahead of
+ * everything else.
+ */
 @Slf4j
 @Data
 @NoArgsConstructor
@@ -74,9 +102,30 @@ public final class OneGameOneRomCommand implements Callable<Integer> {
 
     @CommandLine.Parameters(
             description = "DAT file to use when generating the 1G1R set",
-            arity = "1..*",
+            arity = "0..*",
             paramLabel = "DAT_FILE")
     private List<DatafileArgument> datafiles = ImmutableList.of();
+
+    @CommandLine.Option(
+            names = "--profile",
+            paramLabel = "PATH",
+            converter = ExistingFileConverter.class,
+            description = "Load run settings from a profile file (JSON or YAML). Repeatable; "
+                    + "later files are layered over earlier ones. Explicit flags always win over "
+                    + "a profile value.")
+    private List<Path> profiles = ImmutableList.of();
+
+    @CommandLine.Option(
+            names = "--dump-profile",
+            arity = "0..1",
+            fallbackValue = "yaml",
+            paramLabel = "FORMAT",
+            converter = DumpProfileFormatConverter.class,
+            completionCandidates = DumpProfileFormatConverter.class,
+            description = "Print the effective merged configuration (defaults + profile + "
+                    + "flags) as a profile and exit, without running the pipeline. "
+                    + "Options: ${COMPLETION-CANDIDATES} (default: yaml).")
+    private DumpProfileFormat dumpProfile;
 
     @CommandLine.ArgGroup(heading = "Input options\n", exclusive = false)
     private InputOptions inputOptions;
@@ -106,10 +155,56 @@ public final class OneGameOneRomCommand implements Callable<Integer> {
             Logger root = (Logger) LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);
             root.setLevel(Level.DEBUG);
         }
-        if (outputOptions != null
-                && outputOptions.getFileOptions() != null
-                && outputOptions.getFileOptions().getOutputDir() != null
-                && (inputOptions == null || inputOptions.getInputDirs().isEmpty())) {
+
+        CommandLine.ParseResult parseResult = commandSpec.commandLine().getParseResult();
+        Profile profile;
+        try {
+            profile = SerializationHelper.getInstance().loadProfiles(profiles);
+        } catch (IOException e) {
+            throw new CommandLine.ParameterException(commandSpec.commandLine(), e.getMessage());
+        }
+
+        Filter filter = ProfileBinder.effectiveFilter(parseResult, filteringOptions, profile.getFilter());
+        PostFilter postFilter = ProfileBinder.effectivePostFilter(parseResult, postFilteringOptions, profile.getPostFilter());
+        SortingPreference sortingPreference = ProfileBinder.effectiveSortingPreference(parseResult, sortingOptions, profile.getSort());
+        List<Path> effectiveInputDirs = ProfileBinder.effectiveInputDirs(parseResult, inputOptions, profile.getInput());
+        Profile.OutputSection effectiveOutput = ProfileBinder.effectiveOutput(parseResult, outputOptions, profile.getOutput());
+        AppConfig baseAppConfig = SerializationHelper.getInstance().loadAppConfig();
+        AppConfig appConfig = ProfileBinder.effectivePerformance(baseAppConfig, profile.getPerformance(), performanceOptions);
+
+        if (dumpProfile != null) {
+            Profile effectiveProfile = Profile.builder()
+                    .input(Profile.InputSection.builder()
+                            .dats(ImmutableList.copyOf(ProfileBinder.effectiveDats(datafiles, profile.getInput())))
+                            .dirs(ImmutableList.copyOf(effectiveInputDirs))
+                            .build())
+                    .filter(filter)
+                    .sort(sortingPreference)
+                    .postFilter(postFilter)
+                    .output(effectiveOutput)
+                    .performance(appConfig)
+                    .build();
+            try {
+                List<String> lines = dumpProfile == DumpProfileFormat.JSON
+                        ? SerializationHelper.getInstance().writeAsJson(effectiveProfile)
+                        : SerializationHelper.getInstance().writeAsYaml(effectiveProfile);
+                lines.forEach(System.out::println);
+            } catch (JacksonException e) {
+                throw new CommandLine.ParameterException(
+                        commandSpec.commandLine(),
+                        format("Could not dump profile: %s", e.getMessage()));
+            }
+            return 0;
+        }
+
+        if (datafiles.isEmpty()) {
+            throw new CommandLine.ParameterException(
+                    commandSpec.commandLine(),
+                    "Missing required parameter: 'DAT_FILE'");
+        }
+        if (effectiveOutput.getFile() != null
+                && effectiveOutput.getFile().outputDir() != null
+                && effectiveInputDirs.isEmpty()) {
             throw new CommandLine.ParameterException(
                     commandSpec.commandLine(),
                     format(
@@ -117,31 +212,18 @@ public final class OneGameOneRomCommand implements Callable<Integer> {
                             OutputOptions.FileOptions.OUT_DIR_OPTION,
                             InputOptions.IN_DIR_OPTION));
         }
-        Filter filter = filteringOptions != null
-                ? filteringOptions.toFilter()
-                : Filter.builder().build();
-        PostFilter postFilter = postFilteringOptions != null
-                ? postFilteringOptions.toPostFilter()
-                : PostFilter.builder().build();
-        SortingPreference sortingPreference = sortingOptions != null
-                ? sortingOptions.toSortingPreference()
-                : SortingPreference.builder().build();
         OneGameOneRom oneGameOneRom = new OneGameOneRom(filter, postFilter, sortingPreference);
         List<Datafile> realDataFiles = datafiles.stream()
                 .map(DatafileArgument::getDatafile)
                 .collect(ImmutableList.toImmutableList());
-        AppConfig appConfig = SerializationHelper.getInstance().loadAppConfig();
-        if (performanceOptions != null) {
-            appConfig = appConfig.withScanner(performanceOptions.merge(appConfig.getScanner()));
-            appConfig = appConfig.withCopier(performanceOptions.merge(appConfig.getCopier()));
-        }
         boolean hasErrors = false;
         try (Terminal terminal = createTerminal()) {
             FileScannerLoggingListener scannerLoggingListener = new FileScannerLoggingListener();
             List<FileScanner.Listener> scannerListeners = ImmutableList.of(
                     scannerLoggingListener,
                     new CommandLineProgressBar(terminal, "Scanning", "Scanning input directories..."));
-            if (outputOptions != null && outputOptions.getFileOptions() != null) {
+            FileOutputOptions fileOutputOptions = effectiveOutput.getFile();
+            if (fileOutputOptions != null) {
                 FileCopierLoggingListener copierLoggingListener = new FileCopierLoggingListener();
                 List<FileCopier.Listener> copierListeners = ImmutableList.of(
                         copierLoggingListener,
@@ -149,23 +231,17 @@ public final class OneGameOneRomCommand implements Callable<Integer> {
                 oneGameOneRom.generate(
                         appConfig,
                         realDataFiles,
-                        inputOptions.getInputDirs(),
-                        outputOptions.getFileOptions().toFileOutputOptions(),
+                        effectiveInputDirs,
+                        fileOutputOptions,
                         scannerListeners,
                         copierListeners);
                 hasErrors = scannerLoggingListener.isErrors() || copierLoggingListener.isErrors();
             } else {
-                TextOutputOptions textOutputOptions =
-                        outputOptions != null && outputOptions.getTextOptions() != null
-                                ? outputOptions.getTextOptions().toTextOutputOptions()
-                                : null;
-                List<Path> inputDirs = inputOptions != null
-                        ? inputOptions.getInputDirs()
-                        : null;
+                TextOutputOptions textOutputOptions = effectiveOutput.getText();
                 oneGameOneRom.generate(
                         appConfig,
                         realDataFiles,
-                        inputDirs,
+                        effectiveInputDirs,
                         textOutputOptions,
                         scannerListeners,
                         list -> list.forEach(System.out::println));

--- a/cli/src/main/java/io/github/datromtool/cli/converter/DumpProfileFormatConverter.java
+++ b/cli/src/main/java/io/github/datromtool/cli/converter/DumpProfileFormatConverter.java
@@ -1,0 +1,40 @@
+package io.github.datromtool.cli.converter;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.UnmodifiableIterator;
+import io.github.datromtool.cli.command.DumpProfileFormat;
+import picocli.CommandLine;
+
+import javax.annotation.Nonnull;
+import java.util.Arrays;
+import java.util.Locale;
+
+public final class DumpProfileFormatConverter
+        implements CommandLine.ITypeConverter<DumpProfileFormat>, Iterable<String> {
+
+    private static final ImmutableList<String> names = Arrays.stream(DumpProfileFormat.values())
+            .map(Enum::name)
+            .map(n -> n.toLowerCase(Locale.ROOT))
+            .collect(ImmutableList.toImmutableList());
+
+    @Override
+    @Nonnull
+    public UnmodifiableIterator<String> iterator() {
+        return names.iterator();
+    }
+
+    @Override
+    public DumpProfileFormat convert(String value) {
+        String trimmed = value.trim();
+        return names.stream()
+                .filter(n -> n.equalsIgnoreCase(trimmed))
+                .findFirst()
+                .map(n -> n.toUpperCase(Locale.ROOT))
+                .map(DumpProfileFormat::valueOf)
+                .orElseThrow(() -> new CommandLine.TypeConversionException(
+                        String.format(
+                                "'%s' is not a valid profile dump format. It must be one of %s",
+                                value,
+                                names)));
+    }
+}

--- a/cli/src/main/java/io/github/datromtool/cli/converter/ExistingFileConverter.java
+++ b/cli/src/main/java/io/github/datromtool/cli/converter/ExistingFileConverter.java
@@ -1,0 +1,27 @@
+package io.github.datromtool.cli.converter;
+
+import picocli.CommandLine;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import static java.lang.String.format;
+
+/**
+ * Validates that a {@code --profile} value names an existing regular file, mirroring
+ * {@link ExistingDirectoryConverter}'s existence check for {@code --in-dir}. Content validation
+ * (JSON/YAML parseability, {@link io.github.datromtool.config.Profile} binding) happens later,
+ * when the file is actually loaded via {@code SerializationHelper#loadProfiles}.
+ */
+public final class ExistingFileConverter implements CommandLine.ITypeConverter<Path> {
+
+    @Override
+    public Path convert(String s) {
+        Path path = Paths.get(s);
+        if (!Files.isRegularFile(path)) {
+            throw new CommandLine.TypeConversionException(format("No such file: %s", s));
+        }
+        return path;
+    }
+}

--- a/cli/src/main/java/io/github/datromtool/cli/option/PerformanceOptions.java
+++ b/cli/src/main/java/io/github/datromtool/cli/option/PerformanceOptions.java
@@ -29,7 +29,7 @@ public class PerformanceOptions {
 
     private CopyThreads copyThreads;
     private CopyBufferSize copyBufferSize;
-    private boolean allowRawZipCopy;
+    private Boolean allowRawZipCopy;
 
     @CommandLine.Option(
             names = "--scan-threads",
@@ -80,7 +80,7 @@ public class PerformanceOptions {
             names = "--copy-raw-zip",
             description = "Allow raw copies when copying from/to ZIP file. \n" +
                     "Improves performance, but it disables the renaming of files inside the generated ZIP files.")
-    public void setAllowRawZipCopy(boolean allowRawZipCopy) {
+    public void setAllowRawZipCopy(Boolean allowRawZipCopy) {
         this.allowRawZipCopy = allowRawZipCopy;
     }
 
@@ -106,7 +106,7 @@ public class PerformanceOptions {
     public AppConfig.FileCopierConfig merge(AppConfig.FileCopierConfig original) {
         if (copyThreads != null
                 || copyBufferSize != null
-                || allowRawZipCopy) {
+                || allowRawZipCopy != null) {
             AppConfig.FileCopierConfig.FileCopierConfigBuilder builder = original.toBuilder();
             if (copyThreads != null) {
                 builder.threads(copyThreads);
@@ -114,7 +114,9 @@ public class PerformanceOptions {
             if (copyBufferSize != null) {
                 builder.bufferSize(copyBufferSize);
             }
-            builder.allowRawZipCopy(allowRawZipCopy);
+            if (allowRawZipCopy != null) {
+                builder.allowRawZipCopy(allowRawZipCopy);
+            }
             return builder.build();
         }
         return original;

--- a/cli/src/main/java/io/github/datromtool/cli/profile/ProfileBinder.java
+++ b/cli/src/main/java/io/github/datromtool/cli/profile/ProfileBinder.java
@@ -1,0 +1,277 @@
+package io.github.datromtool.cli.profile;
+
+import com.google.common.collect.ImmutableList;
+import io.github.datromtool.cli.argument.DatafileArgument;
+import io.github.datromtool.cli.option.FilteringOptions;
+import io.github.datromtool.cli.option.InputOptions;
+import io.github.datromtool.cli.option.OutputOptions;
+import io.github.datromtool.cli.option.PerformanceOptions;
+import io.github.datromtool.cli.option.PostFilteringOptions;
+import io.github.datromtool.cli.option.SortingOptions;
+import io.github.datromtool.config.AppConfig;
+import io.github.datromtool.config.Profile;
+import io.github.datromtool.data.FileOutputOptions;
+import io.github.datromtool.data.Filter;
+import io.github.datromtool.data.PostFilter;
+import io.github.datromtool.data.SortingPreference;
+import io.github.datromtool.data.TextOutputOptions;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import picocli.CommandLine;
+
+import javax.annotation.Nullable;
+import java.nio.file.Path;
+import java.util.List;
+
+/**
+ * Applies issue #15's precedence rule (built-in defaults &lt; {@code ~/.DATROMTool/config.yaml}
+ * &lt; {@code --profile} file(s) &lt; explicit CLI flags) field by field, so an untouched field of
+ * a section a flag partially touches still comes from the profile rather than falling back all
+ * the way to the stage default.
+ *
+ * <p>This is the "Option B" fallback from the issue's design: an {@link picocli.CommandLine.IDefaultValueProvider}
+ * was probed first and rejected — see {@code OneGameOneRomCommand}'s class Javadoc for the
+ * evidence — so precedence is resolved here, after a single ordinary parse, by consulting
+ * {@link CommandLine.ParseResult#hasMatchedOption(String)} for every option name that feeds a
+ * given {@link Filter}/{@link PostFilter}/{@link SortingPreference}/output/performance field:
+ * matched -&gt; the CLI-converted value wins for that field; unmatched -&gt; the profile's value
+ * (which is already the stage default when the profile omitted that section) survives.
+ *
+ * <p>Deliberately stays in {@code cli}: it is the only place that knows about picocli's
+ * {@link CommandLine.ParseResult} and the {@code cli.option} classes; {@code core} stays
+ * picocli-free.
+ */
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class ProfileBinder {
+
+    public static Filter effectiveFilter(
+            CommandLine.ParseResult pr,
+            @Nullable FilteringOptions cli,
+            Filter profileFilter) {
+        Filter.FilterBuilder builder = profileFilter.toBuilder();
+        if (cli == null) {
+            return builder.build();
+        }
+        Filter cliFilter = cli.toFilter();
+        if (pr.hasMatchedOption("--include-regions")) {
+            builder.includeRegions(cliFilter.getIncludeRegions());
+        }
+        if (pr.hasMatchedOption("--exclude-regions")) {
+            builder.excludeRegions(cliFilter.getExcludeRegions());
+        }
+        if (pr.hasMatchedOption("--include-languages")) {
+            builder.includeLanguages(cliFilter.getIncludeLanguages());
+        }
+        if (pr.hasMatchedOption("--exclude-languages")) {
+            builder.excludeLanguages(cliFilter.getExcludeLanguages());
+        }
+        if (pr.hasMatchedOption("--exclude-categories")) {
+            builder.excludeCategories(cliFilter.getExcludeCategories());
+        }
+        if (pr.hasMatchedOption("--exclude")
+                || pr.hasMatchedOption("--exclude-regex")
+                || pr.hasMatchedOption("--excludes-file")) {
+            builder.excludes(cliFilter.getExcludes());
+        }
+        if (pr.hasMatchedOption("--include")
+                || pr.hasMatchedOption("--include-regex")
+                || pr.hasMatchedOption("--includes-file")) {
+            builder.includes(cliFilter.getIncludes());
+        }
+        return builder.build();
+    }
+
+    public static PostFilter effectivePostFilter(
+            CommandLine.ParseResult pr,
+            @Nullable PostFilteringOptions cli,
+            PostFilter profilePostFilter) {
+        PostFilter.PostFilterBuilder builder = profilePostFilter.toBuilder();
+        if (cli == null) {
+            return builder.build();
+        }
+        if (pr.hasMatchedOption("--post-exclude")
+                || pr.hasMatchedOption("--post-exclude-regex")
+                || pr.hasMatchedOption("--post-excludes-file")) {
+            builder.excludes(cli.toPostFilter().getExcludes());
+        }
+        return builder.build();
+    }
+
+    public static SortingPreference effectiveSortingPreference(
+            CommandLine.ParseResult pr,
+            @Nullable SortingOptions cli,
+            SortingPreference profileSort) {
+        SortingPreference.SortingPreferenceBuilder builder = profileSort.toBuilder();
+        if (cli == null) {
+            return builder.build();
+        }
+        SortingPreference cliSort = cli.toSortingPreference();
+        if (pr.hasMatchedOption("--sort-regions")) {
+            builder.regions(cliSort.getRegions());
+        }
+        if (pr.hasMatchedOption("--sort-languages")) {
+            builder.languages(cliSort.getLanguages());
+        }
+        if (pr.hasMatchedOption("--prefer")
+                || pr.hasMatchedOption("--prefer-regex")
+                || pr.hasMatchedOption("--prefers-file")) {
+            builder.prefers(cliSort.getPrefers());
+        }
+        if (pr.hasMatchedOption("--avoid")
+                || pr.hasMatchedOption("--avoid-regex")
+                || pr.hasMatchedOption("--avoids-file")) {
+            builder.avoids(cliSort.getAvoids());
+        }
+        if (pr.hasMatchedOption("--prioritize-languages")) {
+            builder.prioritizeLanguages(cliSort.isPrioritizeLanguages());
+        }
+        if (pr.hasMatchedOption("--versions")) {
+            builder.versions(cliSort.getVersions());
+        }
+        if (pr.hasMatchedOption("--revisions")) {
+            builder.revisions(cliSort.getRevisions());
+        }
+        if (pr.hasMatchedOption("--prereleases")) {
+            builder.prereleases(cliSort.getPrereleases());
+        }
+        if (pr.hasMatchedOption("--prefer-prereleases")) {
+            builder.preferPrereleases(cliSort.isPreferPrereleases());
+        }
+        if (pr.hasMatchedOption("--prefer-parents")) {
+            builder.preferParents(cliSort.isPreferParents());
+        }
+        return builder.build();
+    }
+
+    public static List<Path> effectiveInputDirs(
+            CommandLine.ParseResult pr,
+            @Nullable InputOptions cli,
+            Profile.InputSection profileInput) {
+        if (cli != null && pr.hasMatchedOption(InputOptions.IN_DIR_OPTION)) {
+            return cli.getInputDirs();
+        }
+        return profileInput.getDirs();
+    }
+
+    /**
+     * Input DAT files for the {@code --dump-profile} snapshot only: real execution always reads
+     * {@code DAT_FILE} positional arguments (never sourced from a profile), so this is purely
+     * for round-tripping a profile that was built (in full or in part) from a prior
+     * {@code --dump-profile} run.
+     */
+    public static List<Path> effectiveDats(
+            List<DatafileArgument> cliDatafiles,
+            Profile.InputSection profileInput) {
+        if (!cliDatafiles.isEmpty()) {
+            return cliDatafiles.stream()
+                    .map(DatafileArgument::getPath)
+                    .collect(ImmutableList.toImmutableList());
+        }
+        return profileInput.getDats();
+    }
+
+    /**
+     * {@code output.file} and {@code output.text} are alternatives, never independent fields, so
+     * once any flag under one of the two groups is matched the profile's output section is
+     * discarded wholesale in favor of the CLI-chosen alternative (itself overlaid field by field
+     * on the profile's same-kind section, if any); with no output flags matched at all, the
+     * profile's section — file, text, or neither — passes through unchanged.
+     */
+    public static Profile.OutputSection effectiveOutput(
+            CommandLine.ParseResult pr,
+            @Nullable OutputOptions cli,
+            Profile.OutputSection profileOutput) {
+        boolean fileMatched = pr.hasMatchedOption("--out-dir")
+                || pr.hasMatchedOption("--alphabetic")
+                || pr.hasMatchedOption("--archive")
+                || pr.hasMatchedOption("--force-subfolder");
+        boolean textMatched = pr.hasMatchedOption("--out-file")
+                || pr.hasMatchedOption("--out-mode");
+        if (fileMatched && cli != null) {
+            FileOutputOptions cliFile = cli.getFileOptions().toFileOutputOptions();
+            FileOutputOptions base = profileOutput.getFile();
+            Path outputDir = pr.hasMatchedOption("--out-dir") || base == null
+                    ? cliFile.outputDir()
+                    : base.outputDir();
+            boolean alphabetic = pr.hasMatchedOption("--alphabetic") || base == null
+                    ? cliFile.alphabetic()
+                    : base.alphabetic();
+            var archiveType = pr.hasMatchedOption("--archive") || base == null
+                    ? cliFile.archiveType()
+                    : base.archiveType();
+            boolean forceSubfolder = pr.hasMatchedOption("--force-subfolder") || base == null
+                    ? cliFile.forceSubfolder()
+                    : base.forceSubfolder();
+            return Profile.OutputSection.builder()
+                    .file(new FileOutputOptions(outputDir, alphabetic, archiveType, forceSubfolder))
+                    .build();
+        }
+        if (textMatched && cli != null) {
+            TextOutputOptions cliText = cli.getTextOptions().toTextOutputOptions();
+            TextOutputOptions base = profileOutput.getText();
+            Path outputFile = pr.hasMatchedOption("--out-file") || base == null
+                    ? cliText.outputFile()
+                    : base.outputFile();
+            var outputMode = pr.hasMatchedOption("--out-mode") || base == null
+                    ? cliText.outputMode()
+                    : base.outputMode();
+            return Profile.OutputSection.builder()
+                    .text(new TextOutputOptions(outputFile, outputMode))
+                    .build();
+        }
+        return profileOutput;
+    }
+
+    /**
+     * Layers the performance section: {@code config.yaml} (or built-in defaults, already loaded
+     * into {@code base}) is the floor, a profile's non-default {@code performance} fields sit
+     * above it, and explicit {@code --scan-*}/{@code --copy-*} flags (via
+     * {@link PerformanceOptions#merge}, unchanged) win over both. "Non-default" is the same
+     * proxy the rest of this codebase uses for "the profile set this field" (see
+     * {@code @JsonInclude(NON_DEFAULT)} throughout {@code core.config}/{@code core.data}): a
+     * profile field bound to exactly its class's hardcoded default is indistinguishable from an
+     * omitted one, which only matters if a profile deliberately pins a field to a value that
+     * happens to equal the hardcoded default while trying to override a different config.yaml
+     * value — a narrow, accepted edge case, not a core change.
+     */
+    public static AppConfig effectivePerformance(
+            AppConfig base,
+            AppConfig profilePerformance,
+            @Nullable PerformanceOptions cli) {
+        AppConfig.FileScannerConfig scannerDefault = AppConfig.FileScannerConfig.builder().build();
+        AppConfig.FileScannerConfig profileScanner = profilePerformance.getScanner();
+        AppConfig.FileScannerConfig.FileScannerConfigBuilder scannerBuilder = base.getScanner().toBuilder();
+        if (!profileScanner.getDefaultBufferSize().equals(scannerDefault.getDefaultBufferSize())) {
+            scannerBuilder.defaultBufferSize(profileScanner.getDefaultBufferSize());
+        }
+        if (!profileScanner.getMaxBufferSize().equals(scannerDefault.getMaxBufferSize())) {
+            scannerBuilder.maxBufferSize(profileScanner.getMaxBufferSize());
+        }
+        if (!profileScanner.getThreads().equals(scannerDefault.getThreads())) {
+            scannerBuilder.threads(profileScanner.getThreads());
+        }
+
+        AppConfig.FileCopierConfig copierDefault = AppConfig.FileCopierConfig.builder().build();
+        AppConfig.FileCopierConfig profileCopier = profilePerformance.getCopier();
+        AppConfig.FileCopierConfig.FileCopierConfigBuilder copierBuilder = base.getCopier().toBuilder();
+        if (!profileCopier.getBufferSize().equals(copierDefault.getBufferSize())) {
+            copierBuilder.bufferSize(profileCopier.getBufferSize());
+        }
+        if (!profileCopier.getThreads().equals(copierDefault.getThreads())) {
+            copierBuilder.threads(profileCopier.getThreads());
+        }
+        if (profileCopier.isAllowRawZipCopy() != copierDefault.isAllowRawZipCopy()) {
+            copierBuilder.allowRawZipCopy(profileCopier.isAllowRawZipCopy());
+        }
+
+        AppConfig withProfile = base
+                .withScanner(scannerBuilder.build())
+                .withCopier(copierBuilder.build());
+        if (cli != null) {
+            withProfile = withProfile
+                    .withScanner(cli.merge(withProfile.getScanner()))
+                    .withCopier(cli.merge(withProfile.getCopier()));
+        }
+        return withProfile;
+    }
+}

--- a/cli/src/main/java/io/github/datromtool/cli/util/ArgumentUtils.java
+++ b/cli/src/main/java/io/github/datromtool/cli/util/ArgumentUtils.java
@@ -3,6 +3,7 @@ package io.github.datromtool.cli.util;
 import com.google.common.collect.ImmutableSet;
 import io.github.datromtool.cli.argument.PatternsFileArgument;
 import io.github.datromtool.cli.argument.StringFilterArgument;
+import io.github.datromtool.data.NameMatcher;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
@@ -14,31 +15,37 @@ import java.util.stream.Stream;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class ArgumentUtils {
 
-    public static ImmutableSet<Pattern> merge(
+    public static ImmutableSet<NameMatcher> merge(
             Collection<String> strings,
             Collection<Pattern> patterns,
             Collection<PatternsFileArgument> patternsFiles) {
-        return ImmutableSet.<Pattern>builder()
-                .addAll(toLiteralPatterns(strings).iterator())
-                .addAll(patterns)
+        return ImmutableSet.<NameMatcher>builder()
+                .addAll(toLiteralMatchers(strings).iterator())
+                .addAll(toRegexMatchers(patterns).iterator())
                 .addAll(patternsFiles.stream()
                         .map(PatternsFileArgument::getStringFilter)
                         .map(StringFilterArgument::strings)
-                        .flatMap(ArgumentUtils::toLiteralPatterns)
+                        .flatMap(ArgumentUtils::toLiteralMatchers)
                         .iterator())
                 .addAll(patternsFiles.stream()
                         .map(PatternsFileArgument::getStringFilter)
                         .map(StringFilterArgument::patterns)
-                        .flatMap(Collection::stream)
+                        .flatMap(ArgumentUtils::toRegexMatchers)
                         .iterator())
                 .build();
     }
 
     @Nonnull
-    private static Stream<Pattern> toLiteralPatterns(Collection<String> strings) {
+    private static Stream<NameMatcher> toLiteralMatchers(Collection<String> strings) {
         return strings.stream()
-                .map(Pattern::quote)
-                .map(Pattern::compile);
+                .map(NameMatcher::literal);
+    }
+
+    @Nonnull
+    private static Stream<NameMatcher> toRegexMatchers(Collection<Pattern> patterns) {
+        return patterns.stream()
+                .map(Pattern::pattern)
+                .map(NameMatcher::regex);
     }
 
 }

--- a/cli/src/test/java/io/github/datromtool/cli/command/OneGameOneRomCommandProfileTest.java
+++ b/cli/src/test/java/io/github/datromtool/cli/command/OneGameOneRomCommandProfileTest.java
@@ -47,6 +47,20 @@ class OneGameOneRomCommandProfileTest {
         return commandLine;
     }
 
+    // F2: OneGameOneRomCommand's --dump-profile snapshot layers the real
+    // ~/.DATROMTool/config.yaml (or built-in defaults, if absent) into the dumped `performance`
+    // section via SerializationHelper#loadAppConfig (see OneGameOneRomCommand line ~172), so on
+    // any machine whose real config.yaml sets a non-default value, comparing the dump against
+    // Profile.builder().build() (always AppConfig's hardcoded defaults) fails for a reason
+    // unrelated to the behavior under test. Building the expected Profile from that same
+    // in-process loadAppConfig() base keeps every other field's default assertion just as
+    // strict while tolerating this one legitimate machine-dependent field.
+    private static Profile defaultProfileWithRealPerformanceBase() {
+        return Profile.builder()
+                .performance(SerializationHelper.getInstance().loadAppConfig())
+                .build();
+    }
+
     private static String runAndCaptureStdout(String... args) {
         OneGameOneRomCommand command = new OneGameOneRomCommand();
         CommandLine commandLine = newCommandLine(command);
@@ -81,7 +95,11 @@ class OneGameOneRomCommandProfileTest {
         Profile reloaded = assertDoesNotThrow(
                 () -> SerializationHelper.getInstance().getYamlMapper().readValue(output, Profile.class),
                 "default --dump-profile output must be valid YAML parseable as a Profile, got:\n" + output);
-        assertEquals(Profile.builder().build(), reloaded, "no flags/profile must dump the default Profile");
+        assertEquals(
+                defaultProfileWithRealPerformanceBase(),
+                reloaded,
+                "no flags/profile must dump the default Profile (performance section compared "
+                        + "against this machine's real loadAppConfig() base, not hardcoded defaults)");
     }
 
     @Test
@@ -100,7 +118,11 @@ class OneGameOneRomCommandProfileTest {
         Profile reloaded = assertDoesNotThrow(
                 () -> SerializationHelper.getInstance().getJsonMapper().readValue(output, Profile.class),
                 "--dump-profile json output must be valid JSON parseable as a Profile, got:\n" + output);
-        assertEquals(Profile.builder().build(), reloaded);
+        assertEquals(
+                defaultProfileWithRealPerformanceBase(),
+                reloaded,
+                "no flags/profile must dump the default Profile (performance section compared "
+                        + "against this machine's real loadAppConfig() base, not hardcoded defaults)");
     }
 
     // Row 4(b): --dump-profile output, reloaded as a --profile, reproduces the same effective

--- a/cli/src/test/java/io/github/datromtool/cli/command/OneGameOneRomCommandProfileTest.java
+++ b/cli/src/test/java/io/github/datromtool/cli/command/OneGameOneRomCommandProfileTest.java
@@ -1,0 +1,172 @@
+package io.github.datromtool.cli.command;
+
+import io.github.datromtool.SerializationHelper;
+import io.github.datromtool.cli.argument.DatafileArgument;
+import io.github.datromtool.cli.converter.DatafileConverter;
+import io.github.datromtool.config.Profile;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import picocli.CommandLine;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.net.URISyntaxException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Coverage matrix rows 3 (layering), 4 (--dump-profile), and 5 (error surfacing) for issue #15
+ * step 3. Row 1/2/7 field-overlay behavior is pinned directly against {@link
+ * io.github.datromtool.cli.profile.ProfileBinder} in {@code ProfileBinderTest}; row 6 (no
+ * profile, no flags -&gt; unchanged behavior) is the existing cli test suite staying green,
+ * unedited.
+ */
+class OneGameOneRomCommandProfileTest {
+
+    private static Path datFixture() {
+        try {
+            return Paths.get(OneGameOneRomCommandProfileTest.class
+                    .getClassLoader()
+                    .getResource("datafiles/minimal.dat")
+                    .toURI());
+        } catch (URISyntaxException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    private static CommandLine newCommandLine(OneGameOneRomCommand command) {
+        CommandLine commandLine = new CommandLine(command);
+        commandLine.registerConverter(DatafileArgument.class, new DatafileConverter());
+        return commandLine;
+    }
+
+    private static String runAndCaptureStdout(String... args) {
+        OneGameOneRomCommand command = new OneGameOneRomCommand();
+        CommandLine commandLine = newCommandLine(command);
+        commandLine.parseArgs(args);
+        ByteArrayOutputStream captured = new ByteArrayOutputStream();
+        PrintStream original = System.out;
+        System.setOut(new PrintStream(captured));
+        int exitCode;
+        try {
+            exitCode = command.call();
+        } finally {
+            System.setOut(original);
+        }
+        assertEquals(0, exitCode, "--dump-profile must exit 0");
+        return captured.toString();
+    }
+
+    // Row 4(c): --dump-profile does not require DAT_FILE and does not run the pipeline (no
+    // exception even though no DAT file, no --in-dir, no region-data setup is provided).
+    @Test
+    void dumpProfileDoesNotRequireDatFile() {
+        String output = assertDoesNotThrow(
+                () -> runAndCaptureStdout("--dump-profile"),
+                "--dump-profile without DAT_FILE must not throw");
+        assertTrue(output.contains("performance") || !output.isBlank(), "dump output must not be empty");
+    }
+
+    // Row 4(a)+(d): default format is yaml and is parseable as a Profile.
+    @Test
+    void dumpProfileDefaultsToYamlAndParses() {
+        String output = runAndCaptureStdout("--dump-profile");
+        Profile reloaded = assertDoesNotThrow(
+                () -> SerializationHelper.getInstance().getYamlMapper().readValue(output, Profile.class),
+                "default --dump-profile output must be valid YAML parseable as a Profile, got:\n" + output);
+        assertEquals(Profile.builder().build(), reloaded, "no flags/profile must dump the default Profile");
+    }
+
+    @Test
+    void dumpProfileYamlValueMatchesDefault() {
+        String output = runAndCaptureStdout("--dump-profile", "yaml");
+        assertDoesNotThrow(
+                () -> SerializationHelper.getInstance().getYamlMapper().readValue(output, Profile.class),
+                "--dump-profile yaml output must be valid YAML, got:\n" + output);
+    }
+
+    // Row 4(d): explicit json format is honored and differs in shape from yaml (starts with '{').
+    @Test
+    void dumpProfileJsonValueProducesJson() {
+        String output = runAndCaptureStdout("--dump-profile", "json");
+        assertTrue(output.trim().startsWith("{"), "--dump-profile json output must be a JSON object, got:\n" + output);
+        Profile reloaded = assertDoesNotThrow(
+                () -> SerializationHelper.getInstance().getJsonMapper().readValue(output, Profile.class),
+                "--dump-profile json output must be valid JSON parseable as a Profile, got:\n" + output);
+        assertEquals(Profile.builder().build(), reloaded);
+    }
+
+    // Row 4(b): --dump-profile output, reloaded as a --profile, reproduces the same effective
+    // config (round-trip), here using --include-regions to give the dump non-default content.
+    @Test
+    void dumpProfileRoundTripsThroughReload(@TempDir Path tempDir) throws IOException {
+        String firstDump = runAndCaptureStdout(
+                datFixture().toString(), "--include-regions", "USA", "--dump-profile", "json");
+        Path reloadFile = tempDir.resolve("reload.json");
+        Files.writeString(reloadFile, firstDump);
+
+        String secondDump = runAndCaptureStdout("--profile", reloadFile.toString(), "--dump-profile", "json");
+
+        Profile first = SerializationHelper.getInstance().getJsonMapper().readValue(firstDump, Profile.class);
+        Profile second = SerializationHelper.getInstance().getJsonMapper().readValue(secondDump, Profile.class);
+        assertEquals(first.getFilter(), second.getFilter(), "reloading a dumped profile must reproduce the same effective Filter");
+    }
+
+    // Row 3: layering two --profile files, later wins (representative assertion; full merge
+    // semantics are covered in core's SerializationHelper/JsonNodeMerge tests).
+    @Test
+    void laterProfileFileWinsOverEarlierOne(@TempDir Path tempDir) throws IOException {
+        Path first = tempDir.resolve("first.yaml");
+        Path second = tempDir.resolve("second.yaml");
+        Files.writeString(first, "filter:\n  includeRegions: [\"USA\"]\n");
+        Files.writeString(second, "filter:\n  includeRegions: [\"JPN\"]\n");
+
+        String output = runAndCaptureStdout(
+                "--profile", first.toString(),
+                "--profile", second.toString(),
+                "--dump-profile", "json");
+        Profile effective = SerializationHelper.getInstance().getJsonMapper().readValue(output, Profile.class);
+        assertEquals(java.util.Set.of("JPN"), effective.getFilter().getIncludeRegions(), "the later --profile file must win");
+    }
+
+    // Row 5(a): a nonexistent --profile file fails cleanly at parse time, naming the path.
+    @Test
+    void nonexistentProfileFileFailsCleanlyAtParseTime() {
+        OneGameOneRomCommand command = new OneGameOneRomCommand();
+        CommandLine commandLine = newCommandLine(command);
+        CommandLine.ParameterException thrown = assertThrows(
+                CommandLine.ParameterException.class,
+                () -> commandLine.parseArgs("--profile", "/no/such/profile.yaml"),
+                "a nonexistent --profile file must fail parsing");
+        assertTrue(
+                thrown.getMessage().contains("/no/such/profile.yaml"),
+                "error message must name the missing path, got: " + thrown.getMessage());
+    }
+
+    // Row 5(b): a malformed (unparseable) profile file surfaces as a clean ParameterException
+    // naming the file, not a raw stack trace.
+    @Test
+    void malformedProfileFileSurfacesAsParameterException(@TempDir Path tempDir) throws IOException {
+        Path malformed = tempDir.resolve("broken.yaml");
+        Files.writeString(malformed, "filter: [unterminated\n");
+
+        OneGameOneRomCommand command = new OneGameOneRomCommand();
+        CommandLine commandLine = newCommandLine(command);
+        commandLine.parseArgs("--profile", malformed.toString(), "--dump-profile");
+
+        CommandLine.ParameterException thrown = assertThrows(
+                CommandLine.ParameterException.class,
+                command::call,
+                "a malformed profile file must surface as a ParameterException, not a raw exception");
+        assertTrue(
+                thrown.getMessage().contains(malformed.toString()),
+                "error message must name the malformed file, got: " + thrown.getMessage());
+    }
+}

--- a/cli/src/test/java/io/github/datromtool/cli/command/ProfileOptionMigrationTest.java
+++ b/cli/src/test/java/io/github/datromtool/cli/command/ProfileOptionMigrationTest.java
@@ -1,0 +1,76 @@
+package io.github.datromtool.cli.command;
+
+import io.github.datromtool.cli.argument.DatafileArgument;
+import io.github.datromtool.cli.converter.DatafileConverter;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import picocli.CommandLine;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+/**
+ * Red-first surface-change proof for issue #15 step 3: {@code --profile} and
+ * {@code --dump-profile} are new options on {@link OneGameOneRomCommand}. Parse-only (no
+ * {@code call()} execution) so it only pins parser acceptance, not pipeline behavior.
+ *
+ * <p>Executed RED before the migration ({@code --profile}/{@code --dump-profile} were unknown
+ * options, rejected with {@link CommandLine.UnmatchedArgumentException}); frozen byte-identical
+ * and re-run GREEN, unchanged, after the migration.
+ */
+class ProfileOptionMigrationTest {
+
+    private static Path datFixture() {
+        try {
+            return Paths.get(ProfileOptionMigrationTest.class
+                    .getClassLoader()
+                    .getResource("datafiles/minimal.dat")
+                    .toURI());
+        } catch (URISyntaxException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    private static CommandLine newCommandLine() {
+        CommandLine commandLine = new CommandLine(new OneGameOneRomCommand());
+        commandLine.registerConverter(DatafileArgument.class, new DatafileConverter());
+        return commandLine;
+    }
+
+    @Test
+    void profileOptionIsAcceptedWithAnExistingFile(@TempDir Path tempDir) throws IOException {
+        Path emptyProfile = tempDir.resolve("profile.yaml");
+        Files.writeString(emptyProfile, "{}\n");
+        assertDoesNotThrow(
+                () -> newCommandLine().parseArgs(
+                        datFixture().toString(),
+                        "--profile", emptyProfile.toString()),
+                "--profile must be accepted as a known option");
+    }
+
+    @Test
+    void dumpProfileOptionIsAcceptedWithNoValue() {
+        assertDoesNotThrow(
+                () -> newCommandLine().parseArgs(datFixture().toString(), "--dump-profile"),
+                "--dump-profile must be accepted with no value (defaults to yaml)");
+    }
+
+    @Test
+    void dumpProfileOptionIsAcceptedWithYamlValue() {
+        assertDoesNotThrow(
+                () -> newCommandLine().parseArgs(datFixture().toString(), "--dump-profile", "yaml"),
+                "--dump-profile yaml must be accepted");
+    }
+
+    @Test
+    void dumpProfileOptionIsAcceptedWithJsonValue() {
+        assertDoesNotThrow(
+                () -> newCommandLine().parseArgs(datFixture().toString(), "--dump-profile", "json"),
+                "--dump-profile json must be accepted");
+    }
+}

--- a/cli/src/test/java/io/github/datromtool/cli/option/FilteringOptionsTest.java
+++ b/cli/src/test/java/io/github/datromtool/cli/option/FilteringOptionsTest.java
@@ -6,6 +6,7 @@ import io.github.datromtool.cli.converter.GameCategoryConverter;
 import io.github.datromtool.cli.converter.PatternsFileConverter;
 import io.github.datromtool.data.Filter;
 import io.github.datromtool.data.GameCategory;
+import io.github.datromtool.data.NameMatcher;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
@@ -57,8 +58,10 @@ class FilteringOptionsTest {
         }
     }
 
-    private static boolean anyMatches(Set<Pattern> patterns, String candidate) {
-        return patterns.stream().anyMatch(p -> p.matcher(candidate).matches());
+    private static boolean anyMatches(Set<NameMatcher> matchers, String candidate) {
+        return matchers.stream()
+                .map(NameMatcher::getPattern)
+                .anyMatch(p -> p.matcher(candidate).matches());
     }
 
     // Row 1

--- a/cli/src/test/java/io/github/datromtool/cli/option/FilteringOptionsTest.java
+++ b/cli/src/test/java/io/github/datromtool/cli/option/FilteringOptionsTest.java
@@ -1,6 +1,5 @@
 package io.github.datromtool.cli.option;
 
-import io.github.datromtool.Patterns;
 import io.github.datromtool.cli.argument.PatternsFileArgument;
 import io.github.datromtool.cli.converter.GameCategoryConverter;
 import io.github.datromtool.cli.converter.PatternsFileConverter;
@@ -17,7 +16,6 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Locale;
 import java.util.Set;
-import java.util.regex.Pattern;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -158,20 +156,20 @@ class FilteringOptionsTest {
                 "--includes-file patterns must merge into Filter.includes, got: " + filter.getIncludes());
     }
 
-    // Row 9 (new-surface equivalent of the old rows 9/12: nothing excluded by default)
+    // Row 9 (new-surface equivalent of the old rows 9/12: nothing excluded by default). Fixed
+    // per issue #31 review: `getExcludes()` returns a Set<NameMatcher> (never a raw
+    // java.util.regex.Pattern), so the previous `.contains(Pattern)` checks below always
+    // returned false regardless of `excludes`' actual contents -- a vacuously passing
+    // assertion. Asserting the set is empty actually fails on a regression.
     @Test
     void noFlagsExcludeNoCategoryAndExcludeNothing() {
         Filter filter = parse();
         assertTrue(
                 filter.getExcludeCategories().isEmpty(),
                 "default excludeCategories must be empty, got: " + filter.getExcludeCategories());
-        for (Pattern p : new Pattern[]{
-                Patterns.BAD, Patterns.PROGRAM, Patterns.ENHANCEMENT_CHIP, Patterns.PIRATE,
-                Patterns.PROMO, Patterns.UNLICENSED, Patterns.DLC, Patterns.UPDATE}) {
-            assertFalse(
-                    filter.getExcludes().contains(p),
-                    "default excludes must not contain " + p.pattern() + ", got: " + filter.getExcludes());
-        }
+        assertTrue(
+                filter.getExcludes().isEmpty(),
+                "default excludes must be empty, got: " + filter.getExcludes());
     }
 
     // Row 1 of the coverage matrix: --exclude-categories parses to Filter.excludeCategories,

--- a/cli/src/test/java/io/github/datromtool/cli/option/PerformanceOptionsTest.java
+++ b/cli/src/test/java/io/github/datromtool/cli/option/PerformanceOptionsTest.java
@@ -129,6 +129,21 @@ class PerformanceOptionsTest {
                 "--copy-raw-zip alone must set FileCopierConfig.allowRawZipCopy true");
     }
 
+    // Issue #23: a persisted allowRawZipCopy=true must survive a merge triggered by an
+    // unrelated --copy-* flag that doesn't touch --copy-raw-zip at all. Reproduction: config.yaml
+    // has allowRawZipCopy: true, user runs with only --copy-threads 3.
+    @Test
+    void copyThreadsAloneMustNotResetPersistedAllowRawZipCopyToFalse() {
+        PerformanceOptions options = parse("--copy-threads", "3");
+        AppConfig.FileCopierConfig original = AppConfig.FileCopierConfig.builder()
+                .allowRawZipCopy(true)
+                .build();
+        AppConfig.FileCopierConfig merged = options.merge(original);
+        assertTrue(
+                merged.isAllowRawZipCopy(),
+                "--copy-threads alone must not reset a persisted allowRawZipCopy=true to false");
+    }
+
     // Matrix row 6 (issue #14 step 3): scan/copy thread wrappers cannot cross-assign at
     // compile time; this end-to-end parse pins the runtime merge stays independent too.
     @Test

--- a/cli/src/test/java/io/github/datromtool/cli/option/PostFilteringOptionsTest.java
+++ b/cli/src/test/java/io/github/datromtool/cli/option/PostFilteringOptionsTest.java
@@ -2,6 +2,7 @@ package io.github.datromtool.cli.option;
 
 import io.github.datromtool.cli.argument.PatternsFileArgument;
 import io.github.datromtool.cli.converter.PatternsFileConverter;
+import io.github.datromtool.data.NameMatcher;
 import io.github.datromtool.data.PostFilter;
 import org.junit.jupiter.api.Test;
 import picocli.CommandLine;
@@ -9,7 +10,6 @@ import picocli.CommandLine;
 import java.net.URISyntaxException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.regex.Pattern;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -42,9 +42,9 @@ class PostFilteringOptionsTest {
         }
     }
 
-    private static boolean anyMatches(Iterable<Pattern> patterns, String candidate) {
-        for (Pattern p : patterns) {
-            if (p.matcher(candidate).matches()) {
+    private static boolean anyMatches(Iterable<NameMatcher> matchers, String candidate) {
+        for (NameMatcher m : matchers) {
+            if (m.getPattern().matcher(candidate).matches()) {
                 return true;
             }
         }

--- a/cli/src/test/java/io/github/datromtool/cli/option/SortingOptionsTest.java
+++ b/cli/src/test/java/io/github/datromtool/cli/option/SortingOptionsTest.java
@@ -2,6 +2,7 @@ package io.github.datromtool.cli.option;
 
 import io.github.datromtool.cli.argument.PatternsFileArgument;
 import io.github.datromtool.cli.converter.PatternsFileConverter;
+import io.github.datromtool.data.NameMatcher;
 import io.github.datromtool.data.OrderPreference;
 import io.github.datromtool.data.SortingPreference;
 import org.junit.jupiter.api.Test;
@@ -56,12 +57,17 @@ class SortingOptionsTest {
         }
     }
 
-    private static Set<String> patternsOf(Set<Pattern> patterns) {
-        return patterns.stream().map(Pattern::pattern).collect(Collectors.toSet());
+    private static Set<String> patternsOf(Set<NameMatcher> matchers) {
+        return matchers.stream()
+                .map(NameMatcher::getPattern)
+                .map(Pattern::pattern)
+                .collect(Collectors.toSet());
     }
 
-    private static boolean anyMatches(Set<Pattern> patterns, String candidate) {
-        return patterns.stream().anyMatch(p -> p.matcher(candidate).matches());
+    private static boolean anyMatches(Set<NameMatcher> matchers, String candidate) {
+        return matchers.stream()
+                .map(NameMatcher::getPattern)
+                .anyMatch(p -> p.matcher(candidate).matches());
     }
 
     @Test

--- a/cli/src/test/java/io/github/datromtool/cli/profile/ProfileBinderTest.java
+++ b/cli/src/test/java/io/github/datromtool/cli/profile/ProfileBinderTest.java
@@ -1,0 +1,249 @@
+package io.github.datromtool.cli.profile;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import io.github.datromtool.cli.converter.ArchiveTypeConverter;
+import io.github.datromtool.cli.converter.CopyThreadsConverter;
+import io.github.datromtool.cli.converter.OutputModeConverter;
+import io.github.datromtool.cli.converter.ScanThreadsConverter;
+import io.github.datromtool.cli.option.FilteringOptions;
+import io.github.datromtool.cli.option.InputOptions;
+import io.github.datromtool.cli.option.OutputOptions;
+import io.github.datromtool.cli.option.PerformanceOptions;
+import io.github.datromtool.cli.option.SortingOptions;
+import io.github.datromtool.config.AppConfig;
+import io.github.datromtool.config.CopyThreads;
+import io.github.datromtool.config.Profile;
+import io.github.datromtool.config.ScanThreads;
+import io.github.datromtool.data.FileOutputOptions;
+import io.github.datromtool.data.Filter;
+import io.github.datromtool.data.OrderPreference;
+import io.github.datromtool.data.SortingPreference;
+import io.github.datromtool.data.TextOutputOptions;
+import io.github.datromtool.io.ArchiveType;
+import org.junit.jupiter.api.Test;
+import picocli.CommandLine;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+/**
+ * Coverage matrix for issue #15 step 3's {@link ProfileBinder} (the "Option B" field-overlay
+ * precedence mechanism; see {@code OneGameOneRomCommand}'s class Javadoc for why the
+ * {@code IDefaultValueProvider} alternative was rejected).
+ */
+class ProfileBinderTest {
+
+    @CommandLine.Command
+    private static final class Holder {
+
+        // Mirrors OneGameOneRomCommand: uninitialized ArgGroup fields, so an unmatched group
+        // stays null exactly like the real command.
+        @CommandLine.ArgGroup(exclusive = false)
+        FilteringOptions filteringOptions;
+
+        @CommandLine.ArgGroup(exclusive = false)
+        SortingOptions sortingOptions;
+
+        @CommandLine.ArgGroup(exclusive = false)
+        InputOptions inputOptions;
+
+        @CommandLine.ArgGroup(exclusive = false)
+        PerformanceOptions performanceOptions;
+    }
+
+    private static CommandLine parsed(Holder holder, String... args) {
+        CommandLine commandLine = new CommandLine(holder);
+        commandLine.registerConverter(ScanThreads.class, new ScanThreadsConverter());
+        commandLine.registerConverter(CopyThreads.class, new CopyThreadsConverter());
+        commandLine.parseArgs(args);
+        return commandLine;
+    }
+
+    // Row 1: a profile-only run (no CLI flags at all) reproduces the same Filter as the
+    // equivalent flags would, field for field.
+    @Test
+    void profileOnlyFilterMatchesEquivalentFlags() {
+        Holder empty = new Holder();
+        CommandLine.ParseResult pr = parsed(empty).getParseResult();
+        Filter profileFilter = Filter.builder()
+                .includeRegions(ImmutableSet.of("USA"))
+                .build();
+        Filter effective = ProfileBinder.effectiveFilter(pr, empty.filteringOptions, profileFilter);
+
+        Holder viaFlags = new Holder();
+        parsed(viaFlags, "--include-regions", "USA");
+        Filter fromFlags = viaFlags.filteringOptions.toFilter();
+
+        assertEquals(fromFlags, effective, "profile-only includeRegions must equal the equivalent-flag Filter");
+    }
+
+    @Test
+    void profileOnlySortMatchesEquivalentFlags() {
+        Holder empty = new Holder();
+        CommandLine.ParseResult pr = parsed(empty).getParseResult();
+        SortingPreference profileSort = SortingPreference.builder()
+                .versions(OrderPreference.EARLIEST)
+                .build();
+        SortingPreference effective = ProfileBinder.effectiveSortingPreference(pr, empty.sortingOptions, profileSort);
+
+        Holder viaFlags = new Holder();
+        parsed(viaFlags, "--versions", "earliest");
+        SortingPreference fromFlags = viaFlags.sortingOptions.toSortingPreference();
+
+        assertEquals(fromFlags, effective, "profile-only versions=earliest must equal the equivalent-flag SortingPreference");
+    }
+
+    // Row 2: flag beats file for the touched field; profile value survives for an untouched
+    // field of the same section.
+    @Test
+    void explicitVersionsFlagBeatsProfileButRegionsSurviveFromProfile() {
+        Holder holder = new Holder();
+        CommandLine commandLine = parsed(holder, "--versions", "latest");
+
+        SortingPreference profileSort = SortingPreference.builder()
+                .versions(OrderPreference.EARLIEST)
+                .regions(ImmutableSet.of("USA"))
+                .build();
+        SortingPreference effective = ProfileBinder.effectiveSortingPreference(
+                commandLine.getParseResult(), holder.sortingOptions, profileSort);
+
+        assertEquals(OrderPreference.LATEST, effective.getVersions(), "--versions latest must win over the profile's EARLIEST");
+        assertEquals(ImmutableSet.of("USA"), effective.getRegions(), "profile's untouched regions must survive");
+    }
+
+    // Row 7: profile performance.scanner.threads participates below explicit --scan-threads
+    // (flag wins) and above the config.yaml-loaded base; base's untouched fields (bufferSize)
+    // are unaffected.
+    @Test
+    void profilePerformanceLayersAboveBaseAndBelowExplicitFlag() {
+        // Neither threads value may equal the class's runtime-computed default (half the CPU
+        // count): that value is indistinguishable from "unset" (see ProfileBinder's Javadoc), so
+        // picking anything other than the machine-dependent default keeps this test deterministic.
+        ScanThreads runtimeDefault = AppConfig.FileScannerConfig.builder().build().getThreads();
+        ScanThreads baseThreads = new ScanThreads(runtimeDefault.value() + 100);
+        ScanThreads profileThreads = new ScanThreads(runtimeDefault.value() + 200);
+        AppConfig base = AppConfig.builder()
+                .scanner(AppConfig.FileScannerConfig.builder()
+                        .threads(baseThreads)
+                        .build())
+                .build();
+        AppConfig profilePerformance = AppConfig.builder()
+                .scanner(AppConfig.FileScannerConfig.builder()
+                        .threads(profileThreads)
+                        .build())
+                .build();
+
+        // No CLI flags: profile's non-default threads win over base's config.yaml value.
+        AppConfig noCli = ProfileBinder.effectivePerformance(base, profilePerformance, null);
+        assertEquals(profileThreads, noCli.getScanner().getThreads(), "profile threads must win over config.yaml base when no flag given");
+        assertEquals(
+                base.getScanner().getDefaultBufferSize(),
+                noCli.getScanner().getDefaultBufferSize(),
+                "untouched bufferSize must keep the config.yaml base value");
+
+        // Explicit --scan-threads wins over both the profile and the base.
+        Holder holder = new Holder();
+        parsed(holder, "--scan-threads", "7");
+        AppConfig withCli = ProfileBinder.effectivePerformance(base, profilePerformance, holder.performanceOptions);
+        assertEquals(new ScanThreads(7), withCli.getScanner().getThreads(), "--scan-threads must win over both profile and config.yaml base");
+    }
+
+    @Test
+    void defaultProfilePerformanceLeavesBaseUntouched() {
+        AppConfig base = AppConfig.builder()
+                .scanner(AppConfig.FileScannerConfig.builder()
+                        .threads(new ScanThreads(3))
+                        .build())
+                .build();
+        AppConfig defaultProfilePerformance = AppConfig.builder().build();
+
+        AppConfig effective = ProfileBinder.effectivePerformance(base, defaultProfilePerformance, null);
+        assertEquals(
+                base.getScanner().getThreads(),
+                effective.getScanner().getThreads(),
+                "a default (unset) profile performance section must not disturb the config.yaml base");
+    }
+
+    @Test
+    void effectiveInputDirsFallsBackToProfileWhenNoInDirFlag() {
+        Holder holder = new Holder();
+        CommandLine commandLine = parsed(holder);
+        List<Path> dirs = ProfileBinder.effectiveInputDirs(
+                commandLine.getParseResult(),
+                holder.inputOptions,
+                Profile.InputSection.builder()
+                        .dirs(ImmutableList.of(Paths.get("roms")))
+                        .build());
+        assertEquals(List.of(Paths.get("roms")), dirs, "--in-dir absent must fall back to the profile's dirs");
+    }
+
+    @Test
+    void explicitInDirFlagBeatsProfileDirs() {
+        Holder holder = new Holder();
+        CommandLine commandLine = parsed(holder, "--in-dir", ".");
+        List<Path> dirs = ProfileBinder.effectiveInputDirs(
+                commandLine.getParseResult(),
+                holder.inputOptions,
+                Profile.InputSection.builder()
+                        .dirs(ImmutableList.of(Paths.get("roms")))
+                        .build());
+        assertEquals(List.of(Paths.get(".")), dirs, "--in-dir must win over the profile's dirs");
+        assertFalse(dirs.contains(Paths.get("roms")), "profile dirs must not leak in when --in-dir is explicit");
+    }
+
+    @CommandLine.Command
+    private static final class OutputHolder {
+
+        @CommandLine.ArgGroup
+        private OutputOptions outputOptions;
+    }
+
+    private static CommandLine parsedOutput(OutputHolder holder, String... args) {
+        CommandLine commandLine = new CommandLine(holder);
+        commandLine.registerConverter(ArchiveType.class, new ArchiveTypeConverter());
+        commandLine.registerConverter(io.github.datromtool.data.OutputMode.class, new OutputModeConverter());
+        commandLine.parseArgs(args);
+        return commandLine;
+    }
+
+    // Output section: file/text are alternatives, so a CLI flag under one group replaces the
+    // profile's section wholesale, but still overlays field by field within the matched kind.
+    @Test
+    void effectiveOutputOverlaysMatchedFileFieldsOnlyKeepingProfileFieldsUntouched() {
+        OutputHolder holder = new OutputHolder();
+        CommandLine commandLine = parsedOutput(holder, "--out-dir", "new");
+        Profile.OutputSection profileOutput = Profile.OutputSection.builder()
+                .file(new FileOutputOptions(Paths.get("old"), true, ArchiveType.ZIP, true))
+                .build();
+
+        Profile.OutputSection effective = ProfileBinder.effectiveOutput(
+                commandLine.getParseResult(), holder.outputOptions, profileOutput);
+
+        FileOutputOptions file = effective.getFile();
+        assertEquals(Paths.get("new"), file.outputDir(), "--out-dir must win over the profile's outputDir");
+        assertEquals(true, file.alphabetic(), "untouched alphabetic must survive from the profile");
+        assertEquals(ArchiveType.ZIP, file.archiveType(), "untouched archiveType must survive from the profile");
+        assertEquals(true, file.forceSubfolder(), "untouched forceSubfolder must survive from the profile");
+        assertNull(effective.getText(), "file-kind output must not carry a text section");
+    }
+
+    @Test
+    void effectiveOutputPassesThroughProfileSectionWhenNoOutputFlagsMatched() {
+        OutputHolder holder = new OutputHolder();
+        CommandLine commandLine = parsedOutput(holder);
+        Profile.OutputSection profileOutput = Profile.OutputSection.builder()
+                .text(new TextOutputOptions(Paths.get("out.txt"), null))
+                .build();
+
+        Profile.OutputSection effective = ProfileBinder.effectiveOutput(
+                commandLine.getParseResult(), holder.outputOptions, profileOutput);
+
+        assertEquals(profileOutput, effective, "with no output flags matched, the profile's section passes through unchanged");
+    }
+}

--- a/cli/src/test/java/io/github/datromtool/cli/profile/ProfileBinderTest.java
+++ b/cli/src/test/java/io/github/datromtool/cli/profile/ProfileBinderTest.java
@@ -154,6 +154,28 @@ class ProfileBinderTest {
         assertEquals(new ScanThreads(7), withCli.getScanner().getThreads(), "--scan-threads must win over both profile and config.yaml base");
     }
 
+    // Issue #23 / gate finding for issue #15 step 3: profile sets copier.allowRawZipCopy=true;
+    // an explicit --copy-raw-zip=false on the CLI must win (ProfileBinder's documented
+    // "explicit flags win" guarantee), not be silently swallowed by PerformanceOptions#merge's
+    // primitive-boolean guard.
+    @Test
+    void explicitCopyRawZipFalseBeatsProfileAllowRawZipCopyTrue() {
+        AppConfig base = AppConfig.builder().build();
+        AppConfig profilePerformance = AppConfig.builder()
+                .copier(AppConfig.FileCopierConfig.builder()
+                        .allowRawZipCopy(true)
+                        .build())
+                .build();
+
+        Holder holder = new Holder();
+        parsed(holder, "--copy-raw-zip=false");
+        AppConfig effective = ProfileBinder.effectivePerformance(base, profilePerformance, holder.performanceOptions);
+
+        assertFalse(
+                effective.getCopier().isAllowRawZipCopy(),
+                "explicit --copy-raw-zip=false must win over the profile's allowRawZipCopy=true");
+    }
+
     @Test
     void defaultProfilePerformanceLeavesBaseUntouched() {
         AppConfig base = AppConfig.builder()

--- a/core/src/main/java/io/github/datromtool/GameFilterer.java
+++ b/core/src/main/java/io/github/datromtool/GameFilterer.java
@@ -5,6 +5,7 @@ import com.google.common.collect.ImmutableMap;
 import io.github.datromtool.data.Filter;
 import io.github.datromtool.data.GameCategory;
 import io.github.datromtool.data.Pair;
+import io.github.datromtool.data.NameMatcher;
 import io.github.datromtool.data.ParsedGame;
 import io.github.datromtool.data.PostFilter;
 import io.github.datromtool.domain.datafile.logiqx.Game;
@@ -84,6 +85,7 @@ public final class GameFilterer {
 
     private boolean matchesAnyInclude(ParsedGame p) {
         return filter.getIncludes().stream()
+                .map(NameMatcher::getPattern)
                 .map(e -> e.matcher(p.getGame().getName()))
                 .anyMatch(Matcher::find);
     }
@@ -149,6 +151,7 @@ public final class GameFilterer {
 
     private boolean filterExcludes(ParsedGame p) {
         boolean result = filter.getExcludes().stream()
+                .map(NameMatcher::getPattern)
                 .map(e -> e.matcher(p.getGame().getName()))
                 .noneMatch(Matcher::find);
         result |= matchesAnyInclude(p);
@@ -168,11 +171,12 @@ public final class GameFilterer {
                             .toList(),
                     filter);
         }
-        for (Pattern exclude : postFilter.getExcludes()) {
+        for (NameMatcher exclude : postFilter.getExcludes()) {
+            Pattern excludePattern = exclude.getPattern();
             if (input.stream()
                     .map(ParsedGame::getGame)
                     .map(Game::getName)
-                    .map(exclude::matcher)
+                    .map(excludePattern::matcher)
                     .anyMatch(Matcher::find)) {
                 if (log.isDebugEnabled()) {
                     log.debug(

--- a/core/src/main/java/io/github/datromtool/PathJacksonModule.java
+++ b/core/src/main/java/io/github/datromtool/PathJacksonModule.java
@@ -35,7 +35,11 @@ final class PathJacksonModule extends SimpleModule {
         addSerializer(Path.class, new ValueSerializer<Path>() {
             @Override
             public void serialize(Path value, JsonGenerator gen, SerializationContext ctxt) throws JacksonException {
-                gen.writeString(value.toString());
+                // Always emit '/' so a profile written on Windows stays readable everywhere;
+                // separators cannot occur inside a file name, so the replacement is lossless.
+                String separator = value.getFileSystem().getSeparator();
+                String text = value.toString();
+                gen.writeString("/".equals(separator) ? text : text.replace(separator, "/"));
             }
         });
         addDeserializer(Path.class, new ValueDeserializer<Path>() {

--- a/core/src/main/java/io/github/datromtool/PathJacksonModule.java
+++ b/core/src/main/java/io/github/datromtool/PathJacksonModule.java
@@ -1,0 +1,48 @@
+package io.github.datromtool;
+
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.core.JsonParser;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.SerializationContext;
+import tools.jackson.databind.ValueDeserializer;
+import tools.jackson.databind.ValueSerializer;
+import tools.jackson.databind.module.SimpleModule;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+/**
+ * Overrides jackson-databind's built-in {@link Path} handling, which serializes via
+ * {@link Path#toUri()} — turning a relative path into an absolute {@code file:///...} URI
+ * (resolved against the JVM's working directory) on write, and back into an absolute path on
+ * read. That is unsuitable for a portable profile file (issue #15): a profile checked out on
+ * another machine, or simply run from a different working directory, must keep a relative
+ * {@code dats}/{@code dirs}/{@code outputDir}/{@code outputFile} path relative, and the
+ * serialized form should read as a plain path string, not a URI.
+ *
+ * <p>Registered on the JSON and YAML mappers only (profile files and, transitively,
+ * {@link io.github.datromtool.data.FileOutputOptions}/{@link io.github.datromtool.data.TextOutputOptions},
+ * are only ever bound through those formats); the XML mapper is untouched since none of the
+ * XML-bound types ({@code Datafile}, {@code Detector}) have {@link Path} fields.
+ */
+final class PathJacksonModule extends SimpleModule {
+
+    static final PathJacksonModule INSTANCE = new PathJacksonModule();
+
+    private PathJacksonModule() {
+        super("NioPathAsPlainString");
+        addSerializer(Path.class, new ValueSerializer<Path>() {
+            @Override
+            public void serialize(Path value, JsonGenerator gen, SerializationContext ctxt) throws JacksonException {
+                gen.writeString(value.toString());
+            }
+        });
+        addDeserializer(Path.class, new ValueDeserializer<Path>() {
+            @Override
+            public Path deserialize(JsonParser p, DeserializationContext ctxt) throws JacksonException {
+                return Paths.get(p.getString());
+            }
+        });
+    }
+}

--- a/core/src/main/java/io/github/datromtool/SerializationHelper.java
+++ b/core/src/main/java/io/github/datromtool/SerializationHelper.java
@@ -170,7 +170,9 @@ public final class SerializationHelper {
      */
     public Profile loadProfiles(List<Path> paths) throws IOException {
         if (paths.isEmpty()) {
-            return Profile.builder().build();
+            Profile profile = Profile.builder().build();
+            profile.validate();
+            return profile;
         }
         JsonNode merged = null;
         for (Path path : paths) {

--- a/core/src/main/java/io/github/datromtool/SerializationHelper.java
+++ b/core/src/main/java/io/github/datromtool/SerializationHelper.java
@@ -184,23 +184,33 @@ public final class SerializationHelper {
 
     private JsonNode readProfileTree(Path path) throws IOException {
         String fileName = path.getFileName().toString();
+        JsonNode node;
         try {
             if (JSON_PATTERN.matcher(fileName).matches()) {
-                return readTree(path, jsonMapper);
+                node = readTree(path, jsonMapper);
             } else if (YAML_PATTERN.matcher(fileName).matches()) {
-                return readTree(path, yamlMapper);
-            }
-            // We have no idea what this file is, so let's try JSON first and then YAML if it fails.
-            // Each attempt re-opens the file: a mapper that fails partway through may have already
-            // consumed part of a shared stream, so a fresh stream per attempt is required.
-            try {
-                return readTree(path, jsonMapper);
-            } catch (JacksonException ignore) {
-                return readTree(path, yamlMapper);
+                node = readTree(path, yamlMapper);
+            } else {
+                // We have no idea what this file is, so let's try JSON first and then YAML if
+                // it fails. Each attempt re-opens the file: a mapper that fails partway through
+                // may have already consumed part of a shared stream, so a fresh stream per
+                // attempt is required.
+                try {
+                    node = readTree(path, jsonMapper);
+                } catch (JacksonException ignore) {
+                    node = readTree(path, yamlMapper);
+                }
             }
         } catch (JacksonException e) {
             throw new IOException("Failed to parse profile file '" + path + "': " + e.getMessage(), e);
         }
+        // A document that is valid JSON/YAML but literally `null` (no object) binds to a null
+        // Profile; without this guard that null reaches Profile#validate() as an NPE instead of
+        // the documented path-naming IOException every other malformed-profile case surfaces.
+        if (node == null || node.isNull()) {
+            throw new IOException("Profile file '" + path + "' does not contain a profile document (parsed to null)");
+        }
+        return node;
     }
 
     private static JsonNode readTree(Path path, ObjectMapper mapper) throws IOException {

--- a/core/src/main/java/io/github/datromtool/SerializationHelper.java
+++ b/core/src/main/java/io/github/datromtool/SerializationHelper.java
@@ -3,6 +3,8 @@ package io.github.datromtool;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.google.common.collect.ImmutableList;
 import io.github.datromtool.config.AppConfig;
+import io.github.datromtool.config.JsonNodeMerge;
+import io.github.datromtool.config.Profile;
 import io.github.datromtool.data.RegionData;
 import io.github.datromtool.domain.datafile.logiqx.Datafile;
 import io.github.datromtool.domain.detector.Detector;
@@ -12,7 +14,9 @@ import lombok.extern.slf4j.Slf4j;
 import tools.jackson.core.JacksonException;
 import tools.jackson.core.StreamWriteFeature;
 import tools.jackson.databind.DeserializationFeature;
+import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.MapperFeature;
+import tools.jackson.databind.ObjectMapper;
 import tools.jackson.databind.SerializationFeature;
 import tools.jackson.databind.json.JsonMapper;
 import tools.jackson.dataformat.xml.XmlMapper;
@@ -26,6 +30,7 @@ import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.List;
 import java.util.Properties;
 import java.util.regex.Pattern;
 
@@ -100,6 +105,7 @@ public final class SerializationHelper {
     private static JsonMapper createJsonMapper() {
         return JsonMapper.builder()
                 .addModule(new GuavaModule())
+                .addModule(PathJacksonModule.INSTANCE)
                 .enable(SerializationFeature.INDENT_OUTPUT)
                 .enable(StreamWriteFeature.WRITE_BIGDECIMAL_AS_PLAIN)
                 .enable(MapperFeature.ACCEPT_CASE_INSENSITIVE_ENUMS)
@@ -111,6 +117,7 @@ public final class SerializationHelper {
     private static YAMLMapper createYamlMapper() {
         return YAMLMapper.builder()
                 .addModule(new GuavaModule())
+                .addModule(PathJacksonModule.INSTANCE)
                 .enable(SerializationFeature.INDENT_OUTPUT)
                 .enable(StreamWriteFeature.WRITE_BIGDECIMAL_AS_PLAIN)
                 .enable(MapperFeature.ACCEPT_CASE_INSENSITIVE_ENUMS)
@@ -141,6 +148,74 @@ public final class SerializationHelper {
             return loadJson(file, tClass);
         } catch (JacksonException ignore) {
             return loadYaml(file, tClass);
+        }
+    }
+
+    /**
+     * Loads a single {@link Profile} file (JSON or YAML, dispatched by extension exactly like
+     * {@link #loadJsonOrYaml}). Validates the result (see {@link Profile#validate()}) before
+     * returning it. Any parse or validation failure is wrapped so the offending file's path is
+     * part of the exception message.
+     */
+    public Profile loadProfile(Path path) throws IOException {
+        return toProfile(readProfileTree(path), path);
+    }
+
+    /**
+     * Loads and layers multiple {@link Profile} files, later files taking precedence over
+     * earlier ones. Each file is read to a tree first and merged with {@link JsonNodeMerge}
+     * (see {@link Profile}'s Javadoc for the merge rule) before the fully-merged tree is bound
+     * to {@link Profile} once, so the result reflects every file's contribution rather than
+     * repeated whole-object replacement. An empty list yields a default {@link Profile}.
+     */
+    public Profile loadProfiles(List<Path> paths) throws IOException {
+        if (paths.isEmpty()) {
+            return Profile.builder().build();
+        }
+        JsonNode merged = null;
+        for (Path path : paths) {
+            JsonNode node = readProfileTree(path);
+            merged = merged == null ? node : JsonNodeMerge.merge(merged, node);
+        }
+        return toProfile(merged, paths.get(paths.size() - 1));
+    }
+
+    private JsonNode readProfileTree(Path path) throws IOException {
+        String fileName = path.getFileName().toString();
+        try {
+            if (JSON_PATTERN.matcher(fileName).matches()) {
+                return readTree(path, jsonMapper);
+            } else if (YAML_PATTERN.matcher(fileName).matches()) {
+                return readTree(path, yamlMapper);
+            }
+            // We have no idea what this file is, so let's try JSON first and then YAML if it fails.
+            // Each attempt re-opens the file: a mapper that fails partway through may have already
+            // consumed part of a shared stream, so a fresh stream per attempt is required.
+            try {
+                return readTree(path, jsonMapper);
+            } catch (JacksonException ignore) {
+                return readTree(path, yamlMapper);
+            }
+        } catch (JacksonException e) {
+            throw new IOException("Failed to parse profile file '" + path + "': " + e.getMessage(), e);
+        }
+    }
+
+    private static JsonNode readTree(Path path, ObjectMapper mapper) throws IOException {
+        try (InputStream inputStream = Files.newInputStream(path)) {
+            return mapper.readTree(inputStream);
+        }
+    }
+
+    private Profile toProfile(JsonNode node, Path path) throws IOException {
+        try {
+            Profile profile = jsonMapper.treeToValue(node, Profile.class);
+            profile.validate();
+            return profile;
+        } catch (JacksonException e) {
+            throw new IOException("Failed to load profile from '" + path + "': " + e.getMessage(), e);
+        } catch (IllegalArgumentException e) {
+            throw new IOException("Invalid profile in '" + path + "': " + e.getMessage(), e);
         }
     }
 

--- a/core/src/main/java/io/github/datromtool/config/JsonNodeMerge.java
+++ b/core/src/main/java/io/github/datromtool/config/JsonNodeMerge.java
@@ -15,7 +15,11 @@ import java.util.Map;
  *
  * <p>The rule: JSON/YAML <em>objects</em> merge recursively, field by field; everything else —
  * scalars, arrays, and mismatched node types — is replaced wholesale by the overlay's value. A
- * field present only in {@code base} (absent from {@code overlay}) survives unchanged.
+ * field genuinely <em>absent</em> from {@code overlay} survives from {@code base} unchanged, but
+ * an explicit {@code null} in {@code overlay} for a field <em>clears</em> that field entirely
+ * (RFC 7386 JSON merge patch semantics) rather than being treated as absent — the field is
+ * removed so binding falls back to the class's own default, exactly as if it had never been set
+ * by any layered file.
  */
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class JsonNodeMerge {
@@ -30,7 +34,14 @@ public final class JsonNodeMerge {
         if (base.isObject() && overlay.isObject()) {
             ObjectNode result = ((ObjectNode) base).deepCopy();
             for (Map.Entry<String, JsonNode> entry : overlay.properties()) {
-                result.set(entry.getKey(), merge(result.get(entry.getKey()), entry.getValue()));
+                JsonNode overlayValue = entry.getValue();
+                if (overlayValue.isNull()) {
+                    // RFC 7386: explicit null clears the field -- never re-merge it against
+                    // base, and never leave it behind as a literal null either.
+                    result.remove(entry.getKey());
+                } else {
+                    result.set(entry.getKey(), merge(result.get(entry.getKey()), overlayValue));
+                }
             }
             return result;
         }

--- a/core/src/main/java/io/github/datromtool/config/JsonNodeMerge.java
+++ b/core/src/main/java/io/github/datromtool/config/JsonNodeMerge.java
@@ -1,0 +1,39 @@
+package io.github.datromtool.config;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.node.ObjectNode;
+
+import java.util.Map;
+
+/**
+ * Deep-merge for two config trees, later ("overlay") winning over earlier ("base"). Used by
+ * {@link io.github.datromtool.SerializationHelper#loadProfiles} to layer multiple
+ * {@link Profile} files (issue #15) before binding the merged tree to Java, sidestepping update
+ * semantics on the immutable {@code @Value} stage classes entirely.
+ *
+ * <p>The rule: JSON/YAML <em>objects</em> merge recursively, field by field; everything else —
+ * scalars, arrays, and mismatched node types — is replaced wholesale by the overlay's value. A
+ * field present only in {@code base} (absent from {@code overlay}) survives unchanged.
+ */
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class JsonNodeMerge {
+
+    public static JsonNode merge(JsonNode base, JsonNode overlay) {
+        if (overlay == null || overlay.isMissingNode() || overlay.isNull()) {
+            return base;
+        }
+        if (base == null || base.isMissingNode()) {
+            return overlay;
+        }
+        if (base.isObject() && overlay.isObject()) {
+            ObjectNode result = ((ObjectNode) base).deepCopy();
+            for (Map.Entry<String, JsonNode> entry : overlay.properties()) {
+                result.set(entry.getKey(), merge(result.get(entry.getKey()), entry.getValue()));
+            }
+            return result;
+        }
+        return overlay;
+    }
+}

--- a/core/src/main/java/io/github/datromtool/config/Profile.java
+++ b/core/src/main/java/io/github/datromtool/config/Profile.java
@@ -34,8 +34,11 @@ import static lombok.AccessLevel.PRIVATE;
  * field by field, so setting one field of a section in a later file leaves that section's other
  * fields — set by an earlier file — untouched; everything else (scalars, and lists/sets such as
  * {@code sort.regions} or {@code filter.includes}) is replaced wholesale by the later file's
- * value, never appended to or spliced with the earlier one. A section entirely absent from a
- * later file leaves the earlier file's section untouched.
+ * value, never appended to or spliced with the earlier one. A field genuinely <em>absent</em>
+ * from a later file leaves the earlier file's value untouched, but an explicit {@code null} for
+ * a field in a later file (e.g. {@code output: {file: null}}) <em>clears</em> that field
+ * (RFC 7386 JSON merge patch semantics), falling back to its class's own default exactly as if
+ * no file had ever set it — see {@link io.github.datromtool.config.JsonNodeMerge}.
  */
 @Value
 @Jacksonized

--- a/core/src/main/java/io/github/datromtool/config/Profile.java
+++ b/core/src/main/java/io/github/datromtool/config/Profile.java
@@ -1,0 +1,129 @@
+package io.github.datromtool.config;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.google.common.collect.ImmutableList;
+import io.github.datromtool.data.Filter;
+import io.github.datromtool.data.FileOutputOptions;
+import io.github.datromtool.data.PostFilter;
+import io.github.datromtool.data.SortingPreference;
+import io.github.datromtool.data.TextOutputOptions;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
+import lombok.Value;
+import lombok.extern.jackson.Jacksonized;
+
+import java.nio.file.Path;
+
+import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_DEFAULT;
+import static lombok.AccessLevel.PRIVATE;
+
+/**
+ * The settings contract shared by the CLI and the future GUI (issue #15): a serializable
+ * aggregate composing every pipeline stage's existing configuration object, so a profile file
+ * (JSON or YAML, dispatched by {@link io.github.datromtool.SerializationHelper#loadJsonOrYaml})
+ * is the direct serialized form of a run's configuration — no parallel schema. Every section is
+ * independently optional and falls back to that stage's own defaults when omitted, exactly like
+ * omitting the equivalent CLI flag group today.
+ *
+ * <p>When multiple profile files are layered (e.g. {@code --profile} given more than once, later
+ * files taking precedence), they are combined with a documented, format-agnostic deep-merge
+ * performed on the raw JSON/YAML tree before binding to this type (see
+ * {@link io.github.datromtool.SerializationHelper#loadProfiles}): objects merge recursively,
+ * field by field, so setting one field of a section in a later file leaves that section's other
+ * fields — set by an earlier file — untouched; everything else (scalars, and lists/sets such as
+ * {@code sort.regions} or {@code filter.includes}) is replaced wholesale by the later file's
+ * value, never appended to or spliced with the earlier one. A section entirely absent from a
+ * later file leaves the earlier file's section untouched.
+ */
+@Value
+@Jacksonized
+@Builder(toBuilder = true)
+@AllArgsConstructor(access = PRIVATE)
+@NoArgsConstructor(access = PRIVATE, force = true)
+@JsonInclude(NON_DEFAULT)
+public class Profile {
+
+    @Value
+    @Jacksonized
+    @Builder(toBuilder = true)
+    @AllArgsConstructor(access = PRIVATE)
+    @NoArgsConstructor(access = PRIVATE, force = true)
+    @JsonInclude(NON_DEFAULT)
+    public static class InputSection {
+
+        @NonNull
+        @Builder.Default
+        ImmutableList<Path> dats = ImmutableList.of();
+
+        @NonNull
+        @Builder.Default
+        ImmutableList<Path> dirs = ImmutableList.of();
+    }
+
+    /**
+     * {@link #getFile()} and {@link #getText()} are mutually exclusive — a run either produces
+     * archived/copied file output or a text report, never both. Neither is required: an
+     * {@code output} section with both unset is valid and means "no output configured yet"
+     * (e.g. a partial GUI-authored profile). Call {@link #validate()} (or
+     * {@link Profile#validate()}) after loading to enforce the exclusivity; construction itself
+     * does not throw, since Jackson must be able to bind an (invalid) profile before the caller
+     * gets a chance to report a file-path-scoped error.
+     */
+    @Value
+    @Jacksonized
+    @Builder(toBuilder = true)
+    @AllArgsConstructor(access = PRIVATE)
+    @NoArgsConstructor(access = PRIVATE, force = true)
+    @JsonInclude(NON_DEFAULT)
+    public static class OutputSection {
+
+        FileOutputOptions file;
+
+        TextOutputOptions text;
+
+        /**
+         * @throws IllegalArgumentException if both {@link #getFile()} and {@link #getText()}
+         *                                   are set.
+         */
+        public void validate() {
+            if (file != null && text != null) {
+                throw new IllegalArgumentException(
+                        "output.file and output.text are mutually exclusive");
+            }
+        }
+    }
+
+    @NonNull
+    @Builder.Default
+    InputSection input = InputSection.builder().build();
+
+    @NonNull
+    @Builder.Default
+    Filter filter = Filter.builder().build();
+
+    @NonNull
+    @Builder.Default
+    SortingPreference sort = SortingPreference.builder().build();
+
+    @NonNull
+    @Builder.Default
+    PostFilter postFilter = PostFilter.builder().build();
+
+    @NonNull
+    @Builder.Default
+    OutputSection output = OutputSection.builder().build();
+
+    @NonNull
+    @Builder.Default
+    AppConfig performance = AppConfig.builder().build();
+
+    /**
+     * @throws IllegalArgumentException if {@link #getOutput()} has both {@code file} and
+     *                                   {@code text} set.
+     */
+    public void validate() {
+        output.validate();
+    }
+}

--- a/core/src/main/java/io/github/datromtool/data/Filter.java
+++ b/core/src/main/java/io/github/datromtool/data/Filter.java
@@ -5,8 +5,6 @@ import com.google.common.collect.ImmutableSet;
 import lombok.*;
 import lombok.extern.jackson.Jacksonized;
 
-import java.util.regex.Pattern;
-
 import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_DEFAULT;
 import static lombok.AccessLevel.PRIVATE;
 
@@ -36,11 +34,11 @@ public class Filter {
 
     @NonNull
     @Builder.Default
-    ImmutableSet<Pattern> excludes = ImmutableSet.of();
+    ImmutableSet<NameMatcher> excludes = ImmutableSet.of();
 
     @NonNull
     @Builder.Default
-    ImmutableSet<Pattern> includes = ImmutableSet.of();
+    ImmutableSet<NameMatcher> includes = ImmutableSet.of();
 
     /*
      * Adding the filter below here saves re-checking all names

--- a/core/src/main/java/io/github/datromtool/data/GameCategory.java
+++ b/core/src/main/java/io/github/datromtool/data/GameCategory.java
@@ -1,8 +1,10 @@
 package io.github.datromtool.data;
 
+import com.fasterxml.jackson.annotation.JsonValue;
 import io.github.datromtool.Patterns;
 
 import javax.annotation.Nullable;
+import java.util.Locale;
 import java.util.Optional;
 import java.util.regex.Pattern;
 
@@ -47,5 +49,16 @@ public enum GameCategory {
      */
     public Optional<Pattern> getPattern() {
         return Optional.ofNullable(pattern);
+    }
+
+    /**
+     * Serializes lowercase, matching the {@code type}/{@code archiveType} lowercase contract
+     * elsewhere in the profile schema ({@link NameMatcher.MatchType},
+     * {@link io.github.datromtool.io.ArchiveType}). Reads stay case-insensitive via
+     * {@code MapperFeature.ACCEPT_CASE_INSENSITIVE_ENUMS} on the shared mappers.
+     */
+    @JsonValue
+    public String toJson() {
+        return name().toLowerCase(Locale.ROOT);
     }
 }

--- a/core/src/main/java/io/github/datromtool/data/NameMatcher.java
+++ b/core/src/main/java/io/github/datromtool/data/NameMatcher.java
@@ -1,0 +1,93 @@
+package io.github.datromtool.data;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonValue;
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
+
+import java.util.Locale;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
+
+import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
+
+/**
+ * A structured, serialization-friendly stand-in for a raw compiled {@link Pattern}: a
+ * {@link #getValue()} plus a {@link MatchType} tag, so profile files (issue #15) can express
+ * {@code {value, type}} instead of a {@code \Q...\E}-quoted regex string.
+ *
+ * <p>The {@link Pattern} is compiled once at construction (never lazily re-derived on every
+ * match) and is excluded from {@link #equals(Object)}/{@link #hashCode()}/{@link #toString()}
+ * and from JSON/YAML serialization, so two matchers with the same value and type are
+ * interchangeable regardless of the underlying compiled instance.
+ */
+@Getter
+@EqualsAndHashCode
+@ToString
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+@JsonInclude(NON_NULL)
+public final class NameMatcher {
+
+    public enum MatchType {
+        LITERAL,
+        REGEX;
+
+        @JsonValue
+        public String toJson() {
+            return name().toLowerCase(Locale.ROOT);
+        }
+    }
+
+    @NonNull
+    private final String value;
+
+    @NonNull
+    private final MatchType type;
+
+    @ToString.Exclude
+    @EqualsAndHashCode.Exclude
+    @JsonIgnore
+    private final Pattern pattern;
+
+    @JsonCreator
+    public static NameMatcher of(
+            @JsonProperty("value") String value,
+            @JsonProperty("type") MatchType type) {
+        if (value == null) {
+            throw new IllegalArgumentException("NameMatcher value must not be null");
+        }
+        if (type == null) {
+            throw new IllegalArgumentException("NameMatcher type must not be null");
+        }
+        return new NameMatcher(value, type, compile(value, type));
+    }
+
+    public static NameMatcher literal(String value) {
+        return of(value, MatchType.LITERAL);
+    }
+
+    public static NameMatcher regex(String value) {
+        return of(value, MatchType.REGEX);
+    }
+
+    private static Pattern compile(String value, MatchType type) {
+        try {
+            return switch (type) {
+                case LITERAL -> Pattern.compile(Pattern.quote(value));
+                case REGEX -> Pattern.compile(value);
+            };
+        } catch (PatternSyntaxException e) {
+            throw new IllegalArgumentException(
+                    "Invalid regular expression for NameMatcher value '" + value + "': "
+                            + e.getMessage(),
+                    e);
+        }
+    }
+}

--- a/core/src/main/java/io/github/datromtool/data/OrderPreference.java
+++ b/core/src/main/java/io/github/datromtool/data/OrderPreference.java
@@ -1,5 +1,9 @@
 package io.github.datromtool.data;
 
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import java.util.Locale;
+
 /**
  * Replaces the direction-ambiguous {@code early*} boolean pairs on {@link SortingPreference}
  * ({@code earlyVersions}/{@code earlyRevisions}/{@code earlyPrereleases}) with an explicit,
@@ -7,5 +11,16 @@ package io.github.datromtool.data;
  */
 public enum OrderPreference {
     LATEST,
-    EARLIEST
+    EARLIEST;
+
+    /**
+     * Serializes lowercase, matching the {@code type}/{@code archiveType} lowercase contract
+     * elsewhere in the profile schema ({@link NameMatcher.MatchType},
+     * {@link io.github.datromtool.io.ArchiveType}). Reads stay case-insensitive via
+     * {@code MapperFeature.ACCEPT_CASE_INSENSITIVE_ENUMS} on the shared mappers.
+     */
+    @JsonValue
+    public String toJson() {
+        return name().toLowerCase(Locale.ROOT);
+    }
 }

--- a/core/src/main/java/io/github/datromtool/data/PostFilter.java
+++ b/core/src/main/java/io/github/datromtool/data/PostFilter.java
@@ -9,8 +9,6 @@ import lombok.NonNull;
 import lombok.Value;
 import lombok.extern.jackson.Jacksonized;
 
-import java.util.regex.Pattern;
-
 import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_DEFAULT;
 import static lombok.AccessLevel.PRIVATE;
 
@@ -24,6 +22,6 @@ public class PostFilter {
 
     @NonNull
     @Builder.Default
-    ImmutableSet<Pattern> excludes = ImmutableSet.of();
+    ImmutableSet<NameMatcher> excludes = ImmutableSet.of();
 
 }

--- a/core/src/main/java/io/github/datromtool/data/SortingPreference.java
+++ b/core/src/main/java/io/github/datromtool/data/SortingPreference.java
@@ -9,8 +9,6 @@ import lombok.NonNull;
 import lombok.Value;
 import lombok.extern.jackson.Jacksonized;
 
-import java.util.regex.Pattern;
-
 import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_DEFAULT;
 import static lombok.AccessLevel.PRIVATE;
 
@@ -32,11 +30,11 @@ public class SortingPreference {
 
     @NonNull
     @Builder.Default
-    ImmutableSet<Pattern> prefers = ImmutableSet.of();
+    ImmutableSet<NameMatcher> prefers = ImmutableSet.of();
 
     @NonNull
     @Builder.Default
-    ImmutableSet<Pattern> avoids = ImmutableSet.of();
+    ImmutableSet<NameMatcher> avoids = ImmutableSet.of();
 
     @Builder.Default
     boolean prioritizeLanguages = false;

--- a/core/src/main/java/io/github/datromtool/sorting/AvoidsListSubComparator.java
+++ b/core/src/main/java/io/github/datromtool/sorting/AvoidsListSubComparator.java
@@ -1,14 +1,13 @@
 package io.github.datromtool.sorting;
 
 import com.google.common.collect.ImmutableSet;
+import io.github.datromtool.data.NameMatcher;
 import io.github.datromtool.data.ParsedGame;
 import io.github.datromtool.data.SortingPreference;
 
-import java.util.regex.Pattern;
-
 final class AvoidsListSubComparator extends SubComparator {
 
-    private final ImmutableSet<Pattern> avoids;
+    private final ImmutableSet<NameMatcher> avoids;
 
     public AvoidsListSubComparator(SortingPreference sortingPreference) {
         super("Avoids list");

--- a/core/src/main/java/io/github/datromtool/sorting/PrefersListSubComparator.java
+++ b/core/src/main/java/io/github/datromtool/sorting/PrefersListSubComparator.java
@@ -1,14 +1,13 @@
 package io.github.datromtool.sorting;
 
 import com.google.common.collect.ImmutableSet;
+import io.github.datromtool.data.NameMatcher;
 import io.github.datromtool.data.ParsedGame;
 import io.github.datromtool.data.SortingPreference;
 
-import java.util.regex.Pattern;
-
 final class PrefersListSubComparator extends SubComparator {
 
-    private final ImmutableSet<Pattern> prefers;
+    private final ImmutableSet<NameMatcher> prefers;
 
     public PrefersListSubComparator(SortingPreference sortingPreference) {
         super("Prefers list");

--- a/core/src/main/java/io/github/datromtool/sorting/SubComparator.java
+++ b/core/src/main/java/io/github/datromtool/sorting/SubComparator.java
@@ -2,6 +2,7 @@ package io.github.datromtool.sorting;
 
 import com.google.common.collect.ImmutableCollection;
 import com.google.common.collect.ImmutableList;
+import io.github.datromtool.data.NameMatcher;
 import io.github.datromtool.data.ParsedGame;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
@@ -11,7 +12,6 @@ import java.util.Iterator;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -53,24 +53,25 @@ public abstract class SubComparator implements Comparator<ParsedGame> {
     protected int comparePatterns(
             ParsedGame o1,
             ParsedGame o2,
-            ImmutableCollection<Pattern> patterns) {
-        int matches1 = computeMatches(o1, patterns);
-        int matches2 = computeMatches(o2, patterns);
+            ImmutableCollection<NameMatcher> matchers) {
+        int matches1 = computeMatches(o1, matchers);
+        int matches2 = computeMatches(o2, matchers);
         return Integer.compare(matches1, matches2);
     }
 
-    private int computeMatches(ParsedGame parsedGame, ImmutableCollection<Pattern> patterns) {
-        int matches = countMatches(parsedGame.getGame().getName(), patterns);
+    private int computeMatches(ParsedGame parsedGame, ImmutableCollection<NameMatcher> matchers) {
+        int matches = countMatches(parsedGame.getGame().getName(), matchers);
         log.trace(
                 "Obtained {} matches in patterns list {} for '{}'",
                 matches,
-                patterns,
+                matchers,
                 parsedGame.getGame().getName());
         return matches;
     }
 
-    private int countMatches(String string, ImmutableCollection<Pattern> patterns) {
-        return Math.toIntExact(patterns.stream()
+    private int countMatches(String string, ImmutableCollection<NameMatcher> matchers) {
+        return Math.toIntExact(matchers.stream()
+                .map(NameMatcher::getPattern)
                 .map(p -> p.matcher(string))
                 .filter(Matcher::find)
                 .count());

--- a/core/src/test/java/io/github/datromtool/GameFiltererTest.java
+++ b/core/src/test/java/io/github/datromtool/GameFiltererTest.java
@@ -4,6 +4,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import io.github.datromtool.data.Filter;
 import io.github.datromtool.data.GameCategory;
+import io.github.datromtool.data.NameMatcher;
 import io.github.datromtool.data.ParsedGame;
 import io.github.datromtool.data.PostFilter;
 import io.github.datromtool.data.RegionData;
@@ -13,7 +14,6 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 
 import java.util.function.UnaryOperator;
-import java.util.regex.Pattern;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -172,7 +172,7 @@ class GameFiltererTest {
         // pattern-backed category exclusions included. That rescue must still apply here.
         Filter filter = Filter.builder()
                 .excludeCategories(ImmutableSet.of(GameCategory.BAD))
-                .includes(ImmutableSet.of(Pattern.compile("Zelda")))
+                .includes(ImmutableSet.of(NameMatcher.regex("Zelda")))
                 .build();
         GameFilterer filterer = new GameFilterer(filter, PostFilter.builder().build());
         ParsedGame game = plainGame("Zelda [b]");
@@ -188,7 +188,7 @@ class GameFiltererTest {
         // before this PR and were never includes-overridable; that must stay true.
         Filter filter = Filter.builder()
                 .excludeCategories(ImmutableSet.of(GameCategory.PROTO))
-                .includes(ImmutableSet.of(Pattern.compile("Zelda")))
+                .includes(ImmutableSet.of(NameMatcher.regex("Zelda")))
                 .build();
         GameFilterer filterer = new GameFilterer(filter, PostFilter.builder().build());
         ParsedGame game = ParsedGame.builder()
@@ -206,7 +206,7 @@ class GameFiltererTest {
         GameFilterer filterer = new GameFilterer(
                 Filter.builder().build(),
                 PostFilter.builder()
-                        .excludes(ImmutableSet.of(Pattern.compile("Banned")))
+                        .excludes(ImmutableSet.of(NameMatcher.regex("Banned")))
                         .build());
         ParsedGame banned = plainGame("Banned Game");
         ParsedGame allowed = plainGame("Allowed Game");

--- a/core/src/test/java/io/github/datromtool/PathJacksonModuleTest.java
+++ b/core/src/test/java/io/github/datromtool/PathJacksonModuleTest.java
@@ -1,0 +1,61 @@
+package io.github.datromtool;
+
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.json.JsonMapper;
+import tools.jackson.dataformat.yaml.YAMLMapper;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Pins {@link PathJacksonModule}'s override of jackson-databind's built-in {@link Path}
+ * handling: a relative path must serialize as a plain path string and round-trip back to an
+ * equal <em>relative</em> path, not get absolutized into a {@code file://} URI against the JVM's
+ * working directory (issue #15 step 2 — profile files carrying relative
+ * {@code dats}/{@code dirs}/{@code outputDir}/{@code outputFile} paths must stay portable).
+ */
+class PathJacksonModuleTest {
+
+    private static final JsonMapper JSON = SerializationHelper.getInstance().getJsonMapper();
+    private static final YAMLMapper YAML = SerializationHelper.getInstance().getYamlMapper();
+
+    @Test
+    void relativePathSerializesAsPlainStringNotUri() {
+        Path path = Paths.get("roms/game.zip");
+        String json = JSON.writeValueAsString(path);
+        assertFalse(json.contains("file:"), "relative Path must not serialize as a file:// URI, got: " + json);
+        assertEquals("\"roms/game.zip\"", json.trim());
+    }
+
+    @Test
+    void relativePathRoundTripsThroughJsonStayingRelative() {
+        Path path = Paths.get("roms/game.zip");
+        String json = JSON.writeValueAsString(path);
+        Path roundTripped = JSON.readValue(json, Path.class);
+        assertEquals(path, roundTripped);
+        assertFalse(roundTripped.isAbsolute(), "round-tripped path must stay relative, got: " + roundTripped);
+    }
+
+    @Test
+    void relativePathRoundTripsThroughYamlStayingRelative() {
+        Path path = Paths.get("roms/game.zip");
+        String yaml = YAML.writeValueAsString(path);
+        Path roundTripped = YAML.readValue(yaml, Path.class);
+        assertEquals(path, roundTripped);
+        assertFalse(roundTripped.isAbsolute(), "round-tripped path must stay relative, got: " + roundTripped);
+    }
+
+    @Test
+    void absolutePathRoundTripsThroughJson() {
+        Path path = Paths.get("/tmp/roms/game.zip");
+        String json = JSON.writeValueAsString(path);
+        assertFalse(json.contains("file:"), "absolute Path must not serialize as a file:// URI, got: " + json);
+        Path roundTripped = JSON.readValue(json, Path.class);
+        assertEquals(path, roundTripped);
+        assertTrue(roundTripped.isAbsolute());
+    }
+}

--- a/core/src/test/java/io/github/datromtool/PathJacksonModuleTest.java
+++ b/core/src/test/java/io/github/datromtool/PathJacksonModuleTest.java
@@ -51,7 +51,9 @@ class PathJacksonModuleTest {
 
     @Test
     void absolutePathRoundTripsThroughJson() {
-        Path path = Paths.get("/tmp/roms/game.zip");
+        // Built from the working directory so the path is genuinely absolute on every OS
+        // (a literal "/tmp/..." is not absolute on Windows).
+        Path path = Paths.get("").toAbsolutePath().resolve("roms").resolve("game.zip");
         String json = JSON.writeValueAsString(path);
         assertFalse(json.contains("file:"), "absolute Path must not serialize as a file:// URI, got: " + json);
         Path roundTripped = JSON.readValue(json, Path.class);

--- a/core/src/test/java/io/github/datromtool/SerializationHelperProfileTest.java
+++ b/core/src/test/java/io/github/datromtool/SerializationHelperProfileTest.java
@@ -3,6 +3,7 @@ package io.github.datromtool;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import io.github.datromtool.config.Profile;
+import io.github.datromtool.data.OutputMode;
 import io.github.datromtool.util.ArchiveUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -14,7 +15,9 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -191,6 +194,65 @@ class SerializationHelperProfileTest {
     @Test
     void loadProfileWrapsUnparsableFileWithFilePath() throws Exception {
         Path file = writeFile("unparsable.json", "{ this is not valid json or yaml : [ ");
+        IOException thrown = assertThrows(IOException.class, () -> helper.loadProfile(file));
+        assertTrue(
+                thrown.getMessage().contains(file.toString()),
+                "exception message must contain the offending file's path, got: " + thrown.getMessage());
+    }
+
+    // Issue #31 review fix B: an explicit null in a later profile file CLEARS the earlier
+    // file's value (RFC 7386 JSON merge patch semantics) rather than being treated as an
+    // absent field. Layering a file-output profile with a second file that nulls
+    // output.file and sets output.text must merge to text-only output that passes
+    // Profile#validate() (output.file/output.text are mutually exclusive).
+    @Test
+    void loadProfilesExplicitNullClearsEarlierFileOutputSection() throws Exception {
+        Path first = writeFile("first.json", """
+                {
+                  "output": {
+                    "file": {"outputDir": "out", "alphabetic": false, "forceSubfolder": false}
+                  }
+                }
+                """);
+        Path second = writeFile("second.json", """
+                {
+                  "output": {
+                    "file": null,
+                    "text": {"outputMode": "json"}
+                  }
+                }
+                """);
+
+        Profile merged = helper.loadProfiles(List.of(first, second));
+
+        assertDoesNotThrow(
+                merged::validate,
+                "explicit null on output.file must clear it, leaving only output.text set");
+        assertNull(
+                merged.getOutput().getFile(),
+                "output.file must be cleared by the second file's explicit null");
+        assertEquals(
+                OutputMode.JSON,
+                merged.getOutput().getText().outputMode(),
+                "output.text must come from the second file");
+    }
+
+    // Issue #31 review fix C: a profile file whose entire document is a literal `null` (valid
+    // YAML/JSON, but not an object) must not proceed to Profile#validate() on a null Profile
+    // reference (NullPointerException) -- it must fail cleanly as an IOException naming the
+    // file, exactly like every other malformed-profile case above.
+    @Test
+    void loadProfileRejectsNullYamlDocumentWithFilePath() throws Exception {
+        Path file = writeFile("null-document.yaml", "null\n");
+        IOException thrown = assertThrows(IOException.class, () -> helper.loadProfile(file));
+        assertTrue(
+                thrown.getMessage().contains(file.toString()),
+                "exception message must contain the offending file's path, got: " + thrown.getMessage());
+    }
+
+    @Test
+    void loadProfileRejectsNullJsonDocumentWithFilePath() throws Exception {
+        Path file = writeFile("null-document.json", "null");
         IOException thrown = assertThrows(IOException.class, () -> helper.loadProfile(file));
         assertTrue(
                 thrown.getMessage().contains(file.toString()),

--- a/core/src/test/java/io/github/datromtool/SerializationHelperProfileTest.java
+++ b/core/src/test/java/io/github/datromtool/SerializationHelperProfileTest.java
@@ -1,0 +1,199 @@
+package io.github.datromtool;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import io.github.datromtool.config.Profile;
+import io.github.datromtool.util.ArchiveUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * End-to-end {@link SerializationHelper#loadProfile} / {@link SerializationHelper#loadProfiles}
+ * coverage for issue #15 step 2: real files on disk, extension-dispatched format detection,
+ * multi-file layering, and error surfacing. Direct merge-rule unit tests live in
+ * {@code io.github.datromtool.config.JsonNodeMergeTest}; single-{@link Profile} shape tests live
+ * in {@code io.github.datromtool.config.ProfileTest}.
+ */
+class SerializationHelperProfileTest {
+
+    private Path tempDir;
+    private SerializationHelper helper;
+
+    @BeforeEach
+    void setup() throws Exception {
+        tempDir = Files.createTempDirectory("datromtool_profile_test_");
+        helper = SerializationHelper.getInstance(tempDir);
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        ArchiveUtils.deleteFolder(tempDir);
+    }
+
+    private Path writeFile(String name, String content) throws IOException {
+        Path file = tempDir.resolve(name);
+        Files.writeString(file, content, StandardCharsets.UTF_8);
+        return file;
+    }
+
+    // Row 1 (file-backed): an empty JSON file loads to a default Profile.
+    @Test
+    void loadProfileFromEmptyJsonFileYieldsDefaults() throws Exception {
+        Path file = writeFile("empty.json", "{}");
+        assertEquals(Profile.builder().build(), helper.loadProfile(file));
+    }
+
+    // Row 1 (file-backed): an empty YAML file loads to a default Profile.
+    @Test
+    void loadProfileFromEmptyYamlFileYieldsDefaults() throws Exception {
+        Path file = writeFile("empty.yaml", "{}\n");
+        assertEquals(Profile.builder().build(), helper.loadProfile(file));
+    }
+
+    // Row 4: layering two files - later file's list field replaces (4a), later file setting only
+    // one field of a section keeps the earlier file's sibling field (4b), a scalar override
+    // applies (4c), and a section entirely absent from the later file survives from the earlier
+    // one (4d).
+    @Test
+    void loadProfilesLayersLaterFileOverEarlier() throws Exception {
+        Path first = writeFile("first.json", """
+                {
+                  "filter": {"includeRegions": ["USA"], "includeLanguages": ["En"]},
+                  "sort": {"regions": ["USA", "Japan"]},
+                  "performance": {"scanner": {"threads": 4}}
+                }
+                """);
+        Path second = writeFile("second.json", """
+                {
+                  "filter": {"includeLanguages": ["Ja"]},
+                  "sort": {"regions": ["Europe"]},
+                  "performance": {"scanner": {"threads": 8}}
+                }
+                """);
+
+        Profile merged = helper.loadProfiles(List.of(first, second));
+
+        // 4(b): includeRegions survived from the first file, includeLanguages came from the
+        // second.
+        assertEquals(ImmutableSet.of("USA"), merged.getFilter().getIncludeRegions());
+        assertEquals(ImmutableSet.of("Ja"), merged.getFilter().getIncludeLanguages());
+        // 4(a): sort.regions replaced wholesale by the second file's list.
+        assertEquals(ImmutableSet.of("Europe"), merged.getSort().getRegions());
+        // 4(c): scalar override.
+        assertEquals(8, merged.getPerformance().getScanner().getThreads().value());
+        // 4(d): postFilter absent from both files stays at its own default.
+        assertEquals(io.github.datromtool.data.PostFilter.builder().build(), merged.getPostFilter());
+    }
+
+    // Row 4(d) isolated: a section present only in the first file survives untouched when the
+    // second file doesn't mention it at all.
+    @Test
+    void loadProfilesSectionAbsentFromLaterFileSurvives() throws Exception {
+        Path first = writeFile("first.json", "{\"filter\":{\"includeRegions\":[\"USA\"]}}");
+        Path second = writeFile("second.json", "{\"sort\":{\"regions\":[\"Japan\"]}}");
+
+        Profile merged = helper.loadProfiles(List.of(first, second));
+
+        assertEquals(ImmutableSet.of("USA"), merged.getFilter().getIncludeRegions());
+        assertEquals(ImmutableSet.of("Japan"), merged.getSort().getRegions());
+    }
+
+    // Row 4(e): a three-file chain, later files consistently taking precedence.
+    @Test
+    void loadProfilesThreeFileChain() throws Exception {
+        Path first = writeFile("a.json", "{\"filter\":{\"includeRegions\":[\"USA\"],\"includeLanguages\":[\"En\"]}}");
+        Path second = writeFile("b.json", "{\"filter\":{\"includeRegions\":[\"Japan\"]}}");
+        Path third = writeFile("c.json", "{\"filter\":{\"includeLanguages\":[\"Ja\"]}}");
+
+        Profile merged = helper.loadProfiles(List.of(first, second, third));
+
+        assertEquals(ImmutableSet.of("Japan"), merged.getFilter().getIncludeRegions());
+        assertEquals(ImmutableSet.of("Ja"), merged.getFilter().getIncludeLanguages());
+    }
+
+    // Row 6: first file YAML, second file JSON - extension-dispatched formats merge correctly.
+    @Test
+    void loadProfilesMergesMixedFormats() throws Exception {
+        Path yamlFile = writeFile("first.yaml", """
+                filter:
+                  includeRegions: [USA]
+                  includeLanguages: [En]
+                """);
+        Path jsonFile = writeFile("second.json", "{\"filter\":{\"includeLanguages\":[\"Ja\"]}}");
+
+        Profile merged = helper.loadProfiles(List.of(yamlFile, jsonFile));
+
+        assertEquals(ImmutableSet.of("USA"), merged.getFilter().getIncludeRegions());
+        assertEquals(ImmutableSet.of("Ja"), merged.getFilter().getIncludeLanguages());
+    }
+
+    // Row 7: an empty path list yields a default Profile without touching disk.
+    @Test
+    void loadProfilesWithEmptyListYieldsDefaults() throws Exception {
+        assertEquals(Profile.builder().build(), helper.loadProfiles(ImmutableList.of()));
+    }
+
+    // Row 7: FAIL_ON_UNKNOWN_PROPERTIES is disabled on both mappers (SerializationHelper's
+    // createJsonMapper/createYamlMapper), so an unknown field in a profile is silently ignored
+    // rather than rejected - pinning that actual, already-configured behavior for profiles too.
+    @Test
+    void loadProfileIgnoresUnknownField() throws Exception {
+        Path file = writeFile("unknown-field.json",
+                "{\"filter\":{\"includeRegions\":[\"USA\"]},\"notARealSection\":{\"foo\":1}}");
+        Profile profile = helper.loadProfile(file);
+        assertEquals(ImmutableSet.of("USA"), profile.getFilter().getIncludeRegions());
+    }
+
+    // Row 7: a bad enum value fails, and the wrapped exception names the offending file.
+    @Test
+    void loadProfileWrapsBadEnumValueWithFilePath() throws Exception {
+        Path file = writeFile("bad-enum.json", "{\"sort\":{\"versions\":\"not-a-real-value\"}}");
+        IOException thrown = assertThrows(IOException.class, () -> helper.loadProfile(file));
+        assertTrue(
+                thrown.getMessage().contains(file.toString()),
+                "exception message must contain the offending file's path, got: " + thrown.getMessage());
+    }
+
+    // Row 5, file-backed: both output.file and output.text set in a loaded profile is rejected
+    // by loadProfile (which calls Profile#validate()), again naming the offending file.
+    @Test
+    void loadProfileWrapsMutuallyExclusiveOutputSectionWithFilePath() throws Exception {
+        Path file = writeFile("bad-output.json", """
+                {
+                  "output": {
+                    "file": {"outputDir": "out", "alphabetic": false, "forceSubfolder": false},
+                    "text": {"outputMode": "json"}
+                  }
+                }
+                """);
+        IOException thrown = assertThrows(IOException.class, () -> helper.loadProfile(file));
+        assertTrue(
+                thrown.getMessage().contains(file.toString()),
+                "exception message must contain the offending file's path, got: " + thrown.getMessage());
+        assertTrue(
+                thrown.getMessage().contains("mutually exclusive"),
+                "exception message must explain the mutual exclusivity, got: " + thrown.getMessage());
+    }
+
+    // Row 7 corollary: parsing a malformed file that isn't even valid JSON/YAML also names the
+    // file in the wrapped exception.
+    @Test
+    void loadProfileWrapsUnparsableFileWithFilePath() throws Exception {
+        Path file = writeFile("unparsable.json", "{ this is not valid json or yaml : [ ");
+        IOException thrown = assertThrows(IOException.class, () -> helper.loadProfile(file));
+        assertTrue(
+                thrown.getMessage().contains(file.toString()),
+                "exception message must contain the offending file's path, got: " + thrown.getMessage());
+    }
+}

--- a/core/src/test/java/io/github/datromtool/config/JsonNodeMergeTest.java
+++ b/core/src/test/java/io/github/datromtool/config/JsonNodeMergeTest.java
@@ -1,0 +1,99 @@
+package io.github.datromtool.config;
+
+import io.github.datromtool.SerializationHelper;
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.json.JsonMapper;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Direct tests for {@link JsonNodeMerge}, the tree-level deep-merge backing
+ * {@link io.github.datromtool.SerializationHelper#loadProfiles} (issue #15 step 2, coverage
+ * matrix row 4). Each test pins one clause of the documented rule: objects merge recursively,
+ * field by field; everything else (scalars, arrays) is replaced wholesale by the overlay.
+ */
+class JsonNodeMergeTest {
+
+    private static final JsonMapper MAPPER = SerializationHelper.getInstance().getJsonMapper();
+
+    private static JsonNode node(String json) {
+        return MAPPER.readTree(json);
+    }
+
+    // Row 4(a): array-valued fields (e.g. sort.regions) replace wholesale, never append/merge.
+    @Test
+    void arrayFieldReplacesWholesale() {
+        JsonNode base = node("{\"sort\":{\"regions\":[\"USA\",\"Japan\"]}}");
+        JsonNode overlay = node("{\"sort\":{\"regions\":[\"Europe\"]}}");
+        assertEquals(node("{\"sort\":{\"regions\":[\"Europe\"]}}"), JsonNodeMerge.merge(base, overlay));
+    }
+
+    // Row 4(b): setting only filter.includeLanguages in the overlay keeps base's
+    // filter.includeRegions untouched (object recursive merge, field by field).
+    @Test
+    void siblingObjectFieldSurvivesRecursiveMerge() {
+        JsonNode base = node("{\"filter\":{\"includeRegions\":[\"USA\"],\"includeLanguages\":[\"En\"]}}");
+        JsonNode overlay = node("{\"filter\":{\"includeLanguages\":[\"Ja\"]}}");
+        assertEquals(
+                node("{\"filter\":{\"includeRegions\":[\"USA\"],\"includeLanguages\":[\"Ja\"]}}"),
+                JsonNodeMerge.merge(base, overlay));
+    }
+
+    // Row 4(c): scalar override (performance.scanner.threads).
+    @Test
+    void scalarFieldReplaces() {
+        JsonNode base = node("{\"performance\":{\"scanner\":{\"threads\":4}}}");
+        JsonNode overlay = node("{\"performance\":{\"scanner\":{\"threads\":8}}}");
+        assertEquals(node("{\"performance\":{\"scanner\":{\"threads\":8}}}"), JsonNodeMerge.merge(base, overlay));
+    }
+
+    // Row 4(d): a section entirely absent from the overlay survives from base unchanged, while a
+    // sibling section present in both still merges by field.
+    @Test
+    void sectionAbsentFromOverlaySurvives() {
+        JsonNode base = node("{\"filter\":{\"includeRegions\":[\"USA\"]},\"sort\":{\"regions\":[\"USA\"]}}");
+        JsonNode overlay = node("{\"filter\":{\"includeRegions\":[\"Japan\"]}}");
+        assertEquals(
+                node("{\"filter\":{\"includeRegions\":[\"Japan\"]},\"sort\":{\"regions\":[\"USA\"]}}"),
+                JsonNodeMerge.merge(base, overlay));
+    }
+
+    // Row 4(e): three-file chain associativity spot check — folding left-to-right (as
+    // loadProfiles does) must equal folding in the other grouping, since at any leaf path the
+    // rightmost file that defines it always wins regardless of how the folds are grouped.
+    @Test
+    void threeWayChainIsOrderInsensitiveToGrouping() {
+        JsonNode a = node("{\"filter\":{\"includeRegions\":[\"USA\"],\"includeLanguages\":[\"En\"]}}");
+        JsonNode b = node("{\"filter\":{\"includeRegions\":[\"Japan\"]}}");
+        JsonNode c = node("{\"filter\":{\"includeLanguages\":[\"Ja\"]}}");
+
+        JsonNode leftFold = JsonNodeMerge.merge(JsonNodeMerge.merge(a, b), c);
+        JsonNode rightFold = JsonNodeMerge.merge(a, JsonNodeMerge.merge(b, c));
+
+        assertEquals(leftFold, rightFold, "grouping must not change the merged result");
+        assertEquals(
+                node("{\"filter\":{\"includeRegions\":[\"Japan\"],\"includeLanguages\":[\"Ja\"]}}"),
+                leftFold);
+    }
+
+    @Test
+    void overlayWithoutFieldLeavesBaseFieldUnchanged() {
+        JsonNode base = node("{\"a\":1}");
+        JsonNode overlay = MAPPER.createObjectNode();
+        assertEquals(base, JsonNodeMerge.merge(base, overlay));
+    }
+
+    @Test
+    void nullBaseReturnsOverlayVerbatim() {
+        JsonNode overlay = node("{\"a\":1}");
+        assertEquals(overlay, JsonNodeMerge.merge(null, overlay));
+    }
+
+    @Test
+    void mismatchedNodeTypesReplaceWholesale() {
+        JsonNode base = node("{\"filter\":{\"includeRegions\":[\"USA\"]}}");
+        JsonNode overlay = node("{\"filter\":\"reset\"}");
+        assertEquals(node("{\"filter\":\"reset\"}"), JsonNodeMerge.merge(base, overlay));
+    }
+}

--- a/core/src/test/java/io/github/datromtool/config/JsonNodeMergeTest.java
+++ b/core/src/test/java/io/github/datromtool/config/JsonNodeMergeTest.java
@@ -96,4 +96,24 @@ class JsonNodeMergeTest {
         JsonNode overlay = node("{\"filter\":\"reset\"}");
         assertEquals(node("{\"filter\":\"reset\"}"), JsonNodeMerge.merge(base, overlay));
     }
+
+    // Issue #31 review fix B: an explicit JSON/YAML null in the overlay CLEARS the base's
+    // value for that field entirely (RFC 7386 JSON merge patch semantics) -- contrast with
+    // overlayWithoutFieldLeavesBaseFieldUnchanged, where the field is genuinely MISSING and
+    // survives from base instead.
+    @Test
+    void explicitNullInOverlayClearsBaseField() {
+        JsonNode base = node("{\"a\":1,\"b\":2}");
+        JsonNode overlay = node("{\"a\":null}");
+        assertEquals(node("{\"b\":2}"), JsonNodeMerge.merge(base, overlay));
+    }
+
+    @Test
+    void explicitNullClearsNestedObjectFieldWhileSiblingIsSet() {
+        JsonNode base = node("{\"output\":{\"file\":{\"outputDir\":\"out\"}}}");
+        JsonNode overlay = node("{\"output\":{\"file\":null,\"text\":{\"outputMode\":\"json\"}}}");
+        assertEquals(
+                node("{\"output\":{\"text\":{\"outputMode\":\"json\"}}}"),
+                JsonNodeMerge.merge(base, overlay));
+    }
 }

--- a/core/src/test/java/io/github/datromtool/config/ProfileTest.java
+++ b/core/src/test/java/io/github/datromtool/config/ProfileTest.java
@@ -1,0 +1,170 @@
+package io.github.datromtool.config;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import io.github.datromtool.SerializationHelper;
+import io.github.datromtool.data.Filter;
+import io.github.datromtool.data.FileOutputOptions;
+import io.github.datromtool.data.GameCategory;
+import io.github.datromtool.data.NameMatcher;
+import io.github.datromtool.data.OrderPreference;
+import io.github.datromtool.data.OutputMode;
+import io.github.datromtool.data.PostFilter;
+import io.github.datromtool.data.SortingPreference;
+import io.github.datromtool.data.TextOutputOptions;
+import io.github.datromtool.io.ArchiveType;
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.json.JsonMapper;
+import tools.jackson.dataformat.yaml.YAMLMapper;
+
+import java.nio.file.Paths;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Coverage matrix for issue #15 step 2's {@link Profile} aggregate: default omission, full
+ * round-tripping through both formats, section optionality, and output exclusivity validation.
+ * Merge behavior itself is covered directly in {@link JsonNodeMergeTest} and end-to-end in
+ * {@code io.github.datromtool.SerializationHelperProfileTest}.
+ */
+class ProfileTest {
+
+    private static final JsonMapper JSON = SerializationHelper.getInstance().getJsonMapper();
+    private static final YAMLMapper YAML = SerializationHelper.getInstance().getYamlMapper();
+
+    // Row 1: an empty file (JSON "{}" / equivalent empty YAML mapping) yields a default Profile,
+    // and a default-built Profile serializes back to "{}" (NON_DEFAULT omission).
+    @Test
+    void emptyJsonYieldsDefaultProfile() {
+        assertEquals(Profile.builder().build(), JSON.readValue("{}", Profile.class));
+    }
+
+    @Test
+    void emptyYamlYieldsDefaultProfile() {
+        assertEquals(Profile.builder().build(), YAML.readValue("{}\n", Profile.class));
+    }
+
+    @Test
+    void defaultProfileSerializesToEmptyJsonObject() {
+        String json = JSON.writeValueAsString(Profile.builder().build());
+        assertEquals("{}", json.replaceAll("\\s+", ""), "default Profile must serialize to {}, got: " + json);
+    }
+
+    // Row 2: a fully populated profile (every section, NameMatcher entries, GameCategory
+    // excludes, OrderPreference sorts, wrapper-record performance values) round-trips through
+    // both JSON and YAML, and both round trips agree with each other.
+    @Test
+    void fullProfileRoundTripsThroughJsonAndYamlEqual() {
+        Profile profile = fullProfile();
+
+        String json = JSON.writeValueAsString(profile);
+        Profile fromJson = JSON.readValue(json, Profile.class);
+        assertEquals(profile, fromJson, "full Profile must round-trip through JSON, got: " + json);
+
+        String yaml = YAML.writeValueAsString(profile);
+        Profile fromYaml = YAML.readValue(yaml, Profile.class);
+        assertEquals(profile, fromYaml, "full Profile must round-trip through YAML, got: " + yaml);
+
+        assertEquals(fromJson, fromYaml, "JSON and YAML round trips of the same Profile must be equal");
+    }
+
+    private static Profile fullProfile() {
+        return Profile.builder()
+                .input(Profile.InputSection.builder()
+                        .dats(ImmutableList.of(Paths.get("game.dat")))
+                        .dirs(ImmutableList.of(Paths.get("roms")))
+                        .build())
+                .filter(Filter.builder()
+                        .includeRegions(ImmutableSet.of("USA"))
+                        .excludeRegions(ImmutableSet.of("Japan"))
+                        .includeLanguages(ImmutableSet.of("En"))
+                        .excludeLanguages(ImmutableSet.of("Ja"))
+                        .excludes(ImmutableSet.of(NameMatcher.literal("a(b")))
+                        .includes(ImmutableSet.of(NameMatcher.regex("c.d")))
+                        .excludeCategories(ImmutableSet.of(GameCategory.BAD, GameCategory.DLC))
+                        .build())
+                .sort(SortingPreference.builder()
+                        .regions(ImmutableSet.of("USA"))
+                        .languages(ImmutableSet.of("En"))
+                        .prefers(ImmutableSet.of(NameMatcher.literal("Rev")))
+                        .avoids(ImmutableSet.of(NameMatcher.regex("Beta.*")))
+                        .prioritizeLanguages(true)
+                        .versions(OrderPreference.EARLIEST)
+                        .revisions(OrderPreference.EARLIEST)
+                        .prereleases(OrderPreference.EARLIEST)
+                        .preferParents(true)
+                        .preferPrereleases(true)
+                        .build())
+                .postFilter(PostFilter.builder()
+                        .excludes(ImmutableSet.of(NameMatcher.literal("[BIOS]")))
+                        .build())
+                .output(Profile.OutputSection.builder()
+                        .file(new FileOutputOptions(Paths.get("out"), true, ArchiveType.ZIP, true))
+                        .build())
+                .performance(AppConfig.builder()
+                        .scanner(AppConfig.FileScannerConfig.builder()
+                                .threads(new ScanThreads(7))
+                                .defaultBufferSize(new ScanBufferSize(65536))
+                                .maxBufferSize(new ScanMaxBufferSize(1048576))
+                                .build())
+                        .copier(AppConfig.FileCopierConfig.builder()
+                                .threads(new CopyThreads(9))
+                                .bufferSize(new CopyBufferSize(4096))
+                                .build())
+                        .build())
+                .build();
+    }
+
+    // Row 3: a profile with only "filter" populated leaves sort/postFilter/performance/input/
+    // output at their own defaults.
+    @Test
+    void onlyFilterSectionSetLeavesOtherSectionsDefault() {
+        Profile profile = JSON.readValue("{\"filter\":{\"includeRegions\":[\"USA\"]}}", Profile.class);
+        assertEquals(ImmutableSet.of("USA"), profile.getFilter().getIncludeRegions());
+        assertEquals(SortingPreference.builder().build(), profile.getSort());
+        assertEquals(PostFilter.builder().build(), profile.getPostFilter());
+        assertEquals(AppConfig.builder().build(), profile.getPerformance());
+        assertEquals(Profile.InputSection.builder().build(), profile.getInput());
+        assertEquals(Profile.OutputSection.builder().build(), profile.getOutput());
+    }
+
+    // Row 5: output.file and output.text are mutually exclusive.
+    @Test
+    void bothFileAndTextOutputFailsValidation() {
+        Profile profile = Profile.builder()
+                .output(Profile.OutputSection.builder()
+                        .file(new FileOutputOptions(Paths.get("out"), false, null, false))
+                        .text(new TextOutputOptions(null, OutputMode.JSON))
+                        .build())
+                .build();
+        IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class, profile::validate);
+        assertEquals("output.file and output.text are mutually exclusive", thrown.getMessage());
+    }
+
+    @Test
+    void fileOnlyOutputPassesValidation() {
+        Profile profile = Profile.builder()
+                .output(Profile.OutputSection.builder()
+                        .file(new FileOutputOptions(Paths.get("out"), false, null, false))
+                        .build())
+                .build();
+        assertDoesNotThrow(profile::validate);
+    }
+
+    @Test
+    void textOnlyOutputPassesValidation() {
+        Profile profile = Profile.builder()
+                .output(Profile.OutputSection.builder()
+                        .text(new TextOutputOptions(null, OutputMode.JSON))
+                        .build())
+                .build();
+        assertDoesNotThrow(profile::validate);
+    }
+
+    @Test
+    void neitherFileNorTextOutputPassesValidation() {
+        assertDoesNotThrow(() -> Profile.builder().build().validate());
+    }
+}

--- a/core/src/test/java/io/github/datromtool/data/FilterTest.java
+++ b/core/src/test/java/io/github/datromtool/data/FilterTest.java
@@ -61,4 +61,45 @@ class FilterTest {
                 roundTripped,
                 "Filter with excludeCategories must round-trip through YAML, got: " + yaml);
     }
+
+    // Issue #15 step 1, coverage matrix row 3: excludes/includes carry structured NameMatcher
+    // entries, and a literal entry must not leak \Q...\E quoting into the serialized form.
+    @Test
+    void excludesAndIncludesRoundTripThroughJsonWithNoQuoteLeakage() {
+        Filter filter = Filter.builder()
+                .excludes(ImmutableSet.of(NameMatcher.literal("a(b")))
+                .includes(ImmutableSet.of(NameMatcher.regex("c.d")))
+                .build();
+        JsonMapper mapper = SerializationHelper.getInstance().getJsonMapper();
+        String json = mapper.writeValueAsString(filter);
+        assertTrue(
+                json.replaceAll("\\s+", "").contains("\"type\":\"literal\""),
+                "serialized literal exclude entry must contain lowercase type, got: " + json);
+        assertTrue(
+                json.replaceAll("\\s+", "").contains("\"type\":\"regex\""),
+                "serialized regex include entry must contain lowercase type, got: " + json);
+        assertFalse(
+                json.contains("\\Q"),
+                "serialized Filter with a literal matcher must not leak \\Q quoting, got: " + json);
+        Filter roundTripped = mapper.readValue(json, Filter.class);
+        assertEquals(
+                filter,
+                roundTripped,
+                "Filter with excludes/includes NameMatcher sets must round-trip through JSON, got: " + json);
+    }
+
+    @Test
+    void excludesAndIncludesRoundTripThroughYaml() {
+        Filter filter = Filter.builder()
+                .excludes(ImmutableSet.of(NameMatcher.literal("a(b")))
+                .includes(ImmutableSet.of(NameMatcher.regex("c.d")))
+                .build();
+        YAMLMapper mapper = SerializationHelper.getInstance().getYamlMapper();
+        String yaml = mapper.writeValueAsString(filter);
+        Filter roundTripped = mapper.readValue(yaml, Filter.class);
+        assertEquals(
+                filter,
+                roundTripped,
+                "Filter with excludes/includes NameMatcher sets must round-trip through YAML, got: " + yaml);
+    }
 }

--- a/core/src/test/java/io/github/datromtool/data/GameCategoryTest.java
+++ b/core/src/test/java/io/github/datromtool/data/GameCategoryTest.java
@@ -1,0 +1,53 @@
+package io.github.datromtool.data;
+
+import io.github.datromtool.SerializationHelper;
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.json.JsonMapper;
+import tools.jackson.dataformat.yaml.YAMLMapper;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+/**
+ * Issue #31 F5: {@link GameCategory} serializes lowercase, matching the lowercase contract
+ * already established by {@code NameMatcher.MatchType} ({@code type: "literal"}) and
+ * {@link io.github.datromtool.io.ArchiveType} ({@code archiveType: "zip"}), while still reading
+ * either casing (existing profile files written before this fix, or hand-authored uppercase
+ * YAML, keep parsing).
+ */
+class GameCategoryTest {
+
+    @Test
+    void badSerializesLowercaseThroughJson() {
+        JsonMapper mapper = SerializationHelper.getInstance().getJsonMapper();
+        String json = mapper.writeValueAsString(GameCategory.BAD);
+        assertEquals("\"bad\"", json, "GameCategory.BAD must serialize lowercase, got: " + json);
+    }
+
+    @Test
+    void dlcSerializesLowercaseThroughYaml() {
+        YAMLMapper mapper = SerializationHelper.getInstance().getYamlMapper();
+        String yaml = mapper.writeValueAsString(GameCategory.DLC);
+        assertFalse(yaml.contains("DLC"), "GameCategory.DLC must not serialize uppercase through YAML, got: " + yaml);
+        GameCategory roundTripped = mapper.readValue(yaml, GameCategory.class);
+        assertEquals(GameCategory.DLC, roundTripped, "GameCategory must round-trip through YAML, got: " + yaml);
+    }
+
+    @Test
+    void lowercaseValueIsReadCorrectly() {
+        JsonMapper mapper = SerializationHelper.getInstance().getJsonMapper();
+        assertEquals(
+                GameCategory.PROTO,
+                mapper.readValue("\"proto\"", GameCategory.class),
+                "lowercase 'proto' must parse to GameCategory.PROTO");
+    }
+
+    @Test
+    void uppercaseValueIsStillReadCaseInsensitively() {
+        JsonMapper mapper = SerializationHelper.getInstance().getJsonMapper();
+        assertEquals(
+                GameCategory.PROTO,
+                mapper.readValue("\"PROTO\"", GameCategory.class),
+                "uppercase 'PROTO' must still parse to GameCategory.PROTO (case-insensitive reads)");
+    }
+}

--- a/core/src/test/java/io/github/datromtool/data/NameMatcherTest.java
+++ b/core/src/test/java/io/github/datromtool/data/NameMatcherTest.java
@@ -1,0 +1,110 @@
+package io.github.datromtool.data;
+
+import io.github.datromtool.SerializationHelper;
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.json.JsonMapper;
+import tools.jackson.dataformat.yaml.YAMLMapper;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+/**
+ * Coverage matrix rows 1-3 of issue #15 step 1: {@link NameMatcher} replicates the pre-existing
+ * literal-quoting/regex-compiling semantics, is value-based in equality (the derived
+ * {@link java.util.regex.Pattern} is excluded), and round-trips through JSON/YAML with a
+ * lowercase {@code type} and no {@code \Q...\E} leakage for literal entries.
+ */
+class NameMatcherTest {
+
+    // Matrix row 1: LITERAL matches exactly like today's Pattern.quote path.
+    @Test
+    void literalMatcherTreatsMetacharactersAsInert() {
+        NameMatcher matcher = NameMatcher.literal("a(b");
+        assertTrue(
+                matcher.getPattern().matcher("xa(bz").find(),
+                "literal matcher for 'a(b' must match text containing the literal 'a(b'");
+        assertFalse(
+                matcher.getPattern().matcher("ab").find(),
+                "literal matcher for 'a(b' must NOT match 'ab' (would match if unquoted regex)");
+    }
+
+    // Matrix row 1: REGEX compiles and matches as a real regular expression.
+    @Test
+    void regexMatcherCompilesAndMatchesAsRegularExpression() {
+        NameMatcher matcher = NameMatcher.regex("a.b");
+        assertTrue(
+                matcher.getPattern().matcher("aXb").find(),
+                "regex matcher for 'a.b' must match 'aXb' as a regular expression");
+    }
+
+    // Matrix row 1: invalid REGEX value fails clearly at construction, message names the value.
+    @Test
+    void invalidRegexValueFailsAtConstructionWithOffendingValueInMessage() {
+        IllegalArgumentException e = assertThrows(
+                IllegalArgumentException.class,
+                () -> NameMatcher.regex("(["),
+                "an invalid regex must fail at NameMatcher construction");
+        assertTrue(
+                e.getMessage().contains("(["),
+                "exception message must mention the offending value, got: " + e.getMessage());
+    }
+
+    // Matrix row 2: equality is value-based; the compiled Pattern is excluded.
+    @Test
+    void equalityIsValueBasedIgnoringCompiledPattern() {
+        NameMatcher a = NameMatcher.literal("Zelda");
+        NameMatcher b = NameMatcher.literal("Zelda");
+        assertEquals(a, b, "two literal matchers with the same value must be equal");
+        assertEquals(a.hashCode(), b.hashCode(), "equal matchers must have equal hash codes");
+        // Different compiled Pattern instances (Pattern has no value equality) must not affect it.
+        assertNotEquals(a.getPattern(), b.getPattern(), "sanity: Pattern itself is identity-based");
+    }
+
+    @Test
+    void equalityDistinguishesTypeForTheSameValue() {
+        NameMatcher literal = NameMatcher.literal("Zelda");
+        NameMatcher regex = NameMatcher.regex("Zelda");
+        assertNotEquals(
+                literal,
+                regex,
+                "a literal and a regex matcher with the same value must not be equal");
+    }
+
+    // Matrix row 3: JSON/YAML round-trip, lowercase type, case-insensitive read, no \Q leakage.
+    @Test
+    void literalMatcherRoundTripsThroughJsonWithLowercaseTypeAndNoQuoting() {
+        NameMatcher matcher = NameMatcher.literal("Zelda");
+        JsonMapper mapper = SerializationHelper.getInstance().getJsonMapper();
+        String json = mapper.writeValueAsString(matcher);
+        assertTrue(
+                json.replaceAll("\\s+", "").contains("\"type\":\"literal\""),
+                "serialized literal matcher must contain lowercase type, got: " + json);
+        assertFalse(
+                json.contains("\\Q"),
+                "serialized literal matcher must not leak \\Q quoting, got: " + json);
+        NameMatcher roundTripped = mapper.readValue(json, NameMatcher.class);
+        assertEquals(matcher, roundTripped, "NameMatcher must round-trip through JSON, got: " + json);
+    }
+
+    @Test
+    void regexMatcherRoundTripsThroughYaml() {
+        NameMatcher matcher = NameMatcher.regex("a.b");
+        YAMLMapper mapper = SerializationHelper.getInstance().getYamlMapper();
+        String yaml = mapper.writeValueAsString(matcher);
+        assertTrue(
+                yaml.contains("type: \"regex\""),
+                "serialized regex matcher must contain lowercase type, got: " + yaml);
+        NameMatcher roundTripped = mapper.readValue(yaml, NameMatcher.class);
+        assertEquals(matcher, roundTripped, "NameMatcher must round-trip through YAML, got: " + yaml);
+    }
+
+    @Test
+    void typeIsReadCaseInsensitively() {
+        JsonMapper mapper = SerializationHelper.getInstance().getJsonMapper();
+        NameMatcher upper = mapper.readValue("{\"value\":\"Zelda\",\"type\":\"LITERAL\"}", NameMatcher.class);
+        assertEquals(NameMatcher.literal("Zelda"), upper, "type must be read case-insensitively");
+    }
+}

--- a/core/src/test/java/io/github/datromtool/data/OrderPreferenceTest.java
+++ b/core/src/test/java/io/github/datromtool/data/OrderPreferenceTest.java
@@ -1,0 +1,60 @@
+package io.github.datromtool.data;
+
+import io.github.datromtool.SerializationHelper;
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.json.JsonMapper;
+import tools.jackson.dataformat.yaml.YAMLMapper;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+/**
+ * Issue #31 F5: {@link OrderPreference} serializes lowercase, matching the lowercase contract
+ * already established by {@code NameMatcher.MatchType} ({@code type: "literal"}) and
+ * {@link io.github.datromtool.io.ArchiveType} ({@code archiveType: "zip"}), while still reading
+ * either casing (existing profile files written before this fix, or hand-authored uppercase
+ * YAML, keep parsing).
+ */
+class OrderPreferenceTest {
+
+    @Test
+    void earliestSerializesLowercaseThroughJson() {
+        JsonMapper mapper = SerializationHelper.getInstance().getJsonMapper();
+        String json = mapper.writeValueAsString(OrderPreference.EARLIEST);
+        assertEquals("\"earliest\"", json, "OrderPreference.EARLIEST must serialize lowercase, got: " + json);
+    }
+
+    @Test
+    void latestSerializesLowercaseThroughJson() {
+        JsonMapper mapper = SerializationHelper.getInstance().getJsonMapper();
+        String json = mapper.writeValueAsString(OrderPreference.LATEST);
+        assertEquals("\"latest\"", json, "OrderPreference.LATEST must serialize lowercase, got: " + json);
+    }
+
+    @Test
+    void earliestSerializesLowercaseThroughYaml() {
+        YAMLMapper mapper = SerializationHelper.getInstance().getYamlMapper();
+        String yaml = mapper.writeValueAsString(OrderPreference.EARLIEST);
+        assertFalse(yaml.contains("EARLIEST"), "OrderPreference.EARLIEST must not serialize uppercase through YAML, got: " + yaml);
+        OrderPreference roundTripped = mapper.readValue(yaml, OrderPreference.class);
+        assertEquals(OrderPreference.EARLIEST, roundTripped, "OrderPreference must round-trip through YAML, got: " + yaml);
+    }
+
+    @Test
+    void lowercaseValueIsReadCorrectly() {
+        JsonMapper mapper = SerializationHelper.getInstance().getJsonMapper();
+        assertEquals(
+                OrderPreference.EARLIEST,
+                mapper.readValue("\"earliest\"", OrderPreference.class),
+                "lowercase 'earliest' must parse to OrderPreference.EARLIEST");
+    }
+
+    @Test
+    void uppercaseValueIsStillReadCaseInsensitively() {
+        JsonMapper mapper = SerializationHelper.getInstance().getJsonMapper();
+        assertEquals(
+                OrderPreference.EARLIEST,
+                mapper.readValue("\"EARLIEST\"", OrderPreference.class),
+                "uppercase 'EARLIEST' must still parse to OrderPreference.EARLIEST (case-insensitive reads)");
+    }
+}

--- a/core/src/test/java/io/github/datromtool/data/PostFilterTest.java
+++ b/core/src/test/java/io/github/datromtool/data/PostFilterTest.java
@@ -1,0 +1,64 @@
+package io.github.datromtool.data;
+
+import com.google.common.collect.ImmutableSet;
+import io.github.datromtool.SerializationHelper;
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.json.JsonMapper;
+import tools.jackson.dataformat.yaml.YAMLMapper;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Issue #15 step 1, coverage matrix row 3: {@link PostFilter#getExcludes()} carries structured
+ * {@link NameMatcher} entries and round-trips through JSON/YAML via {@link SerializationHelper}
+ * with no {@code \Q...\E} leakage for literal entries.
+ */
+class PostFilterTest {
+
+    @Test
+    void defaultExcludesIsEmpty() {
+        PostFilter postFilter = PostFilter.builder().build();
+        assertTrue(
+                postFilter.getExcludes().isEmpty(),
+                "default PostFilter.excludes must be empty, got: " + postFilter.getExcludes());
+    }
+
+    @Test
+    void excludesRoundTripThroughJsonWithNoQuoteLeakage() {
+        PostFilter postFilter = PostFilter.builder()
+                .excludes(ImmutableSet.of(NameMatcher.literal("a(b"), NameMatcher.regex("c.d")))
+                .build();
+        JsonMapper mapper = SerializationHelper.getInstance().getJsonMapper();
+        String json = mapper.writeValueAsString(postFilter);
+        assertTrue(
+                json.replaceAll("\\s+", "").contains("\"type\":\"literal\""),
+                "serialized literal exclude entry must contain lowercase type, got: " + json);
+        assertTrue(
+                json.replaceAll("\\s+", "").contains("\"type\":\"regex\""),
+                "serialized regex exclude entry must contain lowercase type, got: " + json);
+        assertFalse(
+                json.contains("\\Q"),
+                "serialized PostFilter with a literal matcher must not leak \\Q quoting, got: " + json);
+        PostFilter roundTripped = mapper.readValue(json, PostFilter.class);
+        assertEquals(
+                postFilter,
+                roundTripped,
+                "PostFilter with an excludes NameMatcher set must round-trip through JSON, got: " + json);
+    }
+
+    @Test
+    void excludesRoundTripThroughYaml() {
+        PostFilter postFilter = PostFilter.builder()
+                .excludes(ImmutableSet.of(NameMatcher.literal("a(b"), NameMatcher.regex("c.d")))
+                .build();
+        YAMLMapper mapper = SerializationHelper.getInstance().getYamlMapper();
+        String yaml = mapper.writeValueAsString(postFilter);
+        PostFilter roundTripped = mapper.readValue(yaml, PostFilter.class);
+        assertEquals(
+                postFilter,
+                roundTripped,
+                "PostFilter with an excludes NameMatcher set must round-trip through YAML, got: " + yaml);
+    }
+}

--- a/core/src/test/java/io/github/datromtool/data/SortingPreferenceTest.java
+++ b/core/src/test/java/io/github/datromtool/data/SortingPreferenceTest.java
@@ -1,5 +1,6 @@
 package io.github.datromtool.data;
 
+import com.google.common.collect.ImmutableSet;
 import io.github.datromtool.SerializationHelper;
 import org.junit.jupiter.api.Test;
 import tools.jackson.databind.json.JsonMapper;
@@ -7,6 +8,7 @@ import tools.jackson.dataformat.yaml.YAMLMapper;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Coverage matrix row 5 of issue #14 step 2: {@link SortingPreference#getVersions()},
@@ -67,5 +69,46 @@ class SortingPreferenceTest {
                 preference,
                 roundTripped,
                 "SortingPreference with EARLIEST order preferences must round-trip through YAML, got: " + yaml);
+    }
+
+    // Issue #15 step 1, coverage matrix row 3: prefers/avoids carry structured NameMatcher
+    // entries, and a literal entry must not leak \Q...\E quoting into the serialized form.
+    @Test
+    void prefersAndAvoidsRoundTripThroughJsonWithNoQuoteLeakage() {
+        SortingPreference preference = SortingPreference.builder()
+                .prefers(ImmutableSet.of(NameMatcher.literal("a(b")))
+                .avoids(ImmutableSet.of(NameMatcher.regex("c.d")))
+                .build();
+        JsonMapper mapper = SerializationHelper.getInstance().getJsonMapper();
+        String json = mapper.writeValueAsString(preference);
+        assertTrue(
+                json.replaceAll("\\s+", "").contains("\"type\":\"literal\""),
+                "serialized literal prefers entry must contain lowercase type, got: " + json);
+        assertTrue(
+                json.replaceAll("\\s+", "").contains("\"type\":\"regex\""),
+                "serialized regex avoids entry must contain lowercase type, got: " + json);
+        assertFalse(
+                json.contains("\\Q"),
+                "serialized SortingPreference with a literal matcher must not leak \\Q quoting, got: " + json);
+        SortingPreference roundTripped = mapper.readValue(json, SortingPreference.class);
+        assertEquals(
+                preference,
+                roundTripped,
+                "SortingPreference with prefers/avoids NameMatcher sets must round-trip through JSON, got: " + json);
+    }
+
+    @Test
+    void prefersAndAvoidsRoundTripThroughYaml() {
+        SortingPreference preference = SortingPreference.builder()
+                .prefers(ImmutableSet.of(NameMatcher.literal("a(b")))
+                .avoids(ImmutableSet.of(NameMatcher.regex("c.d")))
+                .build();
+        YAMLMapper mapper = SerializationHelper.getInstance().getYamlMapper();
+        String yaml = mapper.writeValueAsString(preference);
+        SortingPreference roundTripped = mapper.readValue(yaml, SortingPreference.class);
+        assertEquals(
+                preference,
+                roundTripped,
+                "SortingPreference with prefers/avoids NameMatcher sets must round-trip through YAML, got: " + yaml);
     }
 }

--- a/core/src/test/java/io/github/datromtool/sorting/AvoidsListSubComparatorTest.java
+++ b/core/src/test/java/io/github/datromtool/sorting/AvoidsListSubComparatorTest.java
@@ -1,6 +1,7 @@
 package io.github.datromtool.sorting;
 
 import com.google.common.collect.ImmutableSet;
+import io.github.datromtool.data.NameMatcher;
 import io.github.datromtool.data.ParsedGame;
 import io.github.datromtool.data.RegionData;
 import io.github.datromtool.data.SortingPreference;
@@ -8,7 +9,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
-import java.util.regex.Pattern;
 
 import static io.github.datromtool.util.TestUtils.createGame;
 import static io.github.datromtool.util.TestUtils.getRegionByCode;
@@ -44,7 +44,7 @@ class AvoidsListSubComparatorTest {
     @Test
     void testCompare_shouldAvoidIfInAvoidsList() {
         SubComparator subComparator = new AvoidsListSubComparator(SortingPreference.builder()
-                .avoids(ImmutableSet.of(Pattern.compile("(?i)game 1")))
+                .avoids(ImmutableSet.of(NameMatcher.regex("(?i)game 1")))
                 .build());
         ParsedGame tg1 = ParsedGame.builder()
                 .regionData(getRegionByCode(regionData, "USA"))

--- a/core/src/test/java/io/github/datromtool/sorting/GameComparatorTest.java
+++ b/core/src/test/java/io/github/datromtool/sorting/GameComparatorTest.java
@@ -3,6 +3,7 @@ package io.github.datromtool.sorting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import io.github.datromtool.SerializationHelper;
+import io.github.datromtool.data.NameMatcher;
 import io.github.datromtool.data.OrderPreference;
 import io.github.datromtool.data.ParsedGame;
 import io.github.datromtool.data.RegionData;
@@ -11,7 +12,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
-import java.util.regex.Pattern;
 
 import static io.github.datromtool.util.TestUtils.createGame;
 import static io.github.datromtool.util.TestUtils.getRegionByCode;
@@ -1534,7 +1534,7 @@ class GameComparatorTest {
     void testCompare_shouldAvoid_ifInAvoidsList() {
         GameComparator comparator =
                 new GameComparator(SubComparatorProvider.INSTANCE, SortingPreference.builder()
-                        .avoids(ImmutableSet.of(Pattern.compile("(?i)game 1")))
+                        .avoids(ImmutableSet.of(NameMatcher.regex("(?i)game 1")))
                         .build());
         ParsedGame tg1 = ParsedGame.builder()
                 .regionData(getRegionByCode(regionData, "USA"))
@@ -1554,7 +1554,7 @@ class GameComparatorTest {
     void testCompare_shouldPrefer_ifInPrefersList() {
         GameComparator comparator =
                 new GameComparator(SubComparatorProvider.INSTANCE, SortingPreference.builder()
-                        .prefers(ImmutableSet.of(Pattern.compile("(?i)game 2")))
+                        .prefers(ImmutableSet.of(NameMatcher.regex("(?i)game 2")))
                         .build());
         ParsedGame tg1 = ParsedGame.builder()
                 .regionData(getRegionByCode(regionData, "USA"))

--- a/core/src/test/java/io/github/datromtool/sorting/PrefersListSubComparatorTest.java
+++ b/core/src/test/java/io/github/datromtool/sorting/PrefersListSubComparatorTest.java
@@ -1,6 +1,7 @@
 package io.github.datromtool.sorting;
 
 import com.google.common.collect.ImmutableSet;
+import io.github.datromtool.data.NameMatcher;
 import io.github.datromtool.data.ParsedGame;
 import io.github.datromtool.data.RegionData;
 import io.github.datromtool.data.SortingPreference;
@@ -8,7 +9,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
-import java.util.regex.Pattern;
 
 import static io.github.datromtool.util.TestUtils.createGame;
 import static io.github.datromtool.util.TestUtils.getRegionByCode;
@@ -44,7 +44,7 @@ class PrefersListSubComparatorTest {
     @Test
     void testCompare_shouldPreferIfInPrefersList() {
         SubComparator subComparator = new PrefersListSubComparator(SortingPreference.builder()
-                .prefers(ImmutableSet.of(Pattern.compile("(?i)game 2")))
+                .prefers(ImmutableSet.of(NameMatcher.regex("(?i)game 2")))
                 .build());
         ParsedGame tg1 = ParsedGame.builder()
                 .regionData(getRegionByCode(regionData, "USA"))

--- a/logging/pom.xml
+++ b/logging/pom.xml
@@ -19,6 +19,11 @@
             <artifactId>log4j-over-slf4j</artifactId>
             <scope>runtime</scope>
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 

--- a/logging/src/main/resources/io/github/datromtool/logging/defaults.xml
+++ b/logging/src/main/resources/io/github/datromtool/logging/defaults.xml
@@ -5,8 +5,8 @@ Default logback configuration provided for import
 -->
 
 <included>
-    <conversionRule conversionWord="clr" converterClass="io.github.datromtool.logging.ColorConverter" />
-    <conversionRule conversionWord="wEx" converterClass="io.github.datromtool.logging.ExtendedWhitespaceThrowableProxyConverter" />
+    <conversionRule conversionWord="clr" class="io.github.datromtool.logging.ColorConverter" />
+    <conversionRule conversionWord="wEx" class="io.github.datromtool.logging.ExtendedWhitespaceThrowableProxyConverter" />
     <property name="CONSOLE_LOG_PATTERN" value="${CONSOLE_LOG_PATTERN:-%clr(%d{${LOG_DATEFORMAT_PATTERN:-yyyy-MM-dd HH:mm:ss.SSS}}){faint} %clr(${LOG_LEVEL_PATTERN:-%5p}) %clr(${PID:- }){magenta} %clr(---){faint} %clr([%15.15t]){faint} %clr(%-40.40logger{39}){cyan} %clr(:){faint} %m%n${LOG_EXCEPTION_CONVERSION_WORD:-%wEx}}"/>
     <property name="FILE_LOG_PATTERN" value="${FILE_LOG_PATTERN:-%d{${LOG_DATEFORMAT_PATTERN:-yyyy-MM-dd HH:mm:ss.SSS}} ${LOG_LEVEL_PATTERN:-%5p} ${PID:- } --- [%t] %-40.40logger{39} : %m%n${LOG_EXCEPTION_CONVERSION_WORD:-%wEx}}"/>
 </included>

--- a/logging/src/test/java/io/github/datromtool/logging/LogbackDefaultsStatusTest.java
+++ b/logging/src/test/java/io/github/datromtool/logging/LogbackDefaultsStatusTest.java
@@ -1,0 +1,56 @@
+package io.github.datromtool.logging;
+
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.joran.JoranConfigurator;
+import ch.qos.logback.core.status.Status;
+import ch.qos.logback.core.status.StatusManager;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Issue #30: a deprecated {@code converterClass} attribute on a {@code <conversionRule>} makes
+ * logback emit WARN statuses at bootstrap; with no status listener registered, logback then
+ * auto-dumps its entire status history to {@link System#out}, corrupting any command whose
+ * output is redirected (e.g. {@code 1g1r --dump-profile > file}). Booting the packaged
+ * {@code defaults.xml} into a fresh, isolated {@link LoggerContext} must produce zero
+ * WARN-or-above statuses.
+ */
+class LogbackDefaultsStatusTest {
+
+    // A minimal wrapper reproducing exactly how cli/src/main/resources/logback.xml consumes this
+    // file in production: a real classpath <include>, not a hand-parsed fragment.
+    private static final String WRAPPER_CONFIG =
+            "<configuration>"
+                    + "<include resource=\"io/github/datromtool/logging/defaults.xml\"/>"
+                    + "<root level=\"INFO\"/>"
+                    + "</configuration>";
+
+    @Test
+    void bootingPackagedDefaultsProducesNoWarnOrAboveStatus() throws Exception {
+        LoggerContext context = new LoggerContext();
+        JoranConfigurator configurator = new JoranConfigurator();
+        configurator.setContext(context);
+        try (InputStream input = new ByteArrayInputStream(WRAPPER_CONFIG.getBytes(StandardCharsets.UTF_8))) {
+            configurator.doConfigure(input);
+        }
+
+        StatusManager statusManager = context.getStatusManager();
+        List<Status> offending = statusManager.getCopyOfStatusList().stream()
+                .filter(status -> status.getLevel() >= Status.WARN)
+                .toList();
+
+        assertTrue(
+                offending.isEmpty(),
+                "booting defaults.xml must produce zero WARN/ERROR statuses (any WARN/ERROR status "
+                        + "makes logback auto-dump its entire status history to stdout with no listener "
+                        + "registered, corrupting redirected output such as --dump-profile > file), got:\n"
+                        + offending.stream().map(Status::toString).collect(Collectors.joining("\n")));
+    }
+}


### PR DESCRIPTION
Fixes #15
Fixes #23

## What

Five commits, three gated steps plus one gate-driven correction:

**1. `NameMatcher` entries (`7ea6e43`).** `Filter.excludes/includes`, `PostFilter.excludes`, `SortingPreference.prefers/avoids` migrate from `ImmutableSet<Pattern>` to structured `NameMatcher {value, type: literal|regex}` — profiles express matches without `\Q…\E` quoted-pattern leakage. Behavior-preserving: literal compilation replicates the old `Pattern.quote` path exactly; the verifier mutation-tested the literal/regex kind mapping (file-sourced kinds are pinned by 5 tests) and confirmed picocli's built-in Pattern converter uses no flags, so the regex re-compile is lossless.

**2. `Profile` aggregate (`b75780c`, `dac3fda`).** Core `Profile` composes the existing stage objects (`input`, `filter`, `sort`, `postFilter`, `output`, `performance` = `AppConfig`), all sections optional, `@JsonInclude(NON_DEFAULT)`. JSON and YAML both load (existing extension dispatch); multiple files layer via JsonNode deep-merge — objects merge recursively, scalars and arrays replace wholesale (the documented rule, associativity-tested). Rider: `PathJacksonModule` — jackson-databind 3.2.1 serializes `Path` through `toUri()`, absolutizing relative paths and breaking profile portability; paths now serialize as plain strings. The verifier audited every existing Path-bearing type and confirmed no pre-existing persisted surface ever round-tripped a Path, so the module is purely additive.

**3. CLI wiring (`1875262`).** `--profile <file>` (repeatable, layered) and `--dump-profile [json|yaml]` (prints the effective merged config and exits without running; `DAT_FILE` arity relaxed to `0..*` with the original requiredness message preserved for normal runs). Precedence: defaults < `~/.DATROMTool/config.yaml` (performance base, unchanged behavior) < profile file(s) < explicit flags. Wiring is field-overlay keyed on `ParseResult.hasMatchedOption` — the issue-suggested `IDefaultValueProvider` was probed and rejected with executed evidence: it feeds one string per option, and the multi-value pattern options declare no split regex (joining regex values on a delimiter is unsafe). `--dump-profile` output reloads to an identical effective config (round-trip test + jar-level probe).

**4. Correction (`d315da3`).** The step-3 verifier caught a precedence inversion with executed proof: `--copy-raw-zip=false` lost to a profile's `allowRawZipCopy=true` because the copier merge keyed on the primitive field value. `allowRawZipCopy` is now tri-state `Boolean` — which also fixes #23's pre-existing case (persisted `allowRawZipCopy: true` no longer silently reset by `--copy-threads`). Both paths have red→green proofs.

## Known limitation (deliberate)

`profile.input.dats` round-trips through `--dump-profile` but does not yet feed execution — DAT files remain positional arguments at run time. Wiring profile-sourced DATs into execution is deferred to the #19 input-sources work, where the input section grows clonelist/metadata sources anyway.

## Process evidence

Per-step independent verifier gates (canonical gates re-run, red proofs re-executed via `verify-red-proof.sh` or scratch-worktree equivalent, mutation testing: quote-drop, kind-swap, merge-rule flip, overlay-direction break — all caught). Step 3's gate FAILED on the precedence inversion; the correction round carries two executed red→green proofs (frozen hashes `aa5be2fc`, `39532efa`). Full reactor after correction: green (core 413+, cli 141).

🤖 Generated by [Claude Code](https://claude.com/claude-code), posted via @andrebrait's account on their behalf.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added reusable JSON/YAML profiles for CLI settings.
  * Added layered profile loading, with command-line options taking precedence.
  * Added `--dump-profile` with YAML (default) and JSON output.
  * Added support for literal and regular-expression matchers in filters and sorting preferences.
  * Preserved relative paths when profiles are saved and loaded.

* **Bug Fixes**
  * Prevented unrelated performance options from resetting raw ZIP copy settings.
  * Improved validation and error messages for invalid or missing profile files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->