### PR TITLE
cli/core: add "dat check" divergence report and 1g1r --divergence option

### DIFF
--- a/cli/src/main/java/io/github/datromtool/cli/DatRomCommand.java
+++ b/cli/src/main/java/io/github/datromtool/cli/DatRomCommand.java
@@ -1,6 +1,7 @@
 package io.github.datromtool.cli;
 
 import io.github.datromtool.ByteSize;
+import io.github.datromtool.GameParser;
 import io.github.datromtool.cli.argument.DatafileArgument;
 import io.github.datromtool.cli.argument.PatternsFileArgument;
 import io.github.datromtool.cli.command.DatCommand;
@@ -44,6 +45,7 @@ public final class DatRomCommand {
         cmd.registerConverter(ScanBufferSize.class, new ScanBufferSizeConverter());
         cmd.registerConverter(ScanMaxBufferSize.class, new ScanMaxBufferSizeConverter());
         cmd.registerConverter(CopyBufferSize.class, new CopyBufferSizeConverter());
+        cmd.registerConverter(GameParser.DivergenceDetection.class, new DivergenceDetectionConverter());
         int exitCode = cmd.execute(args);
         System.exit(exitCode);
     }

--- a/cli/src/main/java/io/github/datromtool/cli/command/DatCheckCommand.java
+++ b/cli/src/main/java/io/github/datromtool/cli/command/DatCheckCommand.java
@@ -1,0 +1,88 @@
+package io.github.datromtool.cli.command;
+
+import com.google.common.collect.ImmutableList;
+import io.github.datromtool.GameParser;
+import io.github.datromtool.SerializationHelper;
+import io.github.datromtool.cli.GitVersionProvider;
+import io.github.datromtool.cli.argument.DatafileArgument;
+import io.github.datromtool.cli.converter.DatafileConverter;
+import io.github.datromtool.data.ParsedGame;
+import io.github.datromtool.domain.datafile.logiqx.Game;
+import picocli.CommandLine;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.Callable;
+
+import static java.lang.String.format;
+
+/**
+ * Issue #18: surfaces {@link GameParser}'s divergence detection (previously only visible as a
+ * {@code log.warn}, invisible to a normal run) as a standalone report. Detection logic stays in
+ * core: this command only runs {@link GameParser#parse} per DAT (in
+ * {@link GameParser.DivergenceDetection#ALWAYS}, the strictest mode, so name-implied metadata is
+ * compared against DAT-declared metadata unconditionally) and formats
+ * {@link ParsedGame#getDivergences()} it already collects, grouped per input DAT. Exit code
+ * mirrors {@code scan}'s convention: 0 when every DAT is clean, 1 when any divergence is found.
+ */
+@CommandLine.Command(
+        name = "check",
+        description = "Report divergences between No-Intro parsed names and DAT-declared "
+                + "region/language metadata",
+        sortOptions = false,
+        abbreviateSynopsis = true,
+        versionProvider = GitVersionProvider.class,
+        mixinStandardHelpOptions = true)
+public final class DatCheckCommand implements Callable<Integer> {
+
+    @CommandLine.Spec
+    private CommandLine.Model.CommandSpec commandSpec;
+
+    @CommandLine.Parameters(
+            description = "DAT file(s) to check for divergences",
+            arity = "1..*",
+            paramLabel = "DAT_FILE",
+            converter = DatafileConverter.class)
+    private List<DatafileArgument> datafiles;
+
+    @Override
+    public Integer call() {
+        GameParser gameParser;
+        try {
+            gameParser = new GameParser(
+                    SerializationHelper.getInstance().loadRegionData(),
+                    GameParser.DivergenceDetection.ALWAYS);
+        } catch (IOException e) {
+            throw new CommandLine.ParameterException(
+                    commandSpec.commandLine(),
+                    format("Could not load region data: %s", e.getMessage()));
+        }
+
+        boolean anyDivergence = false;
+        for (DatafileArgument datafileArgument : datafiles) {
+            ImmutableList<ParsedGame> parsedGames = gameParser.parse(datafileArgument.getDatafile());
+            List<ParsedGame> divergent = parsedGames.stream()
+                    .filter(pg -> !pg.getDivergences().isEmpty())
+                    .toList();
+            if (divergent.isEmpty()) {
+                System.out.printf("%s: no divergences%n", datafileArgument.getPath());
+                continue;
+            }
+            anyDivergence = true;
+            System.out.printf("%s: %d game(s) with divergences%n",
+                    datafileArgument.getPath(), divergent.size());
+            for (ParsedGame parsedGame : divergent) {
+                Game game = parsedGame.getGame();
+                for (ParsedGame.Divergence divergence : parsedGame.getDivergences()) {
+                    System.out.printf(
+                            "  %s: %s divergence: detected=%s, provided=%s%n",
+                            game.getName(),
+                            divergence.field(),
+                            divergence.detected(),
+                            divergence.provided());
+                }
+            }
+        }
+        return anyDivergence ? 1 : 0;
+    }
+}

--- a/cli/src/main/java/io/github/datromtool/cli/command/DatCheckCommand.java
+++ b/cli/src/main/java/io/github/datromtool/cli/command/DatCheckCommand.java
@@ -6,6 +6,7 @@ import io.github.datromtool.SerializationHelper;
 import io.github.datromtool.cli.GitVersionProvider;
 import io.github.datromtool.cli.argument.DatafileArgument;
 import io.github.datromtool.cli.converter.DatafileConverter;
+import io.github.datromtool.cli.converter.DivergenceDetectionConverter;
 import io.github.datromtool.data.ParsedGame;
 import io.github.datromtool.domain.datafile.logiqx.Game;
 import picocli.CommandLine;
@@ -19,11 +20,19 @@ import static java.lang.String.format;
 /**
  * Issue #18: surfaces {@link GameParser}'s divergence detection (previously only visible as a
  * {@code log.warn}, invisible to a normal run) as a standalone report. Detection logic stays in
- * core: this command only runs {@link GameParser#parse} per DAT (in
- * {@link GameParser.DivergenceDetection#ALWAYS}, the strictest mode, so name-implied metadata is
- * compared against DAT-declared metadata unconditionally) and formats
+ * core: this command only runs {@link GameParser#parse} per DAT and formats
  * {@link ParsedGame#getDivergences()} it already collects, grouped per input DAT. Exit code
  * mirrors {@code scan}'s convention: 0 when every DAT is clean, 1 when any divergence is found.
+ *
+ * <p>Correction round: {@code --divergence} defaults to
+ * {@link GameParser.DivergenceDetection#ONE_WAY}, not {@link GameParser.DivergenceDetection#ALWAYS}.
+ * A verifier probe found {@code ALWAYS} (the previously hardcoded mode) flags 5/5 games on a
+ * release-less DAT (name implies a region, zero {@code <release>} elements at all) — the common
+ * real-world No-Intro DAT shape, since {@code ALWAYS} compares name-detected metadata against
+ * DAT-declared metadata even when the DAT declares none at all. {@code ONE_WAY} (mirroring
+ * {@code 1g1r}'s own default) only compares when both sides are non-empty, so a release-less DAT
+ * reports clean by default; {@code --divergence always} remains available as an explicit,
+ * stricter opt-in.
  */
 @CommandLine.Command(
         name = "check",
@@ -45,13 +54,23 @@ public final class DatCheckCommand implements Callable<Integer> {
             converter = DatafileConverter.class)
     private List<DatafileArgument> datafiles;
 
+    @CommandLine.Option(
+            names = "--divergence",
+            paramLabel = "MODE",
+            converter = DivergenceDetectionConverter.class,
+            completionCandidates = DivergenceDetectionConverter.class,
+            description = "How strictly to flag divergences between No-Intro parsed names and "
+                    + "DAT-declared region/language metadata. Options: ${COMPLETION-CANDIDATES} "
+                    + "(default: one_way).")
+    private GameParser.DivergenceDetection divergenceDetection = GameParser.DivergenceDetection.ONE_WAY;
+
     @Override
     public Integer call() {
         GameParser gameParser;
         try {
             gameParser = new GameParser(
                     SerializationHelper.getInstance().loadRegionData(),
-                    GameParser.DivergenceDetection.ALWAYS);
+                    divergenceDetection);
         } catch (IOException e) {
             throw new CommandLine.ParameterException(
                     commandSpec.commandLine(),

--- a/cli/src/main/java/io/github/datromtool/cli/command/DatCommand.java
+++ b/cli/src/main/java/io/github/datromtool/cli/command/DatCommand.java
@@ -4,7 +4,7 @@ import io.github.datromtool.cli.GitVersionProvider;
 import picocli.CommandLine;
 
 /**
- * Command group for DAT-file-level operations (currently just {@code convert}). Deliberately
+ * Command group for DAT-file-level operations ({@code convert}, {@code check}). Deliberately
  * not {@code Callable}: picocli's default handling of a bare group prints
  * "Missing required subcommand" plus usage on stderr and exits with the usage code, matching
  * the top-level {@code datrom} group's behavior.
@@ -16,6 +16,6 @@ import picocli.CommandLine;
         abbreviateSynopsis = true,
         versionProvider = GitVersionProvider.class,
         mixinStandardHelpOptions = true,
-        subcommands = {DatConvertCommand.class})
+        subcommands = {DatConvertCommand.class, DatCheckCommand.class})
 public final class DatCommand {
 }

--- a/cli/src/main/java/io/github/datromtool/cli/command/OneGameOneRomCommand.java
+++ b/cli/src/main/java/io/github/datromtool/cli/command/OneGameOneRomCommand.java
@@ -5,9 +5,11 @@ import ch.qos.logback.classic.Logger;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.google.common.collect.ImmutableList;
+import io.github.datromtool.GameParser;
 import io.github.datromtool.SerializationHelper;
 import io.github.datromtool.cli.GitVersionProvider;
 import io.github.datromtool.cli.argument.DatafileArgument;
+import io.github.datromtool.cli.converter.DivergenceDetectionConverter;
 import io.github.datromtool.cli.converter.DumpProfileFormatConverter;
 import io.github.datromtool.cli.converter.ExistingFileConverter;
 import io.github.datromtool.cli.option.DiagnosticOptions;
@@ -127,6 +129,16 @@ public final class OneGameOneRomCommand implements Callable<Integer> {
                     + "Options: ${COMPLETION-CANDIDATES} (default: yaml).")
     private DumpProfileFormat dumpProfile;
 
+    @CommandLine.Option(
+            names = "--divergence",
+            paramLabel = "MODE",
+            converter = DivergenceDetectionConverter.class,
+            completionCandidates = DivergenceDetectionConverter.class,
+            description = "How strictly to flag divergences between No-Intro parsed names and "
+                    + "DAT-declared region/language metadata (logged as warnings; does not affect "
+                    + "filtering/output). Options: ${COMPLETION-CANDIDATES} (default: one_way).")
+    private GameParser.DivergenceDetection divergenceDetection = GameParser.DivergenceDetection.ONE_WAY;
+
     @CommandLine.ArgGroup(heading = "Input options\n", exclusive = false)
     private InputOptions inputOptions;
 
@@ -212,7 +224,7 @@ public final class OneGameOneRomCommand implements Callable<Integer> {
                             OutputOptions.FileOptions.OUT_DIR_OPTION,
                             InputOptions.IN_DIR_OPTION));
         }
-        OneGameOneRom oneGameOneRom = new OneGameOneRom(filter, postFilter, sortingPreference);
+        OneGameOneRom oneGameOneRom = new OneGameOneRom(filter, postFilter, sortingPreference, divergenceDetection);
         List<Datafile> realDataFiles = datafiles.stream()
                 .map(DatafileArgument::getDatafile)
                 .collect(ImmutableList.toImmutableList());

--- a/cli/src/main/java/io/github/datromtool/cli/command/OneGameOneRomCommand.java
+++ b/cli/src/main/java/io/github/datromtool/cli/command/OneGameOneRomCommand.java
@@ -102,6 +102,18 @@ public final class OneGameOneRomCommand implements Callable<Integer> {
     @Setter(NONE)
     private CommandLine.Model.CommandSpec commandSpec;
 
+    // Package-private (not private), no lombok-generated accessor: exists purely so
+    // OneGameOneRomCommandDivergenceTest (same package) can pin that the parsed --divergence
+    // value is the one that actually reached OneGameOneRom's constructor, mirroring
+    // ScanCommand.PROGRESS_OUTPUT's test-only visibility pattern. Re-reading this field's own
+    // getDivergenceDetection() getter would not catch a regression where call() hardcodes a mode
+    // at the OneGameOneRom construction call site instead of using the parsed field.
+    @ToString.Exclude
+    @JsonIgnore
+    @Getter(NONE)
+    @Setter(NONE)
+    OneGameOneRom oneGameOneRom;
+
     @CommandLine.Parameters(
             description = "DAT file to use when generating the 1G1R set",
             arity = "0..*",
@@ -224,7 +236,7 @@ public final class OneGameOneRomCommand implements Callable<Integer> {
                             OutputOptions.FileOptions.OUT_DIR_OPTION,
                             InputOptions.IN_DIR_OPTION));
         }
-        OneGameOneRom oneGameOneRom = new OneGameOneRom(filter, postFilter, sortingPreference, divergenceDetection);
+        oneGameOneRom = new OneGameOneRom(filter, postFilter, sortingPreference, divergenceDetection);
         List<Datafile> realDataFiles = datafiles.stream()
                 .map(DatafileArgument::getDatafile)
                 .collect(ImmutableList.toImmutableList());

--- a/cli/src/main/java/io/github/datromtool/cli/converter/DivergenceDetectionConverter.java
+++ b/cli/src/main/java/io/github/datromtool/cli/converter/DivergenceDetectionConverter.java
@@ -1,0 +1,40 @@
+package io.github.datromtool.cli.converter;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.UnmodifiableIterator;
+import io.github.datromtool.GameParser.DivergenceDetection;
+import picocli.CommandLine;
+
+import javax.annotation.Nonnull;
+import java.util.Arrays;
+import java.util.Locale;
+
+public final class DivergenceDetectionConverter
+        implements CommandLine.ITypeConverter<DivergenceDetection>, Iterable<String> {
+
+    private final static ImmutableList<String> aliases = Arrays.stream(DivergenceDetection.values())
+            .map(Enum::name)
+            .map(n -> n.toLowerCase(Locale.ROOT))
+            .collect(ImmutableList.toImmutableList());
+
+    @Override
+    @Nonnull
+    public UnmodifiableIterator<String> iterator() {
+        return aliases.iterator();
+    }
+
+    @Override
+    public DivergenceDetection convert(String value) {
+        String trimmed = value.trim();
+        return aliases.stream()
+                .filter(c -> c.equalsIgnoreCase(trimmed))
+                .findFirst()
+                .map(c -> c.toUpperCase(Locale.ROOT))
+                .map(DivergenceDetection::valueOf)
+                .orElseThrow(() -> new CommandLine.TypeConversionException(
+                        String.format(
+                                "'%s' is not a valid divergence value. It must be one of %s",
+                                value,
+                                aliases)));
+    }
+}

--- a/cli/src/test/java/io/github/datromtool/cli/command/DatCheckCommandTest.java
+++ b/cli/src/test/java/io/github/datromtool/cli/command/DatCheckCommandTest.java
@@ -1,0 +1,114 @@
+package io.github.datromtool.cli.command;
+
+import io.github.datromtool.cli.argument.DatafileArgument;
+import io.github.datromtool.cli.converter.DatafileConverter;
+import org.junit.jupiter.api.Test;
+import picocli.CommandLine;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.net.URISyntaxException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Coverage matrix rows 1-3 and 6 for issue #18's {@code dat check} subcommand: a fixture DAT
+ * with a name/DAT-metadata divergence is reported (game name + divergence kind), a clean DAT
+ * reports none, the exit code mirrors {@code scan}'s convention (0 clean, 1 divergent), multiple
+ * DATs are all processed and grouped per DAT, and stdout stays limited to the report (no
+ * progress/logging noise).
+ */
+class DatCheckCommandTest {
+
+    private static Path fixture(String name) {
+        try {
+            return Paths.get(DatCheckCommandTest.class
+                    .getClassLoader()
+                    .getResource("datafiles/" + name)
+                    .toURI());
+        } catch (URISyntaxException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    private static CommandLine newCommandLine(DatCheckCommand command) {
+        CommandLine commandLine = new CommandLine(command);
+        commandLine.registerConverter(DatafileArgument.class, new DatafileConverter());
+        return commandLine;
+    }
+
+    private static int run(ByteArrayOutputStream captured, String... args) {
+        DatCheckCommand command = new DatCheckCommand();
+        CommandLine commandLine = newCommandLine(command);
+        commandLine.parseArgs(args);
+        PrintStream original = System.out;
+        System.setOut(new PrintStream(captured));
+        try {
+            return command.call();
+        } finally {
+            System.setOut(original);
+        }
+    }
+
+    // Row 1(a) + row 2: a fixture DAT with a known divergence is reported (game name +
+    // divergence kind), and the exit code is 1.
+    @Test
+    void divergentDatReportsGameNameAndDivergenceKindAndExitsOne() {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        int exitCode = run(out, fixture("divergent.dat").toString());
+        String report = out.toString();
+        assertEquals(1, exitCode, "a divergent DAT must exit 1");
+        assertTrue(report.contains("Test Game (Europe)"),
+                "report must name the divergent game, got:\n" + report);
+        assertTrue(report.contains("region divergence"),
+                "report must name the divergence kind, got:\n" + report);
+        assertTrue(report.contains("detected=[EUR]") && report.contains("provided=[ITA]"),
+                "report must show detected vs. provided values, got:\n" + report);
+    }
+
+    // Row 1(b): a clean DAT reports no divergences and exits 0.
+    @Test
+    void cleanDatReportsNoDivergencesAndExitsZero() {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        int exitCode = run(out, fixture("clean.dat").toString());
+        String report = out.toString();
+        assertEquals(0, exitCode, "a clean DAT must exit 0");
+        assertTrue(report.contains("no divergences"),
+                "report must state the DAT is clean, got:\n" + report);
+        assertFalse(report.contains("divergence:"),
+                "a clean report must not list any divergence entries, got:\n" + report);
+    }
+
+    // Row 3: multiple DATs are all processed and the report is grouped per DAT.
+    @Test
+    void multipleDatsAreAllProcessedAndGroupedPerDat() {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        int exitCode = run(out, fixture("clean.dat").toString(), fixture("divergent.dat").toString());
+        String report = out.toString();
+        assertEquals(1, exitCode, "any divergent DAT in the batch must exit 1");
+        int cleanIndex = report.indexOf(fixture("clean.dat").toString());
+        int divergentIndex = report.indexOf(fixture("divergent.dat").toString());
+        assertTrue(cleanIndex >= 0 && divergentIndex >= 0,
+                "report must include a heading line per input DAT, got:\n" + report);
+        assertTrue(report.contains("no divergences"),
+                "report must show the clean DAT's own group as clean, got:\n" + report);
+        assertTrue(report.contains("region divergence"),
+                "report must show the divergent DAT's own group with its finding, got:\n" + report);
+    }
+
+    // Row 6: stdout carries only the report; no logging/progress noise mixed in.
+    @Test
+    void stdoutCarriesOnlyTheReport() {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        run(out, fixture("clean.dat").toString());
+        String report = out.toString();
+        assertEquals(
+                fixture("clean.dat") + ": no divergences" + System.lineSeparator(),
+                report,
+                "stdout must contain exactly the report line, got:\n" + report);
+    }
+}

--- a/cli/src/test/java/io/github/datromtool/cli/command/DatCheckCommandTest.java
+++ b/cli/src/test/java/io/github/datromtool/cli/command/DatCheckCommandTest.java
@@ -1,7 +1,9 @@
 package io.github.datromtool.cli.command;
 
+import io.github.datromtool.GameParser;
 import io.github.datromtool.cli.argument.DatafileArgument;
 import io.github.datromtool.cli.converter.DatafileConverter;
+import io.github.datromtool.cli.converter.DivergenceDetectionConverter;
 import org.junit.jupiter.api.Test;
 import picocli.CommandLine;
 
@@ -38,6 +40,7 @@ class DatCheckCommandTest {
     private static CommandLine newCommandLine(DatCheckCommand command) {
         CommandLine commandLine = new CommandLine(command);
         commandLine.registerConverter(DatafileArgument.class, new DatafileConverter());
+        commandLine.registerConverter(GameParser.DivergenceDetection.class, new DivergenceDetectionConverter());
         return commandLine;
     }
 
@@ -98,6 +101,34 @@ class DatCheckCommandTest {
                 "report must show the clean DAT's own group as clean, got:\n" + report);
         assertTrue(report.contains("region divergence"),
                 "report must show the divergent DAT's own group with its finding, got:\n" + report);
+    }
+
+    // Correction round: dat check's default divergence mode must be ONE_WAY (not the previously
+    // hardcoded ALWAYS), which requires both detected and provided to be non-empty before
+    // comparing. A release-less DAT (name implies a region, zero <release> elements at all) is
+    // the common real-world No-Intro DAT shape a verifier probe found 5/5 games falsely flagged
+    // under ALWAYS. Under ONE_WAY, "provided" is empty, so no comparison is made at all: no
+    // divergence, exit 0.
+    @Test
+    void defaultModeReportsNoDivergencesForAReleaseLessDat() {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        int exitCode = run(out, fixture("release-less.dat").toString());
+        String report = out.toString();
+        assertEquals(0, exitCode, "a release-less DAT must not be flagged under the ONE_WAY default");
+        assertTrue(report.contains("no divergences"),
+                "report must state the release-less DAT is clean under the default mode, got:\n" + report);
+    }
+
+    // Escape hatch: --divergence always still flags the same release-less DAT, pinning that the
+    // stricter mode remains reachable for users who want it.
+    @Test
+    void explicitAlwaysFlagsTheSameReleaseLessDat() {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        int exitCode = run(out, "--divergence", "always", fixture("release-less.dat").toString());
+        String report = out.toString();
+        assertEquals(1, exitCode, "--divergence always must flag a release-less DAT's name-implied region");
+        assertTrue(report.contains("region divergence"),
+                "report must show the region divergence under --divergence always, got:\n" + report);
     }
 
     // Row 6: stdout carries only the report; no logging/progress noise mixed in.

--- a/cli/src/test/java/io/github/datromtool/cli/command/DatCheckCommandTest.java
+++ b/cli/src/test/java/io/github/datromtool/cli/command/DatCheckCommandTest.java
@@ -131,6 +131,42 @@ class DatCheckCommandTest {
                 "report must show the region divergence under --divergence always, got:\n" + report);
     }
 
+    // Second correction round: the "language" divergence report path (GameParser.detectLanguages
+    // -> divergences.add("language", ...) -> this command's per-divergence print loop) had zero
+    // test coverage. Pins a language-only divergence is named and reported, and exits 1.
+    @Test
+    void languageDivergentDatReportsLanguageDivergenceAndExitsOne() {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        int exitCode = run(out, fixture("lang-divergent.dat").toString());
+        String report = out.toString();
+        assertEquals(1, exitCode, "a language-divergent DAT must exit 1");
+        assertTrue(report.contains("Test Game (En)"),
+                "report must name the divergent game, got:\n" + report);
+        assertTrue(report.contains("language divergence"),
+                "report must name the divergence kind, got:\n" + report);
+        assertTrue(report.contains("detected=[en]") && report.contains("provided=[fr]"),
+                "report must show detected vs. provided values, got:\n" + report);
+    }
+
+    // Pins that a single game with BOTH a region and a language divergence gets both rows in the
+    // report, not just one (region and language divergences are collected/printed independently).
+    @Test
+    void multiDivergentGameReportsBothRegionAndLanguageDivergenceRows() {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        int exitCode = run(out, fixture("multi-divergent.dat").toString());
+        String report = out.toString();
+        assertEquals(1, exitCode, "a multi-divergent DAT must exit 1");
+        assertTrue(report.contains("Test Game (Europe) (En): region divergence: detected=[EUR], provided=[ITA]"),
+                "report must include the region divergence row, got:\n" + report);
+        assertTrue(report.contains("Test Game (Europe) (En): language divergence: detected=[en], provided=[fr]"),
+                "report must include the language divergence row, got:\n" + report);
+        long gameRowCount = report.lines()
+                .filter(line -> line.contains("Test Game (Europe) (En)") && line.contains("divergence:"))
+                .count();
+        assertEquals(2, gameRowCount,
+                "both divergence rows must appear under the same game, got:\n" + report);
+    }
+
     // Row 6: stdout carries only the report; no logging/progress noise mixed in.
     @Test
     void stdoutCarriesOnlyTheReport() {

--- a/cli/src/test/java/io/github/datromtool/cli/command/OneGameOneRomCommandDivergenceTest.java
+++ b/cli/src/test/java/io/github/datromtool/cli/command/OneGameOneRomCommandDivergenceTest.java
@@ -91,6 +91,15 @@ class OneGameOneRomCommandDivergenceTest {
     // pipeline (past GameParser.parse + the post-parse validate call) rather than at option
     // parsing — proving the option value flows all the way through OneGameOneRom.generate() for
     // every mode, not just the default.
+    //
+    // CodeRabbit finding: asserting only the identical downstream error does NOT discriminate
+    // which mode actually reached OneGameOneRom -- a call() that hardcoded ONE_WAY at the
+    // OneGameOneRom construction call site (ignoring the parsed `divergenceDetection` field)
+    // would pass this identically for every mode. The added assertion below inspects
+    // `command.oneGameOneRom` (package-private, set by call() itself) via
+    // OneGameOneRom#getDivergenceDetection(), not the command's own field/getter, so a
+    // call-site hardcode is caught: mutation-tested (see handoff) by temporarily hardcoding
+    // ONE_WAY at that call site, which fails this assertion for every non-ONE_WAY mode.
     @Test
     void everyDivergenceValueReachesOneGameOneRomConstruction() {
         for (GameParser.DivergenceDetection mode : GameParser.DivergenceDetection.values()) {
@@ -107,6 +116,32 @@ class OneGameOneRomCommandDivergenceTest {
                     ex.getMessage().contains("Parent/Clone information"),
                     "mode " + mode + " must fail with the same downstream DAT-shape error, got: "
                             + ex.getMessage());
+            assertEquals(mode, command.oneGameOneRom.getDivergenceDetection(),
+                    "mode " + mode + " must be the exact value that reached OneGameOneRom's "
+                            + "constructor, not just the command's own parsed field");
         }
+    }
+
+    // Explicit, named pins for the two specific values the correction round asked for: the
+    // non-default "always" and the default-when-absent "one_way", each verified against the
+    // constructed OneGameOneRom instance (not the command's own field).
+    @Test
+    void divergenceAlwaysReachesOneGameOneRomConstructionAsAlways() {
+        OneGameOneRomCommand command = new OneGameOneRomCommand();
+        CommandLine commandLine = newCommandLine(command);
+        commandLine.parseArgs("--divergence", "always", fixture("minimal.dat").toString());
+        assertThrows(CommandLine.ParameterException.class, command::call);
+        assertEquals(GameParser.DivergenceDetection.ALWAYS, command.oneGameOneRom.getDivergenceDetection(),
+                "--divergence always must reach OneGameOneRom's constructor as ALWAYS");
+    }
+
+    @Test
+    void absentDivergenceReachesOneGameOneRomConstructionAsOneWay() {
+        OneGameOneRomCommand command = new OneGameOneRomCommand();
+        CommandLine commandLine = newCommandLine(command);
+        commandLine.parseArgs(fixture("minimal.dat").toString());
+        assertThrows(CommandLine.ParameterException.class, command::call);
+        assertEquals(GameParser.DivergenceDetection.ONE_WAY, command.oneGameOneRom.getDivergenceDetection(),
+                "absent --divergence must reach OneGameOneRom's constructor as ONE_WAY");
     }
 }

--- a/cli/src/test/java/io/github/datromtool/cli/command/OneGameOneRomCommandDivergenceTest.java
+++ b/cli/src/test/java/io/github/datromtool/cli/command/OneGameOneRomCommandDivergenceTest.java
@@ -1,0 +1,112 @@
+package io.github.datromtool.cli.command;
+
+import io.github.datromtool.GameParser;
+import io.github.datromtool.cli.argument.DatafileArgument;
+import io.github.datromtool.cli.converter.DatafileConverter;
+import io.github.datromtool.cli.converter.DivergenceDetectionConverter;
+import org.junit.jupiter.api.Test;
+import picocli.CommandLine;
+
+import java.net.URISyntaxException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Locale;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Coverage matrix row 4 for issue #18: {@code 1g1r --divergence} accepts each
+ * {@link GameParser.DivergenceDetection} value case-insensitively, rejects a bogus value listing
+ * the valid candidates, defaults to {@code ONE_WAY} (unchanged behavior) when absent, and the
+ * parsed value is the one threaded into {@link io.github.datromtool.command.OneGameOneRom}'s
+ * construction (pinned by running the command end to end and confirming execution reaches past
+ * {@link GameParser} construction/parsing for every accepted value, identically to today's
+ * hardcoded {@code ONE_WAY}).
+ */
+class OneGameOneRomCommandDivergenceTest {
+
+    private static Path fixture(String name) {
+        try {
+            return Paths.get(OneGameOneRomCommandDivergenceTest.class
+                    .getClassLoader()
+                    .getResource("datafiles/" + name)
+                    .toURI());
+        } catch (URISyntaxException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    private static CommandLine newCommandLine(OneGameOneRomCommand command) {
+        CommandLine commandLine = new CommandLine(command);
+        commandLine.registerConverter(DatafileArgument.class, new DatafileConverter());
+        commandLine.registerConverter(GameParser.DivergenceDetection.class, new DivergenceDetectionConverter());
+        return commandLine;
+    }
+
+    // Default (option absent) behaves as ONE_WAY: no behavior change from before this option
+    // existed.
+    @Test
+    void defaultsToOneWayWhenAbsent() {
+        OneGameOneRomCommand command = new OneGameOneRomCommand();
+        newCommandLine(command).parseArgs();
+        assertEquals(GameParser.DivergenceDetection.ONE_WAY, command.getDivergenceDetection());
+    }
+
+    // Every enum value is accepted case-insensitively.
+    @Test
+    void acceptsEveryValueCaseInsensitively() {
+        for (GameParser.DivergenceDetection mode : GameParser.DivergenceDetection.values()) {
+            for (String spelling : new String[]{
+                    mode.name().toLowerCase(Locale.ROOT),
+                    mode.name().toUpperCase(Locale.ROOT)}) {
+                OneGameOneRomCommand command = new OneGameOneRomCommand();
+                newCommandLine(command).parseArgs("--divergence", spelling);
+                assertEquals(mode, command.getDivergenceDetection(),
+                        "spelling '" + spelling + "' must parse as " + mode);
+            }
+        }
+    }
+
+    // A bogus value fails parsing, listing the valid candidates.
+    @Test
+    void bogusValueFailsListingCandidates() {
+        OneGameOneRomCommand command = new OneGameOneRomCommand();
+        CommandLine commandLine = newCommandLine(command);
+        CommandLine.ParameterException ex = assertThrows(
+                CommandLine.ParameterException.class,
+                () -> commandLine.parseArgs("--divergence", "bogus"),
+                "an unknown --divergence value must fail parsing");
+        assertTrue(
+                ex.getMessage().contains("ignore")
+                        && ex.getMessage().contains("one_way")
+                        && ex.getMessage().contains("two_way")
+                        && ex.getMessage().contains("always"),
+                "error must list the valid divergence candidates, got: " + ex.getMessage());
+    }
+
+    // Wiring pin: the parsed mode reaches OneGameOneRom's GameParser construction. minimal.dat has
+    // no Parent/Clone info, so every accepted --divergence value must fail identically deep in the
+    // pipeline (past GameParser.parse + the post-parse validate call) rather than at option
+    // parsing — proving the option value flows all the way through OneGameOneRom.generate() for
+    // every mode, not just the default.
+    @Test
+    void everyDivergenceValueReachesOneGameOneRomConstruction() {
+        for (GameParser.DivergenceDetection mode : GameParser.DivergenceDetection.values()) {
+            OneGameOneRomCommand command = new OneGameOneRomCommand();
+            CommandLine commandLine = newCommandLine(command);
+            commandLine.parseArgs(
+                    "--divergence", mode.name().toLowerCase(Locale.ROOT),
+                    fixture("minimal.dat").toString());
+            CommandLine.ParameterException ex = assertThrows(
+                    CommandLine.ParameterException.class,
+                    command::call,
+                    "mode " + mode + " must still reach the pipeline's DAT-shape validation");
+            assertTrue(
+                    ex.getMessage().contains("Parent/Clone information"),
+                    "mode " + mode + " must fail with the same downstream DAT-shape error, got: "
+                            + ex.getMessage());
+        }
+    }
+}

--- a/cli/src/test/resources/datafiles/clean.dat
+++ b/cli/src/test/resources/datafiles/clean.dat
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<!DOCTYPE datafile PUBLIC "-//Logiqx//DTD ROM Management Datafile//EN" "http://www.logiqx.com/Dats/datafile.dtd">
+<datafile>
+	<header>
+		<name>Clean DAT</name>
+		<description>Clean DAT</description>
+		<version>1.0</version>
+		<author>Test Author</author>
+	</header>
+	<game name="Test Game (Europe)">
+		<description>Test Game (Europe)</description>
+		<release name="Test Game" region="EUR"/>
+		<rom name="test.rom" size="1" crc="00000000"/>
+	</game>
+</datafile>

--- a/cli/src/test/resources/datafiles/divergent.dat
+++ b/cli/src/test/resources/datafiles/divergent.dat
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<!DOCTYPE datafile PUBLIC "-//Logiqx//DTD ROM Management Datafile//EN" "http://www.logiqx.com/Dats/datafile.dtd">
+<datafile>
+	<header>
+		<name>Divergent DAT</name>
+		<description>Divergent DAT</description>
+		<version>1.0</version>
+		<author>Test Author</author>
+	</header>
+	<game name="Test Game (Europe)">
+		<description>Test Game (Europe)</description>
+		<release name="Test Game" region="ITA"/>
+		<rom name="test.rom" size="1" crc="00000000"/>
+	</game>
+</datafile>

--- a/cli/src/test/resources/datafiles/lang-divergent.dat
+++ b/cli/src/test/resources/datafiles/lang-divergent.dat
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<!DOCTYPE datafile PUBLIC "-//Logiqx//DTD ROM Management Datafile//EN" "http://www.logiqx.com/Dats/datafile.dtd">
+<datafile>
+	<header>
+		<name>Language Divergent DAT</name>
+		<description>Language Divergent DAT</description>
+		<version>1.0</version>
+		<author>Test Author</author>
+	</header>
+	<game name="Test Game (En)">
+		<description>Test Game (En)</description>
+		<release name="Test Game" region="" language="fr"/>
+		<rom name="test.rom" size="1" crc="00000000"/>
+	</game>
+</datafile>

--- a/cli/src/test/resources/datafiles/multi-divergent.dat
+++ b/cli/src/test/resources/datafiles/multi-divergent.dat
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<!DOCTYPE datafile PUBLIC "-//Logiqx//DTD ROM Management Datafile//EN" "http://www.logiqx.com/Dats/datafile.dtd">
+<datafile>
+	<header>
+		<name>Multi Divergent DAT</name>
+		<description>Multi Divergent DAT</description>
+		<version>1.0</version>
+		<author>Test Author</author>
+	</header>
+	<game name="Test Game (Europe) (En)">
+		<description>Test Game (Europe) (En)</description>
+		<release name="Test Game" region="ITA" language="fr"/>
+		<rom name="test.rom" size="1" crc="00000000"/>
+	</game>
+</datafile>

--- a/cli/src/test/resources/datafiles/release-less.dat
+++ b/cli/src/test/resources/datafiles/release-less.dat
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<!DOCTYPE datafile PUBLIC "-//Logiqx//DTD ROM Management Datafile//EN" "http://www.logiqx.com/Dats/datafile.dtd">
+<datafile>
+	<header>
+		<name>Release-less DAT</name>
+		<description>Release-less DAT</description>
+		<version>1.0</version>
+		<author>Test Author</author>
+	</header>
+	<game name="Test Game (Europe)">
+		<description>Test Game (Europe)</description>
+		<rom name="test.rom" size="1" crc="00000000"/>
+	</game>
+</datafile>

--- a/core/src/main/java/io/github/datromtool/GameParser.java
+++ b/core/src/main/java/io/github/datromtool/GameParser.java
@@ -15,6 +15,7 @@ import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -48,21 +49,27 @@ public final class GameParser {
 
     public ImmutableList<ParsedGame> parse(Datafile input) {
         return input.getGames().stream()
-                .map(g -> ParsedGame.builder()
-                        .game(g)
-                        .bios(isBios(g))
-                        .parent(isNullOrEmpty(g.getCloneOf()) && isNullOrEmpty(g.getRomOf()))
-                        .bad(detectIsBad(g))
-                        .regionData(detectRegionData(g))
-                        .languages(detectLanguages(g))
-                        .proto(detectProto(g))
-                        .beta(detectBeta(g))
-                        .demo(detectDemo(g))
-                        .sample(detectSample(g))
-                        .revision(detectRevision(g))
-                        .version(detectVersion(g))
-                        .build())
+                .map(this::parseGame)
                 .collect(ImmutableList.toImmutableList());
+    }
+
+    private ParsedGame parseGame(Game g) {
+        List<ParsedGame.Divergence> divergences = new ArrayList<>();
+        return ParsedGame.builder()
+                .game(g)
+                .bios(isBios(g))
+                .parent(isNullOrEmpty(g.getCloneOf()) && isNullOrEmpty(g.getRomOf()))
+                .bad(detectIsBad(g))
+                .regionData(detectRegionData(g, divergences))
+                .languages(detectLanguages(g, divergences))
+                .proto(detectProto(g))
+                .beta(detectBeta(g))
+                .demo(detectDemo(g))
+                .sample(detectSample(g))
+                .revision(detectRevision(g))
+                .version(detectVersion(g))
+                .divergences(ImmutableList.copyOf(divergences))
+                .build();
     }
 
     private static boolean isBios(Game g) {
@@ -83,7 +90,7 @@ public final class GameParser {
         return result;
     }
 
-    private RegionData detectRegionData(Game game) {
+    private RegionData detectRegionData(Game game, List<ParsedGame.Divergence> divergences) {
         Set<RegionData.RegionDataEntry> detected = new LinkedHashSet<>();
         Matcher matcher = Patterns.SECTIONS.matcher(game.getName());
         while (matcher.find()) {
@@ -128,6 +135,10 @@ public final class GameParser {
                     "Detected regions by name do not match with the ones provided by the DAT. "
                             + "Difference(detected={}, provided={}, game={})",
                     detectedCodes, providedCodes, game.getName());
+            divergences.add(new ParsedGame.Divergence(
+                    "region",
+                    ImmutableSet.copyOf(detectedCodes),
+                    ImmutableSet.copyOf(providedCodes)));
         }
         return new RegionData(ImmutableSet.<RegionData.RegionDataEntry>builder()
                 .addAll(detected)
@@ -135,7 +146,7 @@ public final class GameParser {
                 .build());
     }
 
-    private ImmutableSet<String> detectLanguages(Game game) {
+    private ImmutableSet<String> detectLanguages(Game game, List<ParsedGame.Divergence> divergences) {
         Set<String> detected = new LinkedHashSet<>();
         Matcher matcher = Patterns.LANGUAGES.matcher(game.getName());
         while (matcher.find()) {
@@ -172,6 +183,10 @@ public final class GameParser {
                     detected,
                     provided,
                     game.getName());
+            divergences.add(new ParsedGame.Divergence(
+                    "language",
+                    ImmutableSet.copyOf(detected),
+                    ImmutableSet.copyOf(provided)));
         }
         return ImmutableSet.<String>builder()
                 .addAll(detected)

--- a/core/src/main/java/io/github/datromtool/command/OneGameOneRom.java
+++ b/core/src/main/java/io/github/datromtool/command/OneGameOneRom.java
@@ -23,6 +23,7 @@ import io.github.datromtool.io.FileScanner;
 import io.github.datromtool.io.ScanResultMatcher;
 import io.github.datromtool.sorting.GameComparator;
 import io.github.datromtool.sorting.GameNameComparator;
+import lombok.Getter;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -52,7 +53,11 @@ public final class OneGameOneRom {
     private final PostFilter postFilter;
     @NonNull
     private final SortingPreference sortingPreference;
+    // Public getter (not just a private field) so a CLI-level test can pin that the mode it
+    // parsed is the one that actually reached this constructor, rather than only re-reading the
+    // command's own field (which a hardcoded-at-the-call-site regression wouldn't affect).
     @NonNull
+    @Getter
     private final GameParser.DivergenceDetection divergenceDetection;
 
     public void generate(

--- a/core/src/main/java/io/github/datromtool/command/OneGameOneRom.java
+++ b/core/src/main/java/io/github/datromtool/command/OneGameOneRom.java
@@ -52,6 +52,8 @@ public final class OneGameOneRom {
     private final PostFilter postFilter;
     @NonNull
     private final SortingPreference sortingPreference;
+    @NonNull
+    private final GameParser.DivergenceDetection divergenceDetection;
 
     public void generate(
             @Nonnull AppConfig appConfig,
@@ -191,10 +193,10 @@ public final class OneGameOneRom {
                 .map(s -> s.map(ScanResultMatcher.GameMatchList::getParsedGame));
     }
 
-    private static ImmutableList<ParsedGame> parseGames(Collection<Datafile> datafiles) throws IOException {
+    private ImmutableList<ParsedGame> parseGames(Collection<Datafile> datafiles) throws IOException {
         GameParser gameParser = new GameParser(
                 SerializationHelper.getInstance().loadRegionData(),
-                GameParser.DivergenceDetection.ONE_WAY);
+                divergenceDetection);
         return datafiles.stream()
                 .map(gameParser::parse)
                 .flatMap(Collection::stream)

--- a/core/src/main/java/io/github/datromtool/data/ParsedGame.java
+++ b/core/src/main/java/io/github/datromtool/data/ParsedGame.java
@@ -13,6 +13,7 @@ import lombok.NonNull;
 import lombok.Value;
 import lombok.extern.jackson.Jacksonized;
 
+import javax.annotation.Nonnull;
 import java.util.Collection;
 import java.util.stream.Stream;
 
@@ -70,6 +71,22 @@ public class ParsedGame {
     @NonNull
     @Builder.Default
     ImmutableList<Long> version = ImmutableList.of();
+
+    @NonNull
+    @Builder.Default
+    ImmutableList<Divergence> divergences = ImmutableList.of();
+
+    @JsonInclude(NON_DEFAULT)
+    public record Divergence(
+            @Nonnull String field,
+            @Nonnull ImmutableSet<String> detected,
+            @Nonnull ImmutableSet<String> provided) {
+
+        public Divergence {
+            if (detected == null) detected = ImmutableSet.of();
+            if (provided == null) provided = ImmutableSet.of();
+        }
+    }
 
     @JsonIgnore
     public Stream<String> getRegionsStream() {

--- a/core/src/test/java/io/github/datromtool/GameParserTest.java
+++ b/core/src/test/java/io/github/datromtool/GameParserTest.java
@@ -1,10 +1,111 @@
 package io.github.datromtool;
 
+import com.google.common.collect.ImmutableList;
+import io.github.datromtool.data.ParsedGame;
+import io.github.datromtool.data.RegionData;
+import io.github.datromtool.domain.datafile.logiqx.Datafile;
+import io.github.datromtool.domain.datafile.logiqx.Game;
+import io.github.datromtool.domain.datafile.logiqx.Release;
+import io.github.datromtool.domain.datafile.logiqx.enumerations.YesNo;
+import io.github.datromtool.util.TestUtils;
 import org.junit.jupiter.api.Test;
 
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Issue #18 coverage matrix row 5: pins that {@link GameParser.DivergenceDetection} modes
+ * produce an observably different {@link ParsedGame#getDivergences()} result for the same input,
+ * directly at the seam that carries divergence data out of {@link GameParser} (previously only a
+ * {@code log.warn}, invisible outside the log file).
+ */
 class GameParserTest {
 
+    // A name-implied region ("Europe" -> EUR) with no <release> element at all: "provided" is
+    // empty. ONE_WAY/TWO_WAY require both sides non-empty before comparing, so this must NOT be
+    // flagged under ONE_WAY; ALWAYS compares regardless of emptiness, so it MUST be flagged.
+    private static Game gameWithNameOnlyRegion() {
+        return Game.builder()
+                .name("Test Game (Europe)")
+                .description("Test Game (Europe)")
+                .build();
+    }
+
+    private static Datafile datafileOf(Game game) {
+        return Datafile.builder().games(ImmutableList.of(game)).build();
+    }
+
     @Test
-    void testParse() {
+    void oneWayModeIgnoresADivergenceWhenTheDatDeclaresNoRegionAtAll() throws Exception {
+        RegionData regionData = TestUtils.loadRegionData();
+        GameParser gameParser = new GameParser(regionData, GameParser.DivergenceDetection.ONE_WAY);
+
+        ParsedGame parsedGame = gameParser.parse(datafileOf(gameWithNameOnlyRegion())).get(0);
+
+        assertTrue(parsedGame.getDivergences().isEmpty(),
+                "ONE_WAY must not flag a divergence when the DAT declares no region at all, got: "
+                        + parsedGame.getDivergences());
+    }
+
+    @Test
+    void alwaysModeFlagsTheSameCaseOneWayIgnores() throws Exception {
+        RegionData regionData = TestUtils.loadRegionData();
+        GameParser gameParser = new GameParser(regionData, GameParser.DivergenceDetection.ALWAYS);
+
+        ParsedGame parsedGame = gameParser.parse(datafileOf(gameWithNameOnlyRegion())).get(0);
+
+        assertEquals(1, parsedGame.getDivergences().size(),
+                "ALWAYS must flag a divergence when name-implied metadata has no DAT-declared "
+                        + "counterpart at all, got: " + parsedGame.getDivergences());
+        ParsedGame.Divergence divergence = parsedGame.getDivergences().get(0);
+        assertEquals("region", divergence.field());
+        assertEquals(Set.of("EUR"), divergence.detected());
+        assertTrue(divergence.provided().isEmpty());
+    }
+
+    @Test
+    void ignoreModeNeverFlagsEvenAnOutrightMismatch() throws Exception {
+        RegionData regionData = TestUtils.loadRegionData();
+        GameParser gameParser = new GameParser(regionData, GameParser.DivergenceDetection.IGNORE);
+        Game game = Game.builder()
+                .name("Test Game (Europe)")
+                .description("Test Game (Europe)")
+                .releases(ImmutableList.of(
+                        new Release("Test Game", "ITA", null, null, YesNo.NO)))
+                .build();
+
+        ParsedGame parsedGame = gameParser.parse(datafileOf(game)).get(0);
+
+        assertTrue(parsedGame.getDivergences().isEmpty(),
+                "IGNORE must never flag a divergence, got: " + parsedGame.getDivergences());
+    }
+
+    @Test
+    void twoWayModeFlagsAPartialOverlapThatOneWayAccepts() throws Exception {
+        RegionData regionData = TestUtils.loadRegionData();
+        // Name implies only Europe; DAT declares both EUR and USA. ONE_WAY only checks
+        // provided.containsAll(detected) = {EUR,USA}.containsAll({EUR}) = true -> not flagged.
+        // TWO_WAY requires exact equality ({EUR,USA} != {EUR}) -> flagged.
+        Game game = Game.builder()
+                .name("Test Game (Europe)")
+                .description("Test Game (Europe)")
+                .releases(ImmutableList.of(
+                        new Release("Test Game (EUR)", "EUR", null, null, YesNo.NO),
+                        new Release("Test Game (USA)", "USA", null, null, YesNo.NO)))
+                .build();
+
+        GameParser oneWay = new GameParser(regionData, GameParser.DivergenceDetection.ONE_WAY);
+        ParsedGame oneWayParsed = oneWay.parse(datafileOf(game)).get(0);
+        assertTrue(oneWayParsed.getDivergences().isEmpty(),
+                "ONE_WAY must accept a provided superset of detected, got: "
+                        + oneWayParsed.getDivergences());
+
+        GameParser twoWay = new GameParser(regionData, GameParser.DivergenceDetection.TWO_WAY);
+        ParsedGame twoWayParsed = twoWay.parse(datafileOf(game)).get(0);
+        assertEquals(1, twoWayParsed.getDivergences().size(),
+                "TWO_WAY must flag a provided superset that isn't an exact match, got: "
+                        + twoWayParsed.getDivergences());
     }
 }

--- a/core/src/test/java/io/github/datromtool/GameParserTest.java
+++ b/core/src/test/java/io/github/datromtool/GameParserTest.java
@@ -37,6 +37,15 @@ class GameParserTest {
         return Datafile.builder().games(ImmutableList.of(game)).build();
     }
 
+    // A name-implied language ("En" -> "en") with no <release> element at all: "provided" is
+    // empty. Mirrors gameWithNameOnlyRegion for the language side of GameParser.detectLanguages.
+    private static Game gameWithNameOnlyLanguage() {
+        return Game.builder()
+                .name("Test Game (En)")
+                .description("Test Game (En)")
+                .build();
+    }
+
     @Test
     void oneWayModeIgnoresADivergenceWhenTheDatDeclaresNoRegionAtAll() throws Exception {
         RegionData regionData = TestUtils.loadRegionData();
@@ -107,5 +116,60 @@ class GameParserTest {
         assertEquals(1, twoWayParsed.getDivergences().size(),
                 "TWO_WAY must flag a provided superset that isn't an exact match, got: "
                         + twoWayParsed.getDivergences());
+    }
+
+    // Second correction round: the "language" divergence path (GameParser.detectLanguages ->
+    // divergences.add("language", ...)) had zero test coverage. Mirrors the region cases above.
+
+    @Test
+    void oneWayModeIgnoresALanguageDivergenceWhenTheDatDeclaresNoLanguageAtAll() throws Exception {
+        RegionData regionData = TestUtils.loadRegionData();
+        GameParser gameParser = new GameParser(regionData, GameParser.DivergenceDetection.ONE_WAY);
+
+        ParsedGame parsedGame = gameParser.parse(datafileOf(gameWithNameOnlyLanguage())).get(0);
+
+        assertTrue(parsedGame.getDivergences().isEmpty(),
+                "ONE_WAY must not flag a language divergence when the DAT declares no language "
+                        + "at all, got: " + parsedGame.getDivergences());
+    }
+
+    @Test
+    void alwaysModeFlagsTheSameLanguageCaseOneWayIgnores() throws Exception {
+        RegionData regionData = TestUtils.loadRegionData();
+        GameParser gameParser = new GameParser(regionData, GameParser.DivergenceDetection.ALWAYS);
+
+        ParsedGame parsedGame = gameParser.parse(datafileOf(gameWithNameOnlyLanguage())).get(0);
+
+        assertEquals(1, parsedGame.getDivergences().size(),
+                "ALWAYS must flag a language divergence when name-implied metadata has no "
+                        + "DAT-declared counterpart at all, got: " + parsedGame.getDivergences());
+        ParsedGame.Divergence divergence = parsedGame.getDivergences().get(0);
+        assertEquals("language", divergence.field());
+        assertEquals(Set.of("en"), divergence.detected());
+        assertTrue(divergence.provided().isEmpty());
+    }
+
+    @Test
+    void oneWayModeFlagsAGenuineLanguageMismatch() throws Exception {
+        RegionData regionData = TestUtils.loadRegionData();
+        GameParser gameParser = new GameParser(regionData, GameParser.DivergenceDetection.ONE_WAY);
+        // region="" (present but empty) so the release contributes no region at all, keeping
+        // this case isolated to the language field only.
+        Game game = Game.builder()
+                .name("Test Game (En)")
+                .description("Test Game (En)")
+                .releases(ImmutableList.of(
+                        new Release("Test Game", "", "fr", null, YesNo.NO)))
+                .build();
+
+        ParsedGame parsedGame = gameParser.parse(datafileOf(game)).get(0);
+
+        assertEquals(1, parsedGame.getDivergences().size(),
+                "ONE_WAY must flag a genuine language mismatch (both sides non-empty, no "
+                        + "overlap), got: " + parsedGame.getDivergences());
+        ParsedGame.Divergence divergence = parsedGame.getDivergences().get(0);
+        assertEquals("language", divergence.field());
+        assertEquals(Set.of("en"), divergence.detected());
+        assertEquals(Set.of("fr"), divergence.provided());
     }
 }


### PR DESCRIPTION
Fixes #18

## What

**`datrom dat check <dat...> [--divergence <mode>]`** — surfaces the name-vs-metadata divergence detection `GameParser` always performed but only ever logged. Human-readable report grouped per DAT (game name, divergence kind, detected vs provided); exit 1 when divergences found, 0 when clean. Default mode is `one_way`; `--divergence always` is the strict escape hatch — the default was deliberately chosen after an executed probe showed `always` flags 100% of games in release-less DATs (the most common No-Intro shape).

**`1g1r --divergence <ignore|one_way|two_way|always>`** — exposes the previously hardcoded detection mode. Default `one_way` preserves today's behavior exactly.

Core seam (minimal, enumerated): `ParsedGame` gains a `divergences` list (`Divergence(field, detected, provided)` record, default empty — no call-site churn); `GameParser`'s two detect methods append entries beside their existing `log.warn` (logging unchanged); `OneGameOneRom` takes the detection mode as a constructor parameter instead of hardcoding it. The verifier grepped every `ParsedGame` usage — nothing keys on its equality, so the added field changes no behavior.

## Evidence

- Red→green proofs: both surface changes re-derived by the verifier gate with jars built at base and HEAD (`dat check`/`--divergence` rejected at base, accepted at HEAD); the ONE_WAY-default correction has its own frozen red→green (`18f7ffd6` — release-less DAT flagged under the old hardcoded `always`, clean under the new default, `--divergence always` still flags it).
- `GameParserTest` differentiates all four modes pairwise on real data; the gate's mutation (TWO_WAY collapsed into ONE_WAY's predicate) fails exactly the discriminating test.
- stdout carries only the report (jar-verified); progress/logging stay off stdout.
- Full reactor green (core 430, cli 173).

🤖 Generated by [Claude Code](https://claude.com/claude-code), posted via @andrebrait's account on their behalf.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added `dat check` to identify region and language discrepancies in DAT files.
  - Reports affected games, detected values, and DAT-provided values, with appropriate exit codes.
  - Added configurable divergence modes, including one-way, two-way, always, and ignore.
  - Added the `--divergence` option to the one-game/one-ROM command.
  - Supports case-insensitive divergence mode values with helpful validation for invalid entries.

- **Bug Fixes**
  - Divergence information is now captured and included in parsed game results when detected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->