### PR TITLE
cli: add "scan" subcommand for standalone hash reports

### DIFF
--- a/cli/src/main/java/io/github/datromtool/cli/DatRomCommand.java
+++ b/cli/src/main/java/io/github/datromtool/cli/DatRomCommand.java
@@ -5,6 +5,7 @@ import io.github.datromtool.cli.argument.DatafileArgument;
 import io.github.datromtool.cli.argument.PatternsFileArgument;
 import io.github.datromtool.cli.command.DatCommand;
 import io.github.datromtool.cli.command.OneGameOneRomCommand;
+import io.github.datromtool.cli.command.ScanCommand;
 import io.github.datromtool.cli.converter.*;
 import io.github.datromtool.config.CopyBufferSize;
 import io.github.datromtool.config.CopyThreads;
@@ -25,7 +26,7 @@ import picocli.CommandLine;
         versionProvider = GitVersionProvider.class,
         mixinStandardHelpOptions = true,
         showEndOfOptionsDelimiterInUsageHelp = true,
-        subcommands = {OneGameOneRomCommand.class, DatCommand.class})
+        subcommands = {OneGameOneRomCommand.class, DatCommand.class, ScanCommand.class})
 public final class DatRomCommand {
 
     @SuppressWarnings("InstantiationOfUtilityClass")

--- a/cli/src/main/java/io/github/datromtool/cli/command/ScanCommand.java
+++ b/cli/src/main/java/io/github/datromtool/cli/command/ScanCommand.java
@@ -149,11 +149,16 @@ public final class ScanCommand implements Callable<Integer> {
                 : baseAppConfig.getScanner();
     }
 
+    // Pinned by ScanCommandTest: jline writes at file-descriptor level, so a behavioral
+    // stdout-capture test cannot catch a regression of this choice — the constant is the
+    // testable surface.
+    static final TerminalBuilder.SystemOutput PROGRESS_OUTPUT = TerminalBuilder.SystemOutput.ForcedSysErr;
+
     @Nullable
     private Terminal createTerminal() {
         try {
             return TerminalBuilder.builder()
-                    .systemOutput(TerminalBuilder.SystemOutput.ForcedSysErr)
+                    .systemOutput(PROGRESS_OUTPUT)
                     .build();
         } catch (IOException e) {
             log.error("Error while creating terminal", e);

--- a/cli/src/main/java/io/github/datromtool/cli/command/ScanCommand.java
+++ b/cli/src/main/java/io/github/datromtool/cli/command/ScanCommand.java
@@ -1,0 +1,163 @@
+package io.github.datromtool.cli.command;
+
+import com.google.common.collect.ImmutableList;
+import io.github.datromtool.SerializationHelper;
+import io.github.datromtool.cli.GitVersionProvider;
+import io.github.datromtool.cli.converter.ExistingDirectoryConverter;
+import io.github.datromtool.cli.converter.OutputModeConverter;
+import io.github.datromtool.cli.option.PerformanceOptions;
+import io.github.datromtool.cli.progressbar.CommandLineProgressBar;
+import io.github.datromtool.config.AppConfig;
+import io.github.datromtool.data.OutputMode;
+import io.github.datromtool.io.FileScanner;
+import io.github.datromtool.io.logging.FileScannerLoggingListener;
+import lombok.extern.slf4j.Slf4j;
+import org.jline.terminal.Terminal;
+import org.jline.terminal.TerminalBuilder;
+import picocli.CommandLine;
+import tools.jackson.core.JacksonException;
+
+import javax.annotation.Nullable;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Callable;
+
+import static java.lang.String.format;
+
+/**
+ * Issue #17: expose {@link FileScanner} standalone, without a DAT and without the 1G1R
+ * filter/sort/copy pipeline. The report schema is exactly {@link FileScanner.Result} (via
+ * {@link SerializationHelper}'s existing XML/JSON/YAML writers) — no bespoke report DTO lives
+ * here, since {@link FileScanner.Result} already serializes cleanly with every mapper (probed
+ * empirically: {@code archiveType}/{@code path}/{@code digest} round-trip on all three formats
+ * with no core annotations added). The scan results are copied into a plain {@link ArrayList}
+ * before serialization (not the {@link ImmutableList} {@link FileScanner#scan} returns) purely
+ * for a stable XML root tag: Jackson's {@code XmlMapper} derives the root element name from the
+ * concrete class when a bare {@code Object} is handed to {@code writeValueAsString}, and Guava's
+ * {@code ImmutableList} concrete type is the package-private {@code RegularImmutableList} —
+ * valid but leaky. {@code ArrayList} yields {@code <ArrayList>}, which is stable across Guava
+ * versions.
+ *
+ * <p>No DAT is loaded, so {@link FileScanner} is constructed with empty datafile/detector
+ * collections — its constructor already treats an empty datafile collection as "no header
+ * detection" ({@link FileScanner#FileScanner} falls back to
+ * {@code FileScannerParameters.withDefaults()} whenever {@code datafiles.isEmpty()}), which is
+ * exactly the "no DAT" case this command needs.
+ *
+ * <p>The progress bar is wired exactly like {@link OneGameOneRomCommand}, except the backing
+ * {@link Terminal} is always built with
+ * {@link TerminalBuilder.SystemOutput#ForcedSysErr}. Probed empirically: a jline
+ * {@link Terminal}'s {@code writer()} otherwise writes ANSI progress straight to stdout (even
+ * under a non-interactive/dumb terminal), which would corrupt a report written to stdout.
+ * Forcing stderr unconditionally (rather than only when {@code --out-file} is absent) is simpler
+ * than threading that condition through the listener wiring and is strictly safer: it also keeps
+ * progress out of a piped stdout even when {@code --out-file} is set.
+ */
+@Slf4j
+@CommandLine.Command(
+        name = "scan",
+        description = "Scan directories/archives and produce a standalone hash report "
+                + "(no DAT, no 1G1R pipeline)",
+        sortOptions = false,
+        abbreviateSynopsis = true,
+        versionProvider = GitVersionProvider.class,
+        mixinStandardHelpOptions = true)
+public final class ScanCommand implements Callable<Integer> {
+
+    @CommandLine.Spec
+    private CommandLine.Model.CommandSpec commandSpec;
+
+    @CommandLine.Parameters(
+            description = "Directories to scan for ROMs/archives",
+            arity = "1..*",
+            paramLabel = "DIR",
+            converter = ExistingDirectoryConverter.class)
+    private List<Path> dirs;
+
+    @CommandLine.Option(
+            names = "--out-mode",
+            paramLabel = "MODE",
+            converter = OutputModeConverter.class,
+            completionCandidates = OutputModeConverter.class,
+            description = "Report format. Options: ${COMPLETION-CANDIDATES} (default: yaml, for "
+                    + "readable stdout output)")
+    private OutputMode outMode = OutputMode.YAML;
+
+    @CommandLine.Option(
+            names = "--out-file",
+            paramLabel = "PATH",
+            description = "Write the report to this file (default: print to stdout)")
+    private Path outFile;
+
+    @CommandLine.ArgGroup(heading = "Performance options\n", exclusive = false)
+    private PerformanceOptions performanceOptions;
+
+    @Override
+    public Integer call() {
+        AppConfig.FileScannerConfig scannerConfig = resolveScannerConfig();
+        FileScannerLoggingListener loggingListener = new FileScannerLoggingListener();
+        ImmutableList<FileScanner.Result> scanResults = ImmutableList.of();
+        try (Terminal terminal = createTerminal()) {
+            List<FileScanner.Listener> listeners = ImmutableList.of(
+                    loggingListener,
+                    new CommandLineProgressBar(terminal, "Scanning", "Scanning input directories..."));
+            FileScanner fileScanner = new FileScanner(
+                    scannerConfig,
+                    ImmutableList.of(),
+                    ImmutableList.of(),
+                    listeners);
+            scanResults = fileScanner.scan(dirs);
+        } catch (IOException e) {
+            log.error("Error while closing the terminal", e);
+        }
+
+        List<FileScanner.Result> report = new ArrayList<>(scanResults);
+        List<String> lines;
+        try {
+            lines = switch (outMode) {
+                case XML -> SerializationHelper.getInstance().writeAsXml(report);
+                case JSON -> SerializationHelper.getInstance().writeAsJson(report);
+                case YAML -> SerializationHelper.getInstance().writeAsYaml(report);
+            };
+        } catch (JacksonException e) {
+            throw new CommandLine.ParameterException(
+                    commandSpec.commandLine(),
+                    format("Could not write scan report as %s: %s", outMode, e.getMessage()));
+        }
+
+        if (outFile != null) {
+            try {
+                Files.write(outFile, lines);
+            } catch (IOException e) {
+                throw new CommandLine.ParameterException(
+                        commandSpec.commandLine(),
+                        format("Could not write output file '%s': %s", outFile, e.getMessage()));
+            }
+        } else {
+            lines.forEach(System.out::println);
+        }
+        return loggingListener.isErrors() ? 1 : 0;
+    }
+
+    AppConfig.FileScannerConfig resolveScannerConfig() {
+        AppConfig baseAppConfig = SerializationHelper.getInstance().loadAppConfig();
+        return performanceOptions != null
+                ? performanceOptions.merge(baseAppConfig.getScanner())
+                : baseAppConfig.getScanner();
+    }
+
+    @Nullable
+    private Terminal createTerminal() {
+        try {
+            return TerminalBuilder.builder()
+                    .systemOutput(TerminalBuilder.SystemOutput.ForcedSysErr)
+                    .build();
+        } catch (IOException e) {
+            log.error("Error while creating terminal", e);
+            return null;
+        }
+    }
+}

--- a/cli/src/main/java/io/github/datromtool/cli/progressbar/CommandLineProgressBar.java
+++ b/cli/src/main/java/io/github/datromtool/cli/progressbar/CommandLineProgressBar.java
@@ -100,6 +100,12 @@ public final class CommandLineProgressBar implements FileScanner.Listener, FileC
     }
 
     private synchronized void printMainBar(int curr) {
+        if (totalItems <= 0) {
+            // Nothing to divide curr/totalItems by (e.g. a scan of an empty directory) and
+            // nothing meaningful to draw either: skip the bar entirely instead of a
+            // division-by-zero.
+            return;
+        }
         int size = Math.max(0, availableColumns(mainBarPrint, terminal));
         int x = size * curr / totalItems;
         int lineDiff = numThreads + 1;
@@ -237,7 +243,9 @@ public final class CommandLineProgressBar implements FileScanner.Listener, FileC
     @Override
     public void reportTotalItems(int totalItems) {
         this.totalItems = totalItems;
-        int totalItemsLength = (int) Math.floor(Math.log10(totalItems)) + 1;
+        // Math.log10(0) is -Infinity: guard so an empty scan doesn't build a garbage (negative)
+        // field width for mainBarPrint, even though printMainBar() itself now skips drawing it.
+        int totalItemsLength = totalItems > 0 ? (int) Math.floor(Math.log10(totalItems)) + 1 : 1;
         this.mainBarPrint = action + " [%s%s%s] %" + totalItemsLength + "d/" + totalItems;
         printMainBar(0);
     }
@@ -273,7 +281,13 @@ public final class CommandLineProgressBar implements FileScanner.Listener, FileC
     @Override
     public synchronized void reportAllFinished() {
         for (int i = 1; i <= numThreads; i++) {
-            printThread(i, "FINISHED", "", 100, getFinalAverage(i, threadLineData[i - 1]));
+            // Threads that never got a reportStart() (fewer files than configured threads)
+            // leave a null slot: skip them instead of NPE'ing on lineData.getEndInstant().
+            LineData lineData = threadLineData[i - 1];
+            if (lineData == null) {
+                continue;
+            }
+            printThread(i, "FINISHED", "", 100, getFinalAverage(i, lineData));
         }
         printMainBar(totalItems);
         writer.print(ansi()

--- a/cli/src/test/java/io/github/datromtool/cli/command/ScanCommandTest.java
+++ b/cli/src/test/java/io/github/datromtool/cli/command/ScanCommandTest.java
@@ -204,4 +204,14 @@ class ScanCommandTest {
         }
         assertEquals(2, exitCode, "missing DIR parameter must exit with code 2, stderr was:\n" + capturedErr);
     }
+    @Test
+    void progressOutputStaysPinnedToStderr() {
+        // jline writes progress at file-descriptor level, bypassing System.setOut capture,
+        // so no behavioral test can catch a regression of this choice; the end-to-end
+        // property is jar-probe-verified. This pin fails if anyone flips the mode.
+        assertEquals(
+                org.jline.terminal.TerminalBuilder.SystemOutput.ForcedSysErr,
+                ScanCommand.PROGRESS_OUTPUT,
+                "scan progress must go to stderr so stdout stays machine-readable");
+    }
 }

--- a/cli/src/test/java/io/github/datromtool/cli/command/ScanCommandTest.java
+++ b/cli/src/test/java/io/github/datromtool/cli/command/ScanCommandTest.java
@@ -1,0 +1,178 @@
+package io.github.datromtool.cli.command;
+
+import io.github.datromtool.config.AppConfig;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import picocli.CommandLine;
+import tools.jackson.databind.json.JsonMapper;
+import tools.jackson.databind.node.ArrayNode;
+import tools.jackson.dataformat.xml.XmlMapper;
+import tools.jackson.dataformat.yaml.YAMLMapper;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Coverage matrix for issue #17's {@code scan} subcommand.
+ *
+ * <p>Fixture: {@code test-data/data/scan-test-files/0016384} (a small dir already used by
+ * {@code core}'s {@code FileScannerTest}, with known hashes in {@code test-data/data/CRC32SUMS}/
+ * {@code SHA1SUMS}), kept lean here to a couple of known hashes rather than the full fixture set.
+ */
+class ScanCommandTest {
+
+    private static final Path FIXTURE_DIR =
+            Paths.get("../test-data/data/scan-test-files/0016384").toAbsolutePath().normalize();
+
+    // The plain (non-archived, non-headered) 16384-byte fixture file's known digest.
+    private static final String KNOWN_CRC = "4291626c";
+    private static final String KNOWN_MD5 = "25fb98425aea8268ba4e26c00eef4a00";
+    private static final String KNOWN_SHA1 = "c502ca2c1cd3e7301028fe4f29ac51101c3866e7";
+
+    private static int run(ScanCommand command, String... args) {
+        CommandLine commandLine = new CommandLine(command);
+        commandLine.parseArgs(args);
+        return command.call();
+    }
+
+    private static String captureStdout(Runnable action) {
+        ByteArrayOutputStream captured = new ByteArrayOutputStream();
+        PrintStream original = System.out;
+        System.setOut(new PrintStream(captured));
+        try {
+            action.run();
+        } finally {
+            System.setOut(original);
+        }
+        return captured.toString();
+    }
+
+    // Row 1: scanning a fixture dir yields the known entries/hashes (default out-mode: yaml).
+    @Test
+    void scanningFixtureDirYieldsKnownHashes() {
+        assertTrue(Files.isDirectory(FIXTURE_DIR), "fixture dir must exist: " + FIXTURE_DIR);
+        String stdout = captureStdout(() ->
+                assertEquals(0, run(new ScanCommand(), FIXTURE_DIR.toString()), "scan must exit 0"));
+        assertTrue(stdout.contains(KNOWN_CRC), "report must contain the known CRC, got:\n" + stdout);
+        assertTrue(stdout.contains(KNOWN_MD5), "report must contain the known MD5, got:\n" + stdout);
+        assertTrue(stdout.contains(KNOWN_SHA1), "report must contain the known SHA1, got:\n" + stdout);
+        assertTrue(stdout.contains("16384"), "report must contain the known size, got:\n" + stdout);
+    }
+
+    // Row 2(a): --out-mode json produces parseable JSON.
+    @Test
+    void outModeJsonProducesParseableJson() {
+        String stdout = captureStdout(() -> assertEquals(
+                0,
+                run(new ScanCommand(), FIXTURE_DIR.toString(), "--out-mode", "json"),
+                "scan --out-mode json must exit 0"));
+        ArrayNode node = (ArrayNode) new JsonMapper().readTree(stdout);
+        assertFalse(node.isEmpty(), "parsed JSON report must contain entries");
+        assertTrue(stdout.contains(KNOWN_CRC), "JSON report must contain the known CRC");
+    }
+
+    // Row 2(b): --out-mode yaml (also the default) produces parseable YAML.
+    @Test
+    void outModeYamlProducesParseableYaml() {
+        String stdout = captureStdout(() -> assertEquals(
+                0,
+                run(new ScanCommand(), FIXTURE_DIR.toString(), "--out-mode", "yaml"),
+                "scan --out-mode yaml must exit 0"));
+        ArrayNode node = (ArrayNode) new YAMLMapper().readTree(stdout);
+        assertFalse(node.isEmpty(), "parsed YAML report must contain entries");
+    }
+
+    // Row 2(c): --out-mode xml produces parseable XML.
+    @Test
+    void outModeXmlProducesParseableXml() {
+        String stdout = captureStdout(() -> assertEquals(
+                0,
+                run(new ScanCommand(), FIXTURE_DIR.toString(), "--out-mode", "xml"),
+                "scan --out-mode xml must exit 0"));
+        // A successful parse (no exception) is the assertion: a bare XmlMapper.readTree() on a
+        // non-well-formed document throws.
+        var node = new XmlMapper().readTree(stdout);
+        assertTrue(node.has("item"), "parsed XML report must contain <item> entries, got:\n" + stdout);
+    }
+
+    // Row 2(d): --out-file writes a parseable file instead of stdout.
+    @Test
+    void outFileWritesParseableFile(@TempDir Path tempDir) throws IOException {
+        Path outFile = tempDir.resolve("report.json");
+        String stdout = captureStdout(() -> assertEquals(
+                0,
+                run(new ScanCommand(),
+                        FIXTURE_DIR.toString(), "--out-mode", "json", "--out-file", outFile.toString()),
+                "scan --out-file must exit 0"));
+        assertEquals("", stdout, "stdout must be empty when --out-file is set, got:\n" + stdout);
+        String fileContent = Files.readString(outFile);
+        ArrayNode node = (ArrayNode) new JsonMapper().readTree(fileContent);
+        assertFalse(node.isEmpty(), "output file must contain a parseable, non-empty JSON report");
+        assertTrue(fileContent.contains(KNOWN_CRC), "output file must contain the known CRC");
+    }
+
+    // Row 3: a nonexistent dir fails at parse time (ExistingDirectoryConverter).
+    @Test
+    void nonexistentDirFailsAtParseTime() {
+        ScanCommand command = new ScanCommand();
+        CommandLine commandLine = new CommandLine(command);
+        CommandLine.ParameterException ex = assertThrows(
+                CommandLine.ParameterException.class,
+                () -> commandLine.parseArgs("/no/such/directory"),
+                "a nonexistent dir must fail parsing");
+        assertTrue(ex.getMessage().contains("/no/such/directory"),
+                "error must name the offending path, got: " + ex.getMessage());
+    }
+
+    // Row 4: PerformanceOptions scanner knobs parse and reach the effective FileScannerConfig.
+    @Test
+    void scanThreadsOptionReachesTheFileScannerConfig() {
+        ScanCommand command = new ScanCommand();
+        CommandLine commandLine = new CommandLine(command);
+        commandLine.parseArgs("--scan-threads", "3", "--scan-buffer", "64KB", FIXTURE_DIR.toString());
+        AppConfig.FileScannerConfig config = command.resolveScannerConfig();
+        assertEquals(3, config.getThreads().value(),
+                "--scan-threads 3 must reach the effective FileScannerConfig");
+        assertEquals(64 * 1024, config.getDefaultBufferSize().bytes(),
+                "--scan-buffer 64KB must reach the effective FileScannerConfig");
+    }
+
+    // Row 5: the stdout report is not polluted by progress bar/log output (jline is forced to
+    // stderr; logback's cli config only ever writes to a file, never to the console).
+    @Test
+    void stdoutReportIsNotPollutedByProgressOrLogOutput() {
+        String stdout = captureStdout(() ->
+                assertEquals(0, run(new ScanCommand(), FIXTURE_DIR.toString()), "scan must exit 0"));
+        assertFalse(stdout.contains("\u001B"), "stdout must not contain ANSI escape sequences, got:\n" + stdout);
+        assertFalse(stdout.contains("Scanning input directories"),
+                "stdout must not contain progress bar text, got:\n" + stdout);
+        // The whole captured stream must itself parse as a single YAML document (default
+        // out-mode): any interleaved noise line would break the parse.
+        ArrayNode node = (ArrayNode) new YAMLMapper().readTree(stdout);
+        assertFalse(node.isEmpty(), "stdout must parse cleanly as the YAML report alone");
+    }
+
+    // Row 6: no dirs at all is a missing-parameter error, exit 2.
+    @Test
+    void noDirsFailsWithMissingParameterExitCode2() {
+        ByteArrayOutputStream capturedErr = new ByteArrayOutputStream();
+        PrintStream originalErr = System.err;
+        System.setErr(new PrintStream(capturedErr));
+        int exitCode;
+        try {
+            exitCode = new CommandLine(new ScanCommand()).execute();
+        } finally {
+            System.setErr(originalErr);
+        }
+        assertEquals(2, exitCode, "missing DIR parameter must exit with code 2, stderr was:\n" + capturedErr);
+    }
+}

--- a/cli/src/test/java/io/github/datromtool/cli/command/ScanCommandTest.java
+++ b/cli/src/test/java/io/github/datromtool/cli/command/ScanCommandTest.java
@@ -161,6 +161,35 @@ class ScanCommandTest {
         assertFalse(node.isEmpty(), "stdout must parse cleanly as the YAML report alone");
     }
 
+    // Row 7: an empty directory scan must not crash. Previously
+    // CommandLineProgressBar.printMainBar divided by totalItems == 0 (ArithmeticException) once
+    // FileScanner.reportTotalItems(0) fired for a dir with nothing to scan.
+    @Test
+    void emptyDirectoryScanProducesEmptyReport(@TempDir Path emptyDir) {
+        String stdout = captureStdout(() -> assertEquals(
+                0,
+                run(new ScanCommand(), emptyDir.toString(), "--out-mode", "json"),
+                "scan of an empty dir must exit 0"));
+        ArrayNode node = (ArrayNode) new JsonMapper().readTree(stdout);
+        assertTrue(node.isEmpty(), "report for an empty dir must be an empty JSON array, got:\n" + stdout);
+    }
+
+    // Row 8: fewer files than configured scan threads must not crash. Previously
+    // CommandLineProgressBar.reportAllFinished/getFinalAverage NPE'd indexing threadLineData
+    // slots for threads that never received reportStart.
+    @Test
+    void scanningFewerFilesThanThreadsSucceeds(@TempDir Path tempDir) throws IOException {
+        Files.writeString(tempDir.resolve("a.bin"), "aa");
+        Files.writeString(tempDir.resolve("b.bin"), "bb");
+        String stdout = captureStdout(() -> assertEquals(
+                0,
+                run(new ScanCommand(),
+                        tempDir.toString(), "--out-mode", "json", "--scan-threads", "4"),
+                "scan with more threads than files must exit 0"));
+        ArrayNode node = (ArrayNode) new JsonMapper().readTree(stdout);
+        assertEquals(2, node.size(), "report must contain both scanned files, got:\n" + stdout);
+    }
+
     // Row 6: no dirs at all is a missing-parameter error, exit 2.
     @Test
     void noDirsFailsWithMissingParameterExitCode2() {

--- a/cli/src/test/java/io/github/datromtool/cli/command/ScanMigrationTest.java
+++ b/cli/src/test/java/io/github/datromtool/cli/command/ScanMigrationTest.java
@@ -1,0 +1,67 @@
+package io.github.datromtool.cli.command;
+
+import io.github.datromtool.ByteSize;
+import io.github.datromtool.cli.DatRomCommand;
+import io.github.datromtool.cli.argument.DatafileArgument;
+import io.github.datromtool.cli.argument.PatternsFileArgument;
+import io.github.datromtool.cli.converter.ArchiveTypeConverter;
+import io.github.datromtool.cli.converter.ByteSizeConverter;
+import io.github.datromtool.cli.converter.CopyBufferSizeConverter;
+import io.github.datromtool.cli.converter.CopyThreadsConverter;
+import io.github.datromtool.cli.converter.DatafileConverter;
+import io.github.datromtool.cli.converter.GameCategoryConverter;
+import io.github.datromtool.cli.converter.OrderPreferenceConverter;
+import io.github.datromtool.cli.converter.OutputModeConverter;
+import io.github.datromtool.cli.converter.PatternsFileConverter;
+import io.github.datromtool.cli.converter.ScanBufferSizeConverter;
+import io.github.datromtool.cli.converter.ScanMaxBufferSizeConverter;
+import io.github.datromtool.cli.converter.ScanThreadsConverter;
+import io.github.datromtool.config.CopyBufferSize;
+import io.github.datromtool.config.CopyThreads;
+import io.github.datromtool.config.ScanBufferSize;
+import io.github.datromtool.config.ScanMaxBufferSize;
+import io.github.datromtool.config.ScanThreads;
+import io.github.datromtool.data.GameCategory;
+import io.github.datromtool.data.OrderPreference;
+import io.github.datromtool.data.OutputMode;
+import io.github.datromtool.io.ArchiveType;
+import org.junit.jupiter.api.Test;
+import picocli.CommandLine;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+/**
+ * Red-first surface-change proof for issue #17: {@code scan} is a brand-new subcommand
+ * ({@link ScanCommand}) registered on the real {@link DatRomCommand} tree, wired with the exact
+ * converters {@link DatRomCommand#main} registers.
+ *
+ * <p>Executed RED before the migration ({@code scan} was an unknown subcommand, rejected with
+ * {@link CommandLine.UnmatchedArgumentException}); frozen byte-identical and re-run GREEN,
+ * unchanged, after the migration.
+ */
+class ScanMigrationTest {
+
+    private static CommandLine newDatRomCommandLine() {
+        CommandLine cmd = new CommandLine(new DatRomCommand());
+        cmd.registerConverter(ArchiveType.class, new ArchiveTypeConverter());
+        cmd.registerConverter(GameCategory.class, new GameCategoryConverter());
+        cmd.registerConverter(OrderPreference.class, new OrderPreferenceConverter());
+        cmd.registerConverter(OutputMode.class, new OutputModeConverter());
+        cmd.registerConverter(PatternsFileArgument.class, new PatternsFileConverter());
+        cmd.registerConverter(DatafileArgument.class, new DatafileConverter());
+        cmd.registerConverter(ByteSize.class, new ByteSizeConverter());
+        cmd.registerConverter(ScanThreads.class, new ScanThreadsConverter());
+        cmd.registerConverter(CopyThreads.class, new CopyThreadsConverter());
+        cmd.registerConverter(ScanBufferSize.class, new ScanBufferSizeConverter());
+        cmd.registerConverter(ScanMaxBufferSize.class, new ScanMaxBufferSizeConverter());
+        cmd.registerConverter(CopyBufferSize.class, new CopyBufferSizeConverter());
+        return cmd;
+    }
+
+    @Test
+    void scanIsAcceptedByTheDatromCommandTree() {
+        assertDoesNotThrow(
+                () -> newDatRomCommandLine().parseArgs("scan", "."),
+                "'scan <dir>' must be a known subcommand on the datrom command tree");
+    }
+}


### PR DESCRIPTION
Fixes #17

## What

`datrom scan <dirs...> [--out-mode xml|json|yaml] [--out-file <path>] [scan performance options]` — exposes `FileScanner` standalone: hash/inventory report over directories and archives, no DAT required (empty datafiles/detectors fall back to `FileScannerParameters.withDefaults()`, i.e. no header detection). The report serializes the core scan results directly — no bespoke DTO; results are copied to a plain list only to keep the XML root tag sane (`<ArrayList>`, not Guava's package-private type).

stdout stays machine-readable: the jline terminal is built with `SystemOutput.ForcedSysErr`, so progress bars go to stderr unconditionally (jar-probed: 0 ANSI escapes on stdout, progress frames on stderr, output parses as JSON/YAML/XML). Exits 1 when any file failed to scan, 0 otherwise — deliberate divergence from `1g1r`'s always-0 (a report tool should signal partial failure).

## Evidence

- Red→green surface proof: `ScanMigrationTest` RED on master (`Unmatched arguments... 'scan'`), GREEN after; re-executed by the verifier gate via `verify-red-proof.sh`.
- Known-hash fixture test verified non-circular by the gate: expected CRC/MD5/SHA1 match `test-data`'s checksum manifests and an independent `shasum` run.
- Gate mutation (JSON branch writing YAML) fails 2 tests; stdout-cleanliness test exercises the real terminal/progress path (`CommandLineProgressBar.init()` writes ANSI unconditionally).
- Full `mvn verify` green; no core/domain changes.

## Note

`scan --help` shows the copy-side performance flags (`--copy-threads` etc.) because the shared `PerformanceOptions` ArgGroup bundles scan+copy knobs — pre-existing bundling, harmless (unused flags are ignored); splitting the group is a possible future polish item.

🤖 Generated by [Claude Code](https://claude.com/claude-code), posted via @andrebrait's account on their behalf.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a `scan` command for scanning directories for ROMs and archives.
  * Supports JSON, YAML, and XML output, with optional output-file saving.
  * Added configurable scanning performance options and exit status reporting.

* **Bug Fixes**
  * Improved progress display stability for empty scans, limited files, and inactive threads.

* **Tests**
  * Added coverage for scan output formats, validation, configuration options, and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->