### PR TITLE
core/cli: fetch Retool clone lists and metadata from upstream

### DIFF
--- a/cli/src/main/java/io/github/datromtool/cli/DatRomCommand.java
+++ b/cli/src/main/java/io/github/datromtool/cli/DatRomCommand.java
@@ -6,6 +6,7 @@ import io.github.datromtool.cli.argument.DatafileArgument;
 import io.github.datromtool.cli.argument.PatternsFileArgument;
 import io.github.datromtool.cli.command.DatCommand;
 import io.github.datromtool.cli.command.OneGameOneRomCommand;
+import io.github.datromtool.cli.command.RetoolCommand;
 import io.github.datromtool.cli.command.ScanCommand;
 import io.github.datromtool.cli.converter.*;
 import io.github.datromtool.config.CopyBufferSize;
@@ -27,7 +28,7 @@ import picocli.CommandLine;
         versionProvider = GitVersionProvider.class,
         mixinStandardHelpOptions = true,
         showEndOfOptionsDelimiterInUsageHelp = true,
-        subcommands = {OneGameOneRomCommand.class, DatCommand.class, ScanCommand.class})
+        subcommands = {OneGameOneRomCommand.class, DatCommand.class, ScanCommand.class, RetoolCommand.class})
 public final class DatRomCommand {
 
     @SuppressWarnings("InstantiationOfUtilityClass")

--- a/cli/src/main/java/io/github/datromtool/cli/command/OneGameOneRomCommand.java
+++ b/cli/src/main/java/io/github/datromtool/cli/command/OneGameOneRomCommand.java
@@ -39,6 +39,7 @@ import io.github.datromtool.io.FileCopier;
 import io.github.datromtool.io.FileScanner;
 import io.github.datromtool.io.logging.FileCopierLoggingListener;
 import io.github.datromtool.io.logging.FileScannerLoggingListener;
+import io.github.datromtool.retool.RetoolDownloader;
 import io.github.datromtool.retool.RetoolFileResolver;
 import lombok.Data;
 import lombok.Getter;
@@ -55,6 +56,7 @@ import tools.jackson.core.JacksonException;
 
 import javax.annotation.Nullable;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
@@ -117,6 +119,17 @@ public final class OneGameOneRomCommand implements Callable<Integer> {
     @Getter(NONE)
     @Setter(NONE)
     OneGameOneRom oneGameOneRom;
+
+    // Package-private, test-only override (issue #44 step 2): production always resolves the
+    // Retool cache base from RetoolDownloader.DEFAULT_CACHE_DIR (~/.DATROMTool/retool); tests
+    // point this at a temp directory instead so no test ever touches the real home-directory
+    // cache. Same test-only-visibility pattern as this class's own oneGameOneRom field /
+    // ScanCommand.PROGRESS_OUTPUT.
+    @ToString.Exclude
+    @JsonIgnore
+    @Getter(NONE)
+    @Setter(NONE)
+    Path retoolCacheDir = RetoolDownloader.DEFAULT_CACHE_DIR;
 
     @CommandLine.Parameters(
             description = "DAT file to use when generating the 1G1R set",
@@ -255,6 +268,34 @@ public final class OneGameOneRomCommand implements Callable<Integer> {
             throw new CommandLine.ParameterException(
                     commandSpec.commandLine(),
                     format("Could not load DAT file from profile input.dats: %s", e.getMessage()));
+        }
+        // Issue #44 step 2: when neither --clonelist/--retool-metadata nor their profile
+        // equivalents are given, fall back to the Retool update cache's directories IF they
+        // exist - the existing header-name auto-match (RetoolFileResolver#resolveFile) then
+        // applies exactly as it would for an explicitly-passed directory. An absent cache leaves
+        // both paths null, i.e. today's behavior exactly (the oracle case). Never triggers a
+        // network fetch itself - "retool update" is the only network path (RetoolUpdateCommand).
+        //
+        // Deliberately scoped to realDataFiles.size() == 1: with more than one DAT, per-DAT
+        // resolution is unsupported (see the guard just below) and the user never asked for
+        // --clonelist/--retool-metadata, so silently guessing which DAT's header the cache should
+        // match would be surprising. Skipping the fallback outright (rather than erroring, as the
+        // guard below does for an explicit flag) is the chosen behavior: an implicit,
+        // best-effort convenience should degrade to "not applied," not become a hard failure the
+        // user never opted into.
+        if (effectiveClonelistPath == null && effectiveMetadataPath == null && realDataFiles.size() == 1) {
+            Path cachedClonelists = retoolCacheDir.resolve(RetoolDownloader.CLONELISTS_DIRECTORY);
+            Path cachedMetadata = retoolCacheDir.resolve(RetoolDownloader.METADATA_DIRECTORY);
+            if (Files.isDirectory(cachedClonelists)) {
+                log.info("No {} given; falling back to the cached clone lists at '{}'",
+                        InputOptions.CLONELIST_OPTION, cachedClonelists);
+                effectiveClonelistPath = cachedClonelists;
+            }
+            if (Files.isDirectory(cachedMetadata)) {
+                log.info("No {} given; falling back to the cached metadata at '{}'",
+                        InputOptions.RETOOL_METADATA_OPTION, cachedMetadata);
+                effectiveMetadataPath = cachedMetadata;
+            }
         }
         // Review round: --clonelist/--retool-metadata (flag or profile-equivalent) resolve
         // against a single DAT header name (see the block below) - with more than one DAT

--- a/cli/src/main/java/io/github/datromtool/cli/command/OneGameOneRomCommand.java
+++ b/cli/src/main/java/io/github/datromtool/cli/command/OneGameOneRomCommand.java
@@ -289,10 +289,20 @@ public final class OneGameOneRomCommand implements Callable<Integer> {
             if (Files.isDirectory(cachedClonelists)) {
                 log.info("No {} given; falling back to the cached clone lists at '{}'",
                         InputOptions.CLONELIST_OPTION, cachedClonelists);
+                // Review round, finding 6: logback.xml routes the root logger to the FILE
+                // appender only (no console appender) - the log.info above never reaches the
+                // terminal, so a user with a stale/absent-flag cache got silently different 1G1R
+                // grouping with no on-screen indication at all. Printed to stderr (not stdout,
+                // matching RetoolUpdateCommand's own stderr progress convention) so stdout stays
+                // clean/machine-parseable.
+                System.err.printf("No %s given; using cached clone lists at '%s'%n",
+                        InputOptions.CLONELIST_OPTION, cachedClonelists);
                 effectiveClonelistPath = cachedClonelists;
             }
             if (Files.isDirectory(cachedMetadata)) {
                 log.info("No {} given; falling back to the cached metadata at '{}'",
+                        InputOptions.RETOOL_METADATA_OPTION, cachedMetadata);
+                System.err.printf("No %s given; using cached metadata at '%s'%n",
                         InputOptions.RETOOL_METADATA_OPTION, cachedMetadata);
                 effectiveMetadataPath = cachedMetadata;
             }

--- a/cli/src/main/java/io/github/datromtool/cli/command/RetoolCommand.java
+++ b/cli/src/main/java/io/github/datromtool/cli/command/RetoolCommand.java
@@ -1,0 +1,22 @@
+package io.github.datromtool.cli.command;
+
+import io.github.datromtool.cli.GitVersionProvider;
+import picocli.CommandLine;
+
+/**
+ * Command group for Retool cache operations (issue #44 step 2's {@code update} subcommand).
+ * Deliberately not {@code Callable}, mirroring {@link DatCommand} (#16): picocli's default
+ * handling of a bare group prints "Missing required subcommand" plus usage on stderr and exits
+ * with the usage code (verified for this exact shape in PR #33) - not this class's own logic to
+ * reimplement.
+ */
+@CommandLine.Command(
+        name = "retool",
+        description = "Manage the local Retool clone list / metadata cache",
+        sortOptions = false,
+        abbreviateSynopsis = true,
+        versionProvider = GitVersionProvider.class,
+        mixinStandardHelpOptions = true,
+        subcommands = {RetoolUpdateCommand.class})
+public final class RetoolCommand {
+}

--- a/cli/src/main/java/io/github/datromtool/cli/command/RetoolUpdateCommand.java
+++ b/cli/src/main/java/io/github/datromtool/cli/command/RetoolUpdateCommand.java
@@ -74,6 +74,16 @@ public final class RetoolUpdateCommand implements Callable<Integer> {
 
     @Override
     public Integer call() {
+        // Review round, finding 7: RetoolDownloader's constructor rejects a non-HTTPS baseUrl
+        // with an IllegalArgumentException - fine for a programming error, but a raw stack trace
+        // is the wrong surface for a user-supplied --base-url. Validated here, before
+        // buildDownloader() ever constructs one, so this is a clean picocli ParameterException
+        // (exit code 2) like the sibling --dir/cache-dir-creation failure just below.
+        if (!"https".equalsIgnoreCase(baseUrl.getScheme())) {
+            throw new CommandLine.ParameterException(
+                    commandSpec.commandLine(),
+                    format("--base-url must use HTTPS, got: '%s'", baseUrl));
+        }
         try {
             Files.createDirectories(dir);
         } catch (IOException e) {
@@ -83,6 +93,14 @@ public final class RetoolUpdateCommand implements Callable<Integer> {
         }
         System.err.printf("Syncing Retool clone lists/metadata from '%s' into '%s'...%n", baseUrl, dir);
         RetoolDownloader.Result result = buildDownloader().sync();
+        // Review round, finding 8: internal-config.json can retarget the sync to a different
+        // host (RetoolDownloader#resolveEffectiveBase) - the line above only ever named the
+        // *configured* base, so a retarget was invisible to the user even though a different
+        // host entirely was actually used. Surfaced here, after the sync, since the effective
+        // base is only known once RetoolDownloader has resolved it.
+        if (!result.effectiveBaseUrl().equals(baseUrl)) {
+            System.err.printf("Retargeted to '%s' per upstream internal-config.json%n", result.effectiveBaseUrl());
+        }
         System.err.println("Retool sync finished.");
         printReport(result);
         return result.hasFailures() ? 1 : 0;

--- a/cli/src/main/java/io/github/datromtool/cli/command/RetoolUpdateCommand.java
+++ b/cli/src/main/java/io/github/datromtool/cli/command/RetoolUpdateCommand.java
@@ -1,0 +1,128 @@
+package io.github.datromtool.cli.command;
+
+import io.github.datromtool.cli.GitVersionProvider;
+import io.github.datromtool.retool.RetoolDownloader;
+import picocli.CommandLine;
+
+import javax.annotation.Nullable;
+import java.io.IOException;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.Callable;
+
+import static java.lang.String.format;
+
+/**
+ * Issue #44 step 2: {@code datrom retool update} - the sole, explicit-opt-in network path that
+ * syncs Retool clone lists/metadata into the local cache via {@link RetoolDownloader}. {@code
+ * 1g1r} itself never triggers a fetch (see {@link OneGameOneRomCommand}'s cache-fallback wiring) -
+ * this command is the only place a network call can originate from, matching upstream retool's
+ * own offline-by-default posture (see the issue's design notes).
+ *
+ * <p>Prints a human-readable, per-directory report to stdout (checked/downloaded/skipped/failed
+ * counts, plus failed file names) and exits 0 when nothing failed, 1 when any file or whole
+ * directory failed - the same "0 unless something went wrong" convention {@link ScanCommand}
+ * already uses for its own report. Progress is kept simple (this can take a while on first run,
+ * downloading the full clone list/metadata set): {@link RetoolDownloader} already logs
+ * retargeting/skip/failure events at info/warn level, plus a start/finish line this command
+ * prints straight to stderr (not stdout, so the report stays machine-parseable) - no jline
+ * progress bar, since {@link RetoolDownloader} exposes no per-file listener seam to drive one
+ * (unlike {@link io.github.datromtool.io.FileScanner}/{@link io.github.datromtool.io.FileCopier}),
+ * and adding one is out of this step's scope.
+ */
+@CommandLine.Command(
+        name = "update",
+        description = "Download/update Retool clone lists and metadata into the local cache",
+        sortOptions = false,
+        abbreviateSynopsis = true,
+        versionProvider = GitVersionProvider.class,
+        mixinStandardHelpOptions = true)
+public final class RetoolUpdateCommand implements Callable<Integer> {
+
+    @CommandLine.Spec
+    private CommandLine.Model.CommandSpec commandSpec;
+
+    // Literal "(default: ...)" text in the description, not picocli's ${DEFAULT-VALUE}: probed
+    // empirically (RetoolUpdateCommandTest) that this codebase's other commands (ScanCommand's
+    // --out-mode, OneGameOneRomCommand's --divergence) already spell the default out as literal
+    // text rather than relying on ${DEFAULT-VALUE} substitution, which this project's CommandLine
+    // setup does not render (no showDefaultValues) - ${DEFAULT-VALUE} was tried first and failed
+    // the usage-text test with the placeholder left un-substituted.
+    @CommandLine.Option(
+            names = "--base-url",
+            paramLabel = "URL",
+            description = "Base URL of the retool-clonelists-metadata data repository "
+                    + "(default: " + RetoolDownloader.DEFAULT_BASE_URL + ")")
+    private URI baseUrl = URI.create(RetoolDownloader.DEFAULT_BASE_URL);
+
+    @CommandLine.Option(
+            names = "--dir",
+            paramLabel = "PATH",
+            description = "Local cache directory to sync into, created if absent "
+                    + "(default: ~/.DATROMTool/retool)")
+    private Path dir = RetoolDownloader.DEFAULT_CACHE_DIR;
+
+    // Package-private, test-only seam (no CommandLine.Option - never settable from the command
+    // line): production always uses RetoolDownloader's real, network-backed HttpFetcher (the
+    // 2-arg constructor); tests substitute a Fetcher fake here instead, exactly like
+    // RetoolDownloaderTest's own FakeFetcher, so no test ever touches the network. Mirrors
+    // OneGameOneRomCommand's retoolCacheDir / ScanCommand.PROGRESS_OUTPUT's test-only-visibility
+    // pattern.
+    @Nullable
+    RetoolDownloader.Fetcher fetcher;
+
+    @Override
+    public Integer call() {
+        try {
+            Files.createDirectories(dir);
+        } catch (IOException e) {
+            throw new CommandLine.ParameterException(
+                    commandSpec.commandLine(),
+                    format("Could not create cache directory '%s': %s", dir, e.getMessage()));
+        }
+        System.err.printf("Syncing Retool clone lists/metadata from '%s' into '%s'...%n", baseUrl, dir);
+        RetoolDownloader.Result result = buildDownloader().sync();
+        System.err.println("Retool sync finished.");
+        printReport(result);
+        return result.hasFailures() ? 1 : 0;
+    }
+
+    RetoolDownloader buildDownloader() {
+        return fetcher != null
+                ? new RetoolDownloader(baseUrl, dir, fetcher, RetoolDownloader.DEFAULT_CONCURRENCY)
+                : new RetoolDownloader(baseUrl, dir);
+    }
+
+    private static void printReport(RetoolDownloader.Result result) {
+        for (RetoolDownloader.DirectoryResult directoryResult : result.directories()) {
+            if (directoryResult.directorySkipped()) {
+                System.out.printf(
+                        "%s: skipped entire directory (%s)%n",
+                        directoryResult.directory(),
+                        directoryResult.skipReason());
+                continue;
+            }
+            System.out.printf(
+                    "%s: checked=%d downloaded=%d skipped=%d failed=%d%n",
+                    directoryResult.directory(),
+                    directoryResult.checked(),
+                    directoryResult.downloaded(),
+                    directoryResult.skipped(),
+                    directoryResult.failedFiles().size());
+            if (!directoryResult.failedFiles().isEmpty()) {
+                System.out.printf("  failed files: %s%n", String.join(", ", directoryResult.failedFiles()));
+            }
+        }
+    }
+
+    // Package-private test-only accessors (no lombok - this class isn't @Data): let tests pin
+    // --base-url/--dir parsing without duplicating picocli's own parsing logic.
+    URI getBaseUrl() {
+        return baseUrl;
+    }
+
+    Path getDir() {
+        return dir;
+    }
+}

--- a/cli/src/test/java/io/github/datromtool/cli/DatRomCommandRetoolTest.java
+++ b/cli/src/test/java/io/github/datromtool/cli/DatRomCommandRetoolTest.java
@@ -1,0 +1,35 @@
+package io.github.datromtool.cli;
+
+import io.github.datromtool.cli.command.RetoolUpdateCommand;
+import org.junit.jupiter.api.Test;
+import picocli.CommandLine;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+/**
+ * Mandatory red-first proof (issue #44 step 2): {@code retool update} must be accepted by the
+ * top-level {@code datrom} command tree. Executed RED before {@code RetoolCommand}/{@code
+ * RetoolUpdateCommand} were wired into {@link DatRomCommand#subcommands} - picocli rejected
+ * {@code "retool"} as an unmatched positional/subcommand with a {@code
+ * CommandLine.UnmatchedArgumentException} (a {@link CommandLine.ParameterException} subtype) at
+ * parse time, exactly like {@code OneGameOneRomCommandRetoolOptionsTest} pinned for {@code
+ * --clonelist}/{@code --retool-metadata} in issue #19 step 3. Frozen here byte-identical; green
+ * once the subcommand is wired.
+ */
+class DatRomCommandRetoolTest {
+
+    @Test
+    void retoolUpdateSubcommandIsAcceptedByTheCommandTree() {
+        CommandLine commandLine = new CommandLine(new DatRomCommand());
+        CommandLine.ParseResult parseResult = assertDoesNotThrow(
+                () -> commandLine.parseArgs("retool", "update"),
+                "'retool update' must be a recognized subcommand of the top-level command tree");
+        CommandLine.ParseResult retoolResult = parseResult.subcommand();
+        CommandLine.ParseResult updateResult = retoolResult.subcommand();
+        assertInstanceOf(
+                RetoolUpdateCommand.class,
+                updateResult.commandSpec().userObject(),
+                "the parsed subcommand chain must resolve to RetoolUpdateCommand");
+    }
+}

--- a/cli/src/test/java/io/github/datromtool/cli/command/OneGameOneRomCommandRetoolCacheFallbackTest.java
+++ b/cli/src/test/java/io/github/datromtool/cli/command/OneGameOneRomCommandRetoolCacheFallbackTest.java
@@ -1,0 +1,178 @@
+package io.github.datromtool.cli.command;
+
+import io.github.datromtool.cli.argument.DatafileArgument;
+import io.github.datromtool.cli.converter.DatafileConverter;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import picocli.CommandLine;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.net.URISyntaxException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Coverage matrix row 6 for issue #44 step 2: falling back to the Retool update cache's
+ * {@code clonelists}/{@code metadata} directories when neither {@code --clonelist}/
+ * {@code --retool-metadata} nor their profile equivalents are given.
+ *
+ * <p><b>Mandatory red-first proof</b> ({@link #cacheFallbackAppliesWhenNoClonelistFlagGiven}):
+ * executed RED before {@code OneGameOneRomCommand}'s {@code retoolCacheDir} field/fallback block
+ * landed - the test file did not even compile (no such field), and behaviorally there was no
+ * fallback at all. Frozen here byte-identical; green once the fallback landed.
+ *
+ * <p>Uses the same fixtures/helpers as {@link OneGameOneRomCommandRetoolTest} (that class's row 4
+ * {@code clonelistDirectoryAutoMatchesByHeaderName} already proves the header-name auto-match
+ * itself works for an explicit {@code --clonelist} directory; this class only proves the new
+ * fallback wiring reaches that same, unchanged auto-match).
+ */
+class OneGameOneRomCommandRetoolCacheFallbackTest {
+
+    private static final String[] AIR_RAIDERS_VARIANT_NAMES =
+            {"Air Raiders (USA)", "Bogey Blaster (Europe)", "Top Gun (Germany)"};
+
+    private static Path fixture(String name) {
+        try {
+            return Paths.get(OneGameOneRomCommandRetoolCacheFallbackTest.class
+                    .getClassLoader()
+                    .getResource(name)
+                    .toURI());
+        } catch (URISyntaxException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    private static CommandLine newCommandLine(OneGameOneRomCommand command) {
+        CommandLine commandLine = new CommandLine(command);
+        commandLine.registerConverter(DatafileArgument.class, new DatafileConverter());
+        return commandLine;
+    }
+
+    private static String runAndCaptureStdout(OneGameOneRomCommand command) {
+        ByteArrayOutputStream captured = new ByteArrayOutputStream();
+        PrintStream original = System.out;
+        System.setOut(new PrintStream(captured));
+        try {
+            int exitCode = command.call();
+            assertEquals(0, exitCode, "run must exit 0, captured output so far:\n" + captured);
+        } finally {
+            System.setOut(original);
+        }
+        return captured.toString();
+    }
+
+    private static int countAirRaidersVariantMatches(String output) {
+        int matches = 0;
+        for (String name : AIR_RAIDERS_VARIANT_NAMES) {
+            if (output.contains(name)) {
+                matches++;
+            }
+        }
+        return matches;
+    }
+
+    // --- Row 6(a): fallback applies when the cache dir exists and no --clonelist flag is given ---
+
+    @Test
+    void cacheFallbackAppliesWhenNoClonelistFlagGiven(@TempDir Path tempDir) throws IOException {
+        Path cacheDir = tempDir.resolve("retool");
+        Path cachedClonelists = cacheDir.resolve("clonelists");
+        Files.createDirectories(cachedClonelists);
+        Files.copy(
+                fixture("retool/clonelists/Atari - Atari 2600 (No-Intro).json"),
+                cachedClonelists.resolve("Atari - Atari 2600 (No-Intro).json"));
+
+        OneGameOneRomCommand command = new OneGameOneRomCommand();
+        command.retoolCacheDir = cacheDir;
+        CommandLine commandLine = newCommandLine(command);
+        commandLine.parseArgs(fixture("datafiles/atari-air-raiders.dat").toString());
+
+        String output = runAndCaptureStdout(command);
+
+        assertEquals(1, countAirRaidersVariantMatches(output),
+                "cache-fallback clone list must group all three variants into one 1G1R entry, got:\n" + output);
+    }
+
+    // --- Row 6(b): explicit --clonelist still wins over the cache fallback ---
+
+    @Test
+    void explicitClonelistFlagWinsOverCacheFallback(@TempDir Path tempDir) throws IOException {
+        // The cache dir exists but is empty (would fail to auto-match if it were actually used);
+        // the explicit --clonelist flag points at the real, compatible fixture. The run must
+        // succeed and group correctly, proving the flag - not the cache - is what got used.
+        Path cacheDir = tempDir.resolve("retool");
+        Files.createDirectories(cacheDir.resolve("clonelists"));
+
+        OneGameOneRomCommand command = new OneGameOneRomCommand();
+        command.retoolCacheDir = cacheDir;
+        CommandLine commandLine = newCommandLine(command);
+        commandLine.parseArgs(
+                "--clonelist", fixture("retool/clonelists/Atari - Atari 2600 (No-Intro).json").toString(),
+                fixture("datafiles/atari-air-raiders.dat").toString());
+
+        String output = runAndCaptureStdout(command);
+
+        assertEquals(1, countAirRaidersVariantMatches(output),
+                "explicit --clonelist must win over the cache fallback, got:\n" + output);
+    }
+
+    // --- Row 6(c): oracle - an absent cache dir leaves today's behavior exactly unchanged ---
+
+    @Test
+    void absentCacheDirLeavesBehaviorUnchanged(@TempDir Path tempDir) {
+        // foo-bar-family.dat declares a real cloneof relationship in the DAT itself (Bar (Europe)
+        // is cloneof Foo (USA)), so OneGameOneRom's pre-existing "DAT files lack Parent/Clone
+        // information" validation already clears without any clone list at all - unlike
+        // clean.dat/minimal.dat (single isolated entries) or atari-air-raiders.dat (which needs a
+        // clone list to group at all). The only variable under test here is retoolCacheDir
+        // pointing at a directory that was never created: the run must proceed exactly as it
+        // does with the field left at its production default.
+        OneGameOneRomCommand command = new OneGameOneRomCommand();
+        command.retoolCacheDir = tempDir.resolve("never-created");
+        CommandLine commandLine = newCommandLine(command);
+        commandLine.parseArgs(fixture("datafiles/foo-bar-family.dat").toString());
+
+        String output = runAndCaptureStdout(command);
+
+        assertFalse(output.isBlank(), "an absent cache dir must leave today's behavior exactly unchanged");
+        assertTrue(output.contains("Foo (USA)"), "output must contain the DAT's own parent entry, got:\n" + output);
+    }
+
+    // --- Row 7: multi-DAT interaction - fallback does not apply, no error, run proceeds ---
+
+    @Test
+    void cacheFallbackDoesNotApplyWithMultipleDats(@TempDir Path tempDir) throws IOException {
+        // Deliberate design choice (see OneGameOneRomCommand's fallback block Javadoc): with more
+        // than one DAT, the fallback simply does not apply (no per-DAT resolution support, and
+        // the user never asked for --clonelist/--retool-metadata) - it must NOT surface the
+        // explicit-flag multi-DAT rejection either, since no flag/fallback path is actually used.
+        Path cacheDir = tempDir.resolve("retool");
+        Path cachedClonelists = cacheDir.resolve("clonelists");
+        Files.createDirectories(cachedClonelists);
+        Files.copy(
+                fixture("retool/clonelists/Atari - Atari 2600 (No-Intro).json"),
+                cachedClonelists.resolve("Atari - Atari 2600 (No-Intro).json"));
+
+        OneGameOneRomCommand command = new OneGameOneRomCommand();
+        command.retoolCacheDir = cacheDir;
+        CommandLine commandLine = newCommandLine(command);
+        // languageless.dat has an internal cloneof relationship, so the combined DAT set is not
+        // all-parent - required for the run to clear the pre-existing "DAT files lack
+        // Parent/Clone information" validation and actually reach output (same fixture pairing
+        // OneGameOneRomCommandRetoolTest#multipleDatsWithoutClonelistOrMetadataStillProceed uses).
+        commandLine.parseArgs(
+                fixture("datafiles/minimal.dat").toString(),
+                fixture("datafiles/languageless.dat").toString());
+
+        String output = runAndCaptureStdout(command);
+
+        assertFalse(output.isBlank(), "multi-DAT run must proceed normally when the fallback is skipped, not error");
+    }
+}

--- a/cli/src/test/java/io/github/datromtool/cli/command/OneGameOneRomCommandRetoolCacheFallbackTest.java
+++ b/cli/src/test/java/io/github/datromtool/cli/command/OneGameOneRomCommandRetoolCacheFallbackTest.java
@@ -145,6 +145,73 @@ class OneGameOneRomCommandRetoolCacheFallbackTest {
         assertTrue(output.contains("Foo (USA)"), "output must contain the DAT's own parent entry, got:\n" + output);
     }
 
+    // --- CodeRabbit review round (PR #45), finding 4: only clone-list cache fallback had
+    // end-to-end coverage; a regression in the metadata half of the same fallback block stayed
+    // green. Same shape as OneGameOneRomCommandRetoolTest's
+    // retoolMetadataEnrichesLanguagelessDatSoIncludeLanguagesMatches, but via the cache fallback
+    // (retoolCacheDir) instead of an explicit --retool-metadata flag. ---
+
+    @Test
+    void metadataCacheFallbackAppliesWhenNoMetadataFlagGiven(@TempDir Path tempDir) throws IOException {
+        Path cacheDir = tempDir.resolve("retool");
+        Path cachedMetadata = cacheDir.resolve("metadata");
+        Files.createDirectories(cachedMetadata);
+        Files.copy(
+                fixture("retool/metadata/Test Metadata DAT.json"),
+                cachedMetadata.resolve("Test Metadata DAT.json"));
+
+        OneGameOneRomCommand command = new OneGameOneRomCommand();
+        command.retoolCacheDir = cacheDir;
+        CommandLine commandLine = newCommandLine(command);
+        commandLine.parseArgs(
+                "--include-languages", "en",
+                fixture("datafiles/languageless.dat").toString());
+
+        String output = runAndCaptureStdout(command);
+
+        assertTrue(
+                output.contains("Mystery Game (Japan)"),
+                "cache-fallback metadata must enrich the languageless DAT so --include-languages en "
+                        + "matches, got:\n" + output);
+    }
+
+    // --- CodeRabbit review round, finding 6: the fallback's only signal was log.info, which
+    // cli/src/main/resources/logback.xml routes to the FILE appender only - never the console -
+    // so a user running with a stale/absent-flag cache silently got different 1G1R grouping with
+    // no on-screen indication at all. A notice must reach stderr (matching RetoolUpdateCommand's
+    // own stderr progress convention), and stdout must stay clean/machine-parseable. ---
+
+    @Test
+    void cacheFallbackNoticeAppearsOnStderrNotStdout(@TempDir Path tempDir) throws IOException {
+        Path cacheDir = tempDir.resolve("retool");
+        Path cachedClonelists = cacheDir.resolve("clonelists");
+        Files.createDirectories(cachedClonelists);
+        Files.copy(
+                fixture("retool/clonelists/Atari - Atari 2600 (No-Intro).json"),
+                cachedClonelists.resolve("Atari - Atari 2600 (No-Intro).json"));
+
+        OneGameOneRomCommand command = new OneGameOneRomCommand();
+        command.retoolCacheDir = cacheDir;
+        CommandLine commandLine = newCommandLine(command);
+        commandLine.parseArgs(fixture("datafiles/atari-air-raiders.dat").toString());
+
+        ByteArrayOutputStream capturedErr = new ByteArrayOutputStream();
+        PrintStream originalErr = System.err;
+        System.setErr(new PrintStream(capturedErr));
+        String stdout;
+        try {
+            stdout = runAndCaptureStdout(command);
+        } finally {
+            System.setErr(originalErr);
+        }
+
+        String stderr = capturedErr.toString();
+        assertTrue(stderr.contains(cachedClonelists.toString()),
+                "cache fallback must be visible on stderr (console), naming the directory used, got:\n" + stderr);
+        assertFalse(stdout.contains(cachedClonelists.toString()),
+                "stdout must stay clean/machine-parseable - the fallback notice must not leak into it, got:\n" + stdout);
+    }
+
     // --- Row 7: multi-DAT interaction - fallback does not apply, no error, run proceeds ---
 
     @Test

--- a/cli/src/test/java/io/github/datromtool/cli/command/RetoolCommandTest.java
+++ b/cli/src/test/java/io/github/datromtool/cli/command/RetoolCommandTest.java
@@ -1,0 +1,46 @@
+package io.github.datromtool.cli.command;
+
+import org.junit.jupiter.api.Test;
+import picocli.CommandLine;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Coverage matrix row 5 for issue #44 step 2: {@code retool} invoked with no subcommand behaves
+ * exactly like the top-level {@code datrom} group and the {@code dat} group (#16) - picocli's
+ * default handling prints "Missing required subcommand" plus usage on stderr and exits with the
+ * usage code, keeping stdout clean. Mirrors {@link DatCommandTest} exactly - the same shape
+ * verified for {@code dat} in PR #33.
+ */
+class RetoolCommandTest {
+
+    @Test
+    void noSubcommandPrintsMissingSubcommandOnStderrAndExitsUsage() {
+        ByteArrayOutputStream capturedOut = new ByteArrayOutputStream();
+        ByteArrayOutputStream capturedErr = new ByteArrayOutputStream();
+        PrintStream originalOut = System.out;
+        PrintStream originalErr = System.err;
+        System.setOut(new PrintStream(capturedOut));
+        System.setErr(new PrintStream(capturedErr));
+        int exitCode;
+        try {
+            exitCode = new CommandLine(new RetoolCommand()).execute();
+        } finally {
+            System.setOut(originalOut);
+            System.setErr(originalErr);
+        }
+
+        assertEquals(CommandLine.ExitCode.USAGE, exitCode, "exit code must be picocli's USAGE code");
+        String err = capturedErr.toString();
+        assertTrue(err.contains("Missing required subcommand"),
+                "stderr must name the missing subcommand requirement, got:\n" + err);
+        assertTrue(err.contains("Usage:") && err.contains("update"),
+                "stderr must include usage help mentioning 'update', got:\n" + err);
+        assertEquals("", capturedOut.toString(),
+                "stdout must stay clean when no subcommand is given");
+    }
+}

--- a/cli/src/test/java/io/github/datromtool/cli/command/RetoolUpdateCommandTest.java
+++ b/cli/src/test/java/io/github/datromtool/cli/command/RetoolUpdateCommandTest.java
@@ -1,0 +1,207 @@
+package io.github.datromtool.cli.command;
+
+import io.github.datromtool.SerializationHelper;
+import io.github.datromtool.retool.RetoolDownloader;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import picocli.CommandLine;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.MessageDigest;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Coverage matrix for issue #44 step 2's {@code retool update} subcommand. {@link
+ * RetoolUpdateCommand#buildDownloader()} is the injectable seam this suite uses to reach
+ * {@link RetoolDownloader} with an in-test {@link RetoolDownloader.Fetcher} fake (via the
+ * package-private {@code fetcher} field) instead of the real network - see that field's Javadoc.
+ * No test in this class ever touches the network.
+ */
+class RetoolUpdateCommandTest {
+
+    private static final URI BASE = URI.create("https://example.test/data");
+
+    private static byte[] hashJson(Map<String, String> hashes) {
+        return SerializationHelper.getInstance().getJsonMapper().writeValueAsBytes(hashes);
+    }
+
+    private static String sha256Hex(byte[] bytes) {
+        try {
+            byte[] digest = MessageDigest.getInstance("SHA-256").digest(bytes);
+            StringBuilder sb = new StringBuilder(digest.length * 2);
+            for (byte b : digest) {
+                sb.append(String.format("%02x", b));
+            }
+            return sb.toString();
+        } catch (Exception e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    private static URI uri(String path) {
+        return URI.create(BASE + "/" + path);
+    }
+
+    private static RetoolUpdateCommand newCommand(Path dir, RetoolDownloader.Fetcher fetcher) {
+        RetoolUpdateCommand command = new RetoolUpdateCommand();
+        command.fetcher = fetcher;
+        CommandLine commandLine = new CommandLine(command);
+        commandLine.parseArgs("--base-url", BASE.toString(), "--dir", dir.toString());
+        return command;
+    }
+
+    private static String captureStdout(Runnable action) {
+        ByteArrayOutputStream captured = new ByteArrayOutputStream();
+        PrintStream original = System.out;
+        System.setOut(new PrintStream(captured));
+        try {
+            action.run();
+        } finally {
+            System.setOut(original);
+        }
+        return captured.toString();
+    }
+
+    // --- Row 4: --dir/--base-url defaults and overrides parse correctly ---
+
+    @Test
+    void defaultsAreRetoolDownloaderDefaults() {
+        RetoolUpdateCommand command = new RetoolUpdateCommand();
+        new CommandLine(command).parseArgs();
+        assertEquals(URI.create(RetoolDownloader.DEFAULT_BASE_URL), command.getBaseUrl(),
+                "--base-url default must be RetoolDownloader.DEFAULT_BASE_URL");
+        assertEquals(RetoolDownloader.DEFAULT_CACHE_DIR, command.getDir(),
+                "--dir default must be RetoolDownloader.DEFAULT_CACHE_DIR (~/.DATROMTool/retool)");
+    }
+
+    @Test
+    void usageHelpShowsResolvedDefaults() {
+        // Probe (see RetoolUpdateCommand's field Javadoc): picocli's ${DEFAULT-VALUE}
+        // interpolation left the placeholder un-substituted for this project's CommandLine setup
+        // (no showDefaultValues configured) - tried first and failed this exact assertion, which
+        // is why the descriptions spell the default out as literal text instead. Whitespace is
+        // stripped before comparing (a second probe: picocli's usage-text word wrapping hard-
+        // breaks the long base URL mid-word, with no original space at the break point, so a
+        // plain contains() check on the raw usage text fails too).
+        String usage = new CommandLine(new RetoolUpdateCommand()).getUsageMessage();
+        String usageNoWhitespace = usage.replaceAll("\\s+", "");
+        assertTrue(usageNoWhitespace.contains(RetoolDownloader.DEFAULT_BASE_URL),
+                "usage help must show the --base-url default, got:\n" + usage);
+        assertTrue(usageNoWhitespace.contains(".DATROMTool/retool"),
+                "usage help must show the --dir default, got:\n" + usage);
+    }
+
+    @Test
+    void baseUrlAndDirOverridesParseCorrectly(@TempDir Path tempDir) {
+        Path customDir = tempDir.resolve("custom-cache");
+        URI customBaseUrl = URI.create("https://custom.example/data");
+        RetoolUpdateCommand command = new RetoolUpdateCommand();
+        new CommandLine(command).parseArgs("--base-url", customBaseUrl.toString(), "--dir", customDir.toString());
+        assertEquals(customBaseUrl, command.getBaseUrl());
+        assertEquals(customDir, command.getDir());
+    }
+
+    // --- Row 2/3: end-to-end against the in-test Fetcher fake; report content; exit codes ---
+
+    @Test
+    void endToEndSyncPrintsCountsAndExitsZeroWhenNothingFailed(@TempDir Path tempDir) throws IOException {
+        FakeFetcher fetcher = new FakeFetcher();
+        fetcher.stub(uri("config/internal-config.json"), "{}");
+        byte[] content = "hello\n".getBytes(StandardCharsets.UTF_8);
+        fetcher.stub(uri("clonelists/hash.json"), hashJson(Map.of("foo.json", sha256Hex(content))));
+        fetcher.stub(uri("clonelists/foo.json"), content);
+        fetcher.stub(uri("metadata/hash.json"), hashJson(Map.of()));
+
+        RetoolUpdateCommand command = newCommand(tempDir, fetcher);
+        int[] exitCode = new int[1];
+        String stdout = captureStdout(() -> exitCode[0] = command.call());
+
+        assertEquals(0, exitCode[0], "nothing failed, must exit 0");
+        assertTrue(stdout.contains("clonelists: checked=1 downloaded=1 skipped=0 failed=0"),
+                "report must contain clonelists counts, got:\n" + stdout);
+        assertTrue(stdout.contains("metadata: checked=0 downloaded=0 skipped=0 failed=0"),
+                "report must contain metadata counts, got:\n" + stdout);
+        assertTrue(Files.isRegularFile(tempDir.resolve("clonelists").resolve("foo.json")),
+                "the synced file must actually exist on disk");
+    }
+
+    @Test
+    void failedFileNamesAppearInReportAndExitCodeIsOne(@TempDir Path tempDir) throws IOException {
+        FakeFetcher fetcher = new FakeFetcher();
+        fetcher.stub(uri("config/internal-config.json"), "{}");
+        fetcher.stub(uri("clonelists/hash.json"),
+                hashJson(Map.of("missing.json", sha256Hex("irrelevant".getBytes(StandardCharsets.UTF_8)))));
+        fetcher.notFound(uri("clonelists/missing.json"));
+        fetcher.stub(uri("metadata/hash.json"), hashJson(Map.of()));
+
+        RetoolUpdateCommand command = newCommand(tempDir, fetcher);
+        int[] exitCode = new int[1];
+        String stdout = captureStdout(() -> exitCode[0] = command.call());
+
+        assertEquals(1, exitCode[0], "a failed file must exit 1");
+        assertTrue(stdout.contains("failed files: missing.json"),
+                "report must name the failed file, got:\n" + stdout);
+    }
+
+    @Test
+    void dirIsCreatedWhenAbsent(@TempDir Path tempDir) throws IOException {
+        Path notYetCreated = tempDir.resolve("does-not-exist-yet").resolve("retool");
+        FakeFetcher fetcher = new FakeFetcher();
+        fetcher.stub(uri("config/internal-config.json"), "{}");
+        fetcher.stub(uri("clonelists/hash.json"), hashJson(Map.of()));
+        fetcher.stub(uri("metadata/hash.json"), hashJson(Map.of()));
+
+        RetoolUpdateCommand command = newCommand(notYetCreated, fetcher);
+        captureStdout(command::call);
+
+        assertTrue(Files.isDirectory(notYetCreated), "--dir must be created if it did not already exist");
+    }
+
+    /**
+     * Same in-memory {@link RetoolDownloader.Fetcher} test double shape as {@code
+     * RetoolDownloaderTest}'s own {@code FakeFetcher} (core module) - duplicated here rather than
+     * shared across modules since it is a handful of lines and {@code cli} has no existing
+     * test-fixture dependency on {@code core}'s test-jar.
+     */
+    private static final class FakeFetcher implements RetoolDownloader.Fetcher {
+
+        private final Map<URI, byte[]> responses = new LinkedHashMap<>();
+        private final Set<URI> notFoundUris = new HashSet<>();
+
+        void stub(URI uri, byte[] body) {
+            responses.put(uri, body);
+        }
+
+        void stub(URI uri, String body) {
+            stub(uri, body.getBytes(StandardCharsets.UTF_8));
+        }
+
+        void notFound(URI uri) {
+            notFoundUris.add(uri);
+        }
+
+        @Override
+        public byte[] fetch(URI uri) throws IOException {
+            if (notFoundUris.contains(uri)) {
+                throw new RetoolDownloader.HttpStatusException(uri, 404);
+            }
+            byte[] body = responses.get(uri);
+            if (body == null) {
+                throw new IOException("No stub registered for " + uri);
+            }
+            return body;
+        }
+    }
+}

--- a/cli/src/test/java/io/github/datromtool/cli/command/RetoolUpdateCommandTest.java
+++ b/cli/src/test/java/io/github/datromtool/cli/command/RetoolUpdateCommandTest.java
@@ -169,6 +169,54 @@ class RetoolUpdateCommandTest {
         assertTrue(Files.isDirectory(notYetCreated), "--dir must be created if it did not already exist");
     }
 
+    // --- CodeRabbit review round (PR #45), finding 7: a non-HTTPS --base-url must surface as a
+    // clean picocli ParameterException (exit code 2, like the sibling --dir/cache-dir-creation
+    // failure just above), not an IllegalArgumentException raw stack trace escaping from
+    // RetoolDownloader's constructor. ---
+
+    @Test
+    void nonHttpsBaseUrlSurfacesAsParameterExceptionExitCode2(@TempDir Path tempDir) {
+        ByteArrayOutputStream capturedErr = new ByteArrayOutputStream();
+        PrintStream originalErr = System.err;
+        System.setErr(new PrintStream(capturedErr));
+        int exitCode;
+        try {
+            exitCode = new CommandLine(new RetoolUpdateCommand())
+                    .execute("--base-url", "http://insecure.example/data", "--dir", tempDir.toString());
+        } finally {
+            System.setErr(originalErr);
+        }
+        assertEquals(2, exitCode, "a non-HTTPS --base-url must exit 2, stderr was:\n" + capturedErr);
+        assertTrue(capturedErr.toString().contains("HTTPS"),
+                "error must name HTTPS as the requirement, got:\n" + capturedErr);
+    }
+
+    // --- CodeRabbit review round, finding 8: internal-config.json's cloneListMetadataUrl can
+    // retarget the sync to a different host; printing only the originally-configured base (as
+    // this command did before this fix) means the user never sees which host was actually used. ---
+
+    @Test
+    void retargetedBaseUrlIsSurfacedOnStderr(@TempDir Path tempDir) throws IOException {
+        URI overrideBase = URI.create("https://override.example/other");
+        FakeFetcher fetcher = new FakeFetcher();
+        fetcher.stub(uri("config/internal-config.json"), hashJson(Map.of("cloneListMetadataUrl", overrideBase.toString())));
+        fetcher.stub(URI.create(overrideBase + "/clonelists/hash.json"), hashJson(Map.of()));
+        fetcher.stub(URI.create(overrideBase + "/metadata/hash.json"), hashJson(Map.of()));
+
+        RetoolUpdateCommand command = newCommand(tempDir, fetcher);
+        ByteArrayOutputStream capturedErr = new ByteArrayOutputStream();
+        PrintStream originalErr = System.err;
+        System.setErr(new PrintStream(capturedErr));
+        try {
+            captureStdout(command::call);
+        } finally {
+            System.setErr(originalErr);
+        }
+
+        assertTrue(capturedErr.toString().contains(overrideBase.toString()),
+                "stderr must surface the actually-used (retargeted) base URL, got:\n" + capturedErr);
+    }
+
     /**
      * Same in-memory {@link RetoolDownloader.Fetcher} test double shape as {@code
      * RetoolDownloaderTest}'s own {@code FakeFetcher} (core module) - duplicated here rather than

--- a/core/src/main/java/io/github/datromtool/retool/RetoolDownloader.java
+++ b/core/src/main/java/io/github/datromtool/retool/RetoolDownloader.java
@@ -9,6 +9,7 @@ import tools.jackson.databind.json.JsonMapper;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
@@ -74,9 +75,22 @@ public final class RetoolDownloader {
     public static final String DEFAULT_BASE_URL =
             "https://raw.githubusercontent.com/unexpectedpanda/retool-clonelists-metadata/main";
 
-    private static final List<String> SYNCED_DIRECTORIES = List.of("clonelists", "metadata");
+    /** Directory names within the cache/upstream repo - also the names {@code cli}'s 1G1R
+     * command uses for its cache-fallback directories (issue #44 step 2), kept as one source of
+     * truth rather than a second hardcoded copy of these literals. */
+    public static final String CLONELISTS_DIRECTORY = "clonelists";
+    public static final String METADATA_DIRECTORY = "metadata";
 
-    private static final int DEFAULT_CONCURRENCY = 10;
+    private static final List<String> SYNCED_DIRECTORIES =
+            List.of(CLONELISTS_DIRECTORY, METADATA_DIRECTORY);
+
+    /** {@code ~/.DATROMTool/retool} - beside the existing {@code config.yaml}/
+     * {@code region-data.yaml} (issue #44 step 2's default {@code --dir} and 1G1R's cache-fallback
+     * base), reusing {@link SerializationHelper#DEFAULT_BASE_PATH} rather than a second hardcoded
+     * copy of {@code .DATROMTool}. */
+    public static final Path DEFAULT_CACHE_DIR = SerializationHelper.DEFAULT_BASE_PATH.resolve("retool");
+
+    public static final int DEFAULT_CONCURRENCY = 10;
 
     /** A few bounded attempts on transport failure, per the issue's error policy; a 404 never
      * retries (see {@link #fetchWithRetry}). Upstream retries 5 times with a fixed 5s sleep; a
@@ -479,6 +493,14 @@ public final class RetoolDownloader {
         private static final Duration CONNECT_TIMEOUT = Duration.ofSeconds(10);
         private static final Duration REQUEST_TIMEOUT = Duration.ofSeconds(30);
 
+        /** A3 (issue #44 step 2 gate finding): the largest real upstream file is ~53KB (per the
+         * issue), so 32MB is generous headroom while still bounding memory use against a
+         * misbehaving/malicious server streaming an unbounded response - {@link
+         * HttpResponse.BodyHandlers#ofByteArray} previously buffered a response fully before this
+         * class got any chance to check its size. Enforced by {@link #readBounded} while the body
+         * is still being streamed, not after the fact. */
+        private static final long MAX_RESPONSE_BYTES = 32L * 1024 * 1024;
+
         private final HttpClient client;
         private final String userAgent;
 
@@ -503,16 +525,42 @@ public final class RetoolDownloader {
                     .GET()
                     .build();
             try {
-                HttpResponse<byte[]> response = client.send(request, HttpResponse.BodyHandlers.ofByteArray());
+                HttpResponse<InputStream> response = client.send(request, HttpResponse.BodyHandlers.ofInputStream());
                 int status = response.statusCode();
-                if (status < 200 || status >= 300) {
-                    throw new HttpStatusException(uri, status);
+                try (InputStream body = response.body()) {
+                    if (status < 200 || status >= 300) {
+                        throw new HttpStatusException(uri, status);
+                    }
+                    return readBounded(body, MAX_RESPONSE_BYTES, uri);
                 }
-                return response.body();
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
                 throw new IOException(format("Interrupted while fetching '%s'", uri), e);
             }
+        }
+
+        /**
+         * Reads {@code in} fully into a byte array, throwing {@link IOException} as soon as more
+         * than {@code maxBytes} have been read - never buffering past the cap - rather than
+         * reading an unbounded response and only checking its size afterward. Package-visible and
+         * parameterized on {@code maxBytes} (rather than hardcoding {@link #MAX_RESPONSE_BYTES}
+         * internally) so it is unit-testable with a small cap and a cheap synthetic stream,
+         * without needing an actual multi-megabyte payload or any real network/socket.
+         */
+        static byte[] readBounded(InputStream in, long maxBytes, URI uri) throws IOException {
+            java.io.ByteArrayOutputStream buffer = new java.io.ByteArrayOutputStream();
+            byte[] chunk = new byte[8192];
+            long total = 0;
+            int read;
+            while ((read = in.read(chunk)) != -1) {
+                total += read;
+                if (total > maxBytes) {
+                    throw new IOException(format(
+                            "Response body for '%s' exceeded the %d-byte cap", uri, maxBytes));
+                }
+                buffer.write(chunk, 0, read);
+            }
+            return buffer.toByteArray();
         }
     }
 

--- a/core/src/main/java/io/github/datromtool/retool/RetoolDownloader.java
+++ b/core/src/main/java/io/github/datromtool/retool/RetoolDownloader.java
@@ -1,0 +1,539 @@
+package io.github.datromtool.retool;
+
+import com.google.common.collect.ImmutableList;
+import io.github.datromtool.SerializationHelper;
+import lombok.extern.slf4j.Slf4j;
+import tools.jackson.core.type.TypeReference;
+import tools.jackson.databind.json.JsonMapper;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static java.lang.String.format;
+
+/**
+ * Syncs Retool {@code clonelists} and {@code metadata} from the {@code retool-clonelists-
+ * metadata} data repository (issue #44 step 1) into a local cache directory, downloading only
+ * files whose sha256 differs from the published {@code hash.json} manifest - mirroring retool
+ * v2.4.9's own update mechanism ({@code modules/clone_lists/update_clone_list_metadata.py}),
+ * verified against its source rather than its docs (see the issue for line references).
+ *
+ * <p><b>Scope (this step):</b> only {@code clonelists} and {@code metadata} are synced, not
+ * upstream's {@code mias}/{@code retroachievements} directories - out of scope for this
+ * codebase's current Retool integration (issue #19), which only consumes clone lists and
+ * metadata. Add them as their own {@link #SYNCED_DIRECTORIES} entries if/when a future issue
+ * wires them up; nothing else in this class is directory-specific.
+ *
+ * <p><b>Concurrency:</b> a bounded {@link ExecutorService} (fixed pool, default {@link
+ * #DEFAULT_CONCURRENCY} threads - upstream's own parallel-download count), created fresh per
+ * {@link #sync()} call and closed at the end, mirroring {@code FileScanner}/{@code FileCopier}'s
+ * per-call executor lifecycle in {@code io}. Unlike those, this closes it via Java 19+'s
+ * {@link ExecutorService#close()} (try-with-resources) rather than a manual shutdown dance - a
+ * newer, equivalent idiom this codebase's Java 25 baseline allows and no existing caller here
+ * needs to match byte-for-byte.
+ *
+ * <p><b>Testability:</b> all network access goes through the injectable {@link Fetcher} seam
+ * (constructor parameter), so tests never touch the network. The default {@link HttpFetcher}
+ * exists for real use; tests instead pass an in-test fake (a {@code Map}-backed stub recording
+ * every {@link URI} it was asked to fetch) rather than standing up a real {@code
+ * com.sun.net.httpserver.HttpServer} socket - a fake gives byte-for-byte control over per-URI
+ * responses/404s/transport failures with no ephemeral-port binding, which is one more source of
+ * flakiness on this project's cross-OS CI matrix (ubuntu/macos/windows) for no behavioral gain:
+ * {@link Fetcher} is a one-method seam, so a real socket would only re-verify the JDK's own
+ * {@code HttpClient}, not this class's sync logic.
+ */
+@Slf4j
+public final class RetoolDownloader {
+
+    /**
+     * Upstream's hardcoded fallback base URL ({@code constants.py:3-5}), overridable at runtime
+     * by the fetched {@code internal-config.json}'s {@code cloneListMetadataUrl} - see
+     * {@link #resolveEffectiveBase()}.
+     */
+    public static final String DEFAULT_BASE_URL =
+            "https://raw.githubusercontent.com/unexpectedpanda/retool-clonelists-metadata/main";
+
+    private static final List<String> SYNCED_DIRECTORIES = List.of("clonelists", "metadata");
+
+    private static final int DEFAULT_CONCURRENCY = 10;
+
+    /** A few bounded attempts on transport failure, per the issue's error policy; a 404 never
+     * retries (see {@link #fetchWithRetry}). Upstream retries 5 times with a fixed 5s sleep; a
+     * fixed 5s sleep would make the default suite take minutes, so this uses a much shorter
+     * delay - the *policy* (bounded retries, fixed delay, then fail) is what's being ported, not
+     * upstream's literal timing, which was never a contract callers depend on. */
+    private static final int MAX_ATTEMPTS = 3;
+    private static final Duration RETRY_DELAY = Duration.ofMillis(200);
+
+    private final URI baseUrl;
+    private final Path cacheDir;
+    private final Fetcher fetcher;
+    private final int concurrency;
+    private final JsonMapper jsonMapper;
+
+    public RetoolDownloader(@Nonnull URI baseUrl, @Nonnull Path cacheDir) {
+        this(baseUrl, cacheDir, new HttpFetcher(), DEFAULT_CONCURRENCY);
+    }
+
+    public RetoolDownloader(
+            @Nonnull URI baseUrl,
+            @Nonnull Path cacheDir,
+            @Nonnull Fetcher fetcher,
+            int concurrency) {
+        if (!"https".equalsIgnoreCase(baseUrl.getScheme())) {
+            throw new IllegalArgumentException(
+                    format("Retool base URL must use HTTPS, got: '%s'", baseUrl));
+        }
+        if (concurrency <= 0) {
+            throw new IllegalArgumentException("concurrency must be positive, got: " + concurrency);
+        }
+        this.baseUrl = baseUrl;
+        this.cacheDir = cacheDir;
+        this.fetcher = fetcher;
+        this.concurrency = concurrency;
+        this.jsonMapper = SerializationHelper.getInstance().getJsonMapper();
+    }
+
+    /**
+     * Syncs every entry in {@link #SYNCED_DIRECTORIES}, returning a per-directory accounting of
+     * what happened. Never throws for a single file/directory failure - those are recorded in the
+     * returned {@link Result} (see the issue's error policy) - it only propagates if the sync
+     * thread itself is interrupted.
+     */
+    @Nonnull
+    public Result sync() {
+        URI effectiveBase = resolveEffectiveBase();
+        ThreadFactory threadFactory = new NamedThreadFactory("RETOOL-DOWNLOADER");
+        ImmutableList.Builder<DirectoryResult> results = ImmutableList.builder();
+        try (ExecutorService executorService = Executors.newFixedThreadPool(concurrency, threadFactory)) {
+            for (String directory : SYNCED_DIRECTORIES) {
+                results.add(syncDirectory(executorService, effectiveBase, directory));
+            }
+        }
+        return new Result(results.build());
+    }
+
+    /**
+     * Fetches {@code {base}/config/internal-config.json} and honors its {@code
+     * cloneListMetadataUrl} key if present, non-blank, different from the configured base, and
+     * itself HTTPS (kept simple per the issue: no recursive re-resolution, no further validation
+     * beyond scheme). Any failure to fetch/parse the config (missing file, transport error,
+     * malformed JSON) is logged and falls back to the originally configured base URL - the
+     * config's whole purpose is retargeting an already-working sync, so a failure here must never
+     * abort the run.
+     */
+    private URI resolveEffectiveBase() {
+        URI configUri = join(baseUrl, "config", "internal-config.json");
+        try {
+            byte[] configBytes = fetchWithRetry(configUri);
+            Map<String, Object> config = jsonMapper.readValue(configBytes, new TypeReference<Map<String, Object>>() {
+            });
+            Object override = config.get("cloneListMetadataUrl");
+            if (override instanceof String overrideUrl
+                    && !overrideUrl.isBlank()
+                    && !overrideUrl.equals(baseUrl.toString())) {
+                URI overrideUri = URI.create(overrideUrl);
+                if ("https".equalsIgnoreCase(overrideUri.getScheme())) {
+                    log.info("Retargeting Retool sync base URL per internal-config.json: '{}'", overrideUrl);
+                    return overrideUri;
+                }
+                log.warn("Ignoring non-HTTPS cloneListMetadataUrl override '{}'", overrideUrl);
+            }
+        } catch (Exception e) {
+            log.warn("Could not fetch/parse '{}'; using configured base URL '{}'", configUri, baseUrl, e);
+        }
+        return baseUrl;
+    }
+
+    /**
+     * Syncs one directory: fetches its {@code hash.json} manifest (the list of files to sync -
+     * upstream never enumerates the directory itself), then dispatches one bounded task per
+     * manifest entry. A missing/unparseable {@code hash.json} skips only this directory - other
+     * directories still run (per the issue's error policy) - recorded via {@link
+     * DirectoryResult#skipped}.
+     */
+    private DirectoryResult syncDirectory(ExecutorService executorService, URI base, String directory) {
+        URI hashUri = join(base, directory, "hash.json");
+        Map<String, String> hashes;
+        try {
+            byte[] hashBytes = fetchWithRetry(hashUri);
+            hashes = jsonMapper.readValue(hashBytes, new TypeReference<Map<String, String>>() {
+            });
+            if (hashes == null) {
+                throw new IOException("hash.json parsed to null");
+            }
+        } catch (Exception e) {
+            log.warn("Skipping directory '{}': could not fetch/parse '{}'", directory, hashUri, e);
+            return DirectoryResult.skipped(directory, format("Could not fetch/parse hash.json: %s", e.getMessage()));
+        }
+
+        Path dirPath = cacheDir.resolve(directory);
+        try {
+            Files.createDirectories(dirPath);
+        } catch (IOException e) {
+            log.warn("Skipping directory '{}': could not create cache directory '{}'", directory, dirPath, e);
+            return DirectoryResult.skipped(directory, format("Could not create cache directory: %s", e.getMessage()));
+        }
+
+        List<Callable<FileOutcome>> tasks = hashes.entrySet().stream()
+                .map(entry -> (Callable<FileOutcome>) () ->
+                        syncFile(base, directory, dirPath, entry.getKey(), entry.getValue()))
+                .toList();
+
+        int downloaded = 0;
+        int skipped = 0;
+        ImmutableList.Builder<String> failed = ImmutableList.builder();
+        try {
+            List<Future<FileOutcome>> futures = executorService.invokeAll(tasks);
+            for (Future<FileOutcome> future : futures) {
+                FileOutcome outcome = future.get();
+                switch (outcome.status()) {
+                    case DOWNLOADED -> downloaded++;
+                    case SKIPPED -> skipped++;
+                    case FAILED -> failed.add(outcome.fileName());
+                }
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException(format("Interrupted while syncing directory '%s'", directory), e);
+        } catch (ExecutionException e) {
+            // syncFile() never lets a checked/unchecked exception escape - every failure path
+            // returns FileOutcome.failed(...) - so this can only mean a programming error.
+            throw new IllegalStateException(
+                    format("Unexpected task failure while syncing directory '%s'", directory), e.getCause());
+        }
+        return new DirectoryResult(directory, hashes.size(), downloaded, skipped, failed.build(), false, null);
+    }
+
+    /**
+     * Downloads one manifest entry if needed (missing locally, or present with a mismatching
+     * hash - see {@link #needsDownload}), writing it atomically (see {@link #atomicWrite}) so an
+     * interrupted run cannot leave a truncated file that later parses as corrupt. Every failure
+     * path is caught and converted to {@link FileOutcome#failed} - this method is invoked as an
+     * {@link ExecutorService} task and must never let an exception escape, or one bad file would
+     * poison {@link ExecutorService#invokeAll} for the whole directory.
+     */
+    private FileOutcome syncFile(URI base, String directory, Path dirPath, String fileName, String expectedHash) {
+        if (isUnsafeFileName(fileName)) {
+            log.warn("Refusing to sync unsafe file name '{}' from directory '{}' manifest", fileName, directory);
+            return FileOutcome.failed(fileName);
+        }
+        Path localFile = dirPath.resolve(fileName);
+        try {
+            if (!needsDownload(localFile, expectedHash)) {
+                return FileOutcome.skipped(fileName);
+            }
+            URI fileUri = join(base, directory, percentEncodeSegment(fileName));
+            byte[] content = fetchWithRetry(fileUri);
+            atomicWrite(localFile, content);
+            return FileOutcome.downloaded(fileName);
+        } catch (Exception e) {
+            log.warn("Failed to sync '{}/{}'", directory, fileName, e);
+            return FileOutcome.failed(fileName);
+        }
+    }
+
+    // Manifest entries are file names from the (semi-trusted) configured upstream, not user
+    // input - but a compromised/misconfigured source publishing "../../evil" as a key must not
+    // be able to write outside the cache directory, so the same bare-name shape check
+    // RetoolFileResolver applies to DAT header names applies here too.
+    private static boolean isUnsafeFileName(String fileName) {
+        return fileName.isEmpty()
+                || fileName.contains("/")
+                || fileName.contains("\\")
+                || fileName.equals("..")
+                || fileName.equals(".");
+    }
+
+    /**
+     * {@code true} if {@code localFile} is absent, or its LF-normalized bytes (see {@link
+     * #normalizeLineEndings}) hash to something other than {@code expectedHash} (case-
+     * insensitive) - replicating upstream's CRLF-to-LF rewrite-before-hash so hashes computed
+     * here match the published manifest for a byte-identical file saved with CRLF line endings.
+     * Never rewrites {@code localFile} itself - only the in-memory bytes used for hashing are
+     * normalized.
+     */
+    private boolean needsDownload(Path localFile, String expectedHash) {
+        if (!Files.isRegularFile(localFile)) {
+            return true;
+        }
+        try {
+            byte[] raw = Files.readAllBytes(localFile);
+            byte[] normalized = normalizeLineEndings(raw);
+            String actualHash = sha256Hex(normalized);
+            return !actualHash.equalsIgnoreCase(expectedHash);
+        } catch (IOException e) {
+            log.warn("Could not read local file '{}' for hash comparison; will re-download", localFile, e);
+            return true;
+        }
+    }
+
+    private static byte[] normalizeLineEndings(byte[] bytes) {
+        java.io.ByteArrayOutputStream out = new java.io.ByteArrayOutputStream(bytes.length);
+        for (int i = 0; i < bytes.length; i++) {
+            byte b = bytes[i];
+            if (b == '\r' && i + 1 < bytes.length && bytes[i + 1] == '\n') {
+                continue; // drop the \r, the following \n is written on the next iteration
+            }
+            out.write(b);
+        }
+        return out.toByteArray();
+    }
+
+    private static String sha256Hex(byte[] bytes) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] hash = digest.digest(bytes);
+            StringBuilder sb = new StringBuilder(hash.length * 2);
+            for (byte b : hash) {
+                sb.append(format("%02x", b));
+            }
+            return sb.toString();
+        } catch (NoSuchAlgorithmException e) {
+            // SHA-256 is a mandatory JDK algorithm (java.security.MessageDigest javadoc) - this
+            // can only mean a broken JDK installation, not a reachable runtime condition.
+            throw new IllegalStateException("SHA-256 not available", e);
+        }
+    }
+
+    // Temp file + atomic move within the same directory (same filesystem, so ATOMIC_MOVE is
+    // always honored) - an interrupted write leaves only an orphaned .tmp file, never a
+    // truncated/corrupt localFile.
+    private static void atomicWrite(Path localFile, byte[] content) throws IOException {
+        Path tmp = Files.createTempFile(localFile.getParent(), localFile.getFileName().toString(), ".tmp");
+        try {
+            Files.write(tmp, content);
+            Files.move(tmp, localFile, StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE);
+        } catch (IOException e) {
+            Files.deleteIfExists(tmp);
+            throw e;
+        }
+    }
+
+    /**
+     * Fetches {@code uri}, retrying transport failures up to {@link #MAX_ATTEMPTS} times with a
+     * fixed delay, but never retrying a 404 ({@link HttpStatusException} with {@link
+     * HttpStatusException#statusCode()} {@code == 404}) - it means the file was intentionally
+     * removed/renamed upstream, not a transient failure, exactly like upstream's own "404 -> warn
+     * and skip, no retry" policy.
+     */
+    private byte[] fetchWithRetry(URI uri) throws IOException {
+        IOException last = null;
+        for (int attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+            try {
+                return fetcher.fetch(uri);
+            } catch (HttpStatusException e) {
+                if (e.statusCode() == 404) {
+                    throw e;
+                }
+                last = e;
+            } catch (IOException e) {
+                last = e;
+            }
+            if (attempt < MAX_ATTEMPTS) {
+                sleepBeforeRetry();
+            }
+        }
+        throw last;
+    }
+
+    private static void sleepBeforeRetry() {
+        try {
+            Thread.sleep(RETRY_DELAY.toMillis());
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException("Interrupted during retry backoff", e);
+        }
+    }
+
+    private static URI join(URI base, String... segments) {
+        StringBuilder sb = new StringBuilder(base.toString());
+        if (sb.isEmpty() || sb.charAt(sb.length() - 1) != '/') {
+            sb.append('/');
+        }
+        for (int i = 0; i < segments.length; i++) {
+            if (i > 0) {
+                sb.append('/');
+            }
+            sb.append(segments[i]);
+        }
+        return URI.create(sb.toString());
+    }
+
+    /**
+     * Percent-encodes {@code segment} (a file's bare name, i.e. the URI's last path segment) per
+     * RFC 3986's unreserved-character set ({@code ALPHA / DIGIT / "-" / "." / "_" / "~"}) -
+     * everything else becomes a {@code %XX} UTF-8 byte escape. Deliberately not {@link
+     * java.net.URLEncoder}: it is an {@code application/x-www-form-urlencoded} encoder, not an
+     * RFC 3986 one - it emits {@code +} for space instead of {@code %20}, which upstream's own
+     * {@code urllib.parse.quote}-based encoding (and raw.githubusercontent.com's own URL parsing)
+     * does not accept as a space.
+     */
+    private static String percentEncodeSegment(String segment) {
+        byte[] bytes = segment.getBytes(StandardCharsets.UTF_8);
+        StringBuilder sb = new StringBuilder(bytes.length);
+        for (byte b : bytes) {
+            int c = b & 0xFF;
+            if ((c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9')
+                    || c == '-' || c == '.' || c == '_' || c == '~') {
+                sb.append((char) c);
+            } else {
+                sb.append('%').append(format("%02X", c));
+            }
+        }
+        return sb.toString();
+    }
+
+    /** A single {@code fileName -> outcome} result from {@link #syncFile}. */
+    private record FileOutcome(Status status, String fileName) {
+        enum Status {DOWNLOADED, SKIPPED, FAILED}
+
+        static FileOutcome downloaded(String fileName) {
+            return new FileOutcome(Status.DOWNLOADED, fileName);
+        }
+
+        static FileOutcome skipped(String fileName) {
+            return new FileOutcome(Status.SKIPPED, fileName);
+        }
+
+        static FileOutcome failed(String fileName) {
+            return new FileOutcome(Status.FAILED, fileName);
+        }
+    }
+
+    /**
+     * One directory's sync outcome. {@code checked} is the manifest's entry count (0 if the
+     * directory was skipped outright); {@code downloaded + skipped + failedFiles.size()} always
+     * equals {@code checked} for a processed (non-skipped) directory.
+     */
+    public record DirectoryResult(
+            String directory,
+            int checked,
+            int downloaded,
+            int skipped,
+            ImmutableList<String> failedFiles,
+            boolean directorySkipped,
+            @Nullable String skipReason) {
+
+        static DirectoryResult skipped(String directory, String reason) {
+            return new DirectoryResult(directory, 0, 0, 0, ImmutableList.of(), true, reason);
+        }
+    }
+
+    /** The overall sync outcome - one {@link DirectoryResult} per {@link #SYNCED_DIRECTORIES} entry. */
+    public record Result(ImmutableList<DirectoryResult> directories) {
+
+        public boolean hasFailures() {
+            return directories.stream()
+                    .anyMatch(d -> d.directorySkipped() || !d.failedFiles().isEmpty());
+        }
+    }
+
+    /** The injectable network seam - see this class's Javadoc for why tests fake this instead of the network. */
+    public interface Fetcher {
+        byte[] fetch(URI uri) throws IOException;
+    }
+
+    /** A non-2xx HTTP response, carrying the status code so callers can special-case 404. */
+    public static final class HttpStatusException extends IOException {
+        private final int statusCode;
+
+        public HttpStatusException(URI uri, int statusCode) {
+            super(format("HTTP %d fetching '%s'", statusCode, uri));
+            this.statusCode = statusCode;
+        }
+
+        public int statusCode() {
+            return statusCode;
+        }
+    }
+
+    /**
+     * The default, real-network {@link Fetcher}: JDK {@link HttpClient} with explicit connect/
+     * read timeouts and an honest User-Agent identifying this tool (unlike upstream, which spoofs
+     * a Chrome User-Agent - see the issue's design notes).
+     */
+    public static final class HttpFetcher implements Fetcher {
+
+        private static final Duration CONNECT_TIMEOUT = Duration.ofSeconds(10);
+        private static final Duration REQUEST_TIMEOUT = Duration.ofSeconds(30);
+
+        private final HttpClient client;
+        private final String userAgent;
+
+        public HttpFetcher() {
+            this.client = HttpClient.newBuilder()
+                    .connectTimeout(CONNECT_TIMEOUT)
+                    .followRedirects(HttpClient.Redirect.NORMAL)
+                    .build();
+            this.userAgent = buildUserAgent();
+        }
+
+        private static String buildUserAgent() {
+            String version = SerializationHelper.getInstance().getVersionString();
+            return format("DATROMTool/%s", version != null ? version : "unknown");
+        }
+
+        @Override
+        public byte[] fetch(URI uri) throws IOException {
+            HttpRequest request = HttpRequest.newBuilder(uri)
+                    .header("User-Agent", userAgent)
+                    .timeout(REQUEST_TIMEOUT)
+                    .GET()
+                    .build();
+            try {
+                HttpResponse<byte[]> response = client.send(request, HttpResponse.BodyHandlers.ofByteArray());
+                int status = response.statusCode();
+                if (status < 200 || status >= 300) {
+                    throw new HttpStatusException(uri, status);
+                }
+                return response.body();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new IOException(format("Interrupted while fetching '%s'", uri), e);
+            }
+        }
+    }
+
+    // io.github.datromtool.io.IndexedThreadFactory is package-private to io.github.datromtool.io
+    // and not reusable here; this is the same daemon-thread-with-logged-uncaught-handler shape,
+    // scoped locally instead.
+    private static final class NamedThreadFactory implements ThreadFactory {
+
+        private final String namePrefix;
+        private final AtomicInteger indexCounter = new AtomicInteger(1);
+
+        private NamedThreadFactory(String namePrefix) {
+            this.namePrefix = namePrefix;
+        }
+
+        @Override
+        public Thread newThread(@Nonnull Runnable r) {
+            Thread thread = new Thread(r, namePrefix + "-" + indexCounter.getAndIncrement());
+            thread.setDaemon(true);
+            thread.setUncaughtExceptionHandler((t, e) -> log.error("Unexpected exception thrown", e));
+            return thread;
+        }
+    }
+}

--- a/core/src/main/java/io/github/datromtool/retool/RetoolDownloader.java
+++ b/core/src/main/java/io/github/datromtool/retool/RetoolDownloader.java
@@ -16,6 +16,7 @@ import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 import java.security.MessageDigest;
@@ -145,7 +146,7 @@ public final class RetoolDownloader {
                 results.add(syncDirectory(executorService, effectiveBase, directory));
             }
         }
-        return new Result(results.build());
+        return new Result(results.build(), effectiveBase);
     }
 
     /**
@@ -247,19 +248,40 @@ public final class RetoolDownloader {
      * path is caught and converted to {@link FileOutcome#failed} - this method is invoked as an
      * {@link ExecutorService} task and must never let an exception escape, or one bad file would
      * poison {@link ExecutorService#invokeAll} for the whole directory.
+     *
+     * <p><b>Review round (issue #44 PR #45), finding 1:</b> a successful fetch is no longer
+     * trusted blindly - its LF-normalized bytes must hash to {@code expectedHash} (the same
+     * comparison {@link #needsDownload} uses) before {@link #atomicWrite} ever runs. A mismatch
+     * (truncated/corrupted transfer, or a manifest/file pair that disagree) is a failure, not a
+     * silent write of bad data that a later run might not even notice re-downloading, since the
+     * corrupted bytes would already be on disk influencing behavior until then.
      */
     private FileOutcome syncFile(URI base, String directory, Path dirPath, String fileName, String expectedHash) {
         if (isUnsafeFileName(fileName)) {
             log.warn("Refusing to sync unsafe file name '{}' from directory '{}' manifest", fileName, directory);
             return FileOutcome.failed(fileName);
         }
-        Path localFile = dirPath.resolve(fileName);
+        Path localFile;
+        try {
+            localFile = resolveWithinCache(dirPath, fileName);
+        } catch (IOException e) {
+            log.warn("Refusing to sync file name '{}' from directory '{}' manifest: {}", fileName, directory, e.getMessage());
+            return FileOutcome.failed(fileName);
+        }
         try {
             if (!needsDownload(localFile, expectedHash)) {
                 return FileOutcome.skipped(fileName);
             }
             URI fileUri = join(base, directory, percentEncodeSegment(fileName));
             byte[] content = fetchWithRetry(fileUri);
+            byte[] normalized = normalizeLineEndings(content);
+            String actualHash = sha256Hex(normalized);
+            if (!actualHash.equalsIgnoreCase(expectedHash)) {
+                log.warn(
+                        "Refusing to write '{}/{}': downloaded content hash '{}' does not match manifest hash '{}'",
+                        directory, fileName, actualHash, expectedHash);
+                return FileOutcome.failed(fileName);
+            }
             atomicWrite(localFile, content);
             return FileOutcome.downloaded(fileName);
         } catch (Exception e) {
@@ -272,12 +294,49 @@ public final class RetoolDownloader {
     // input - but a compromised/misconfigured source publishing "../../evil" as a key must not
     // be able to write outside the cache directory, so the same bare-name shape check
     // RetoolFileResolver applies to DAT header names applies here too.
+    //
+    // Review round, finding 3: ':' is also rejected - "C:payload" isn't caught by any of the
+    // other shape checks (no '/', no '\\', not ".."/"."), but on Windows Path#resolve treats a
+    // leading "X:" as drive-relative, resolving against that drive's current directory and
+    // escaping the cache directory entirely.
     private static boolean isUnsafeFileName(String fileName) {
         return fileName.isEmpty()
                 || fileName.contains("/")
                 || fileName.contains("\\")
+                || fileName.contains(":")
                 || fileName.equals("..")
                 || fileName.equals(".");
+    }
+
+    /**
+     * Resolves {@code fileName} within {@code dirPath}, given the platform cannot even express
+     * every string as a path (e.g. a NUL byte - review round, finding 2) and {@link
+     * Path#resolve(String)} throws an <em>unchecked</em> {@link InvalidPathException} for those,
+     * which - unlike every other failure in {@link #syncFile} - was escaping this method
+     * entirely, because the resolve previously ran before any try block. Per {@link
+     * #syncDirectory}'s {@link ExecutionException} handling, an escaping unchecked exception here
+     * would poison the whole directory sync, not just the one bad manifest entry.
+     *
+     * <p>Also asserts containment (defense in depth, mirroring {@link
+     * RetoolFileResolver#resolveFile}'s own containment assert for the same class of
+     * hostile-manifest-entry threat): {@link #isUnsafeFileName} already rejects every traversal
+     * shape this class knows of, but a resolved candidate that somehow still escapes {@code
+     * dirPath} must never be written to, regardless of which check let it through.
+     */
+    private static Path resolveWithinCache(Path dirPath, String fileName) throws IOException {
+        Path normalizedDir = dirPath.normalize();
+        Path candidate;
+        try {
+            candidate = normalizedDir.resolve(fileName).normalize();
+        } catch (InvalidPathException e) {
+            throw new IOException(format("'%s' is not a valid path on this platform", fileName), e);
+        }
+        if (!candidate.startsWith(normalizedDir)) {
+            throw new IOException(format(
+                    "File name '%s' resolves outside cache directory '%s' - refusing to use it",
+                    fileName, dirPath));
+        }
+        return candidate;
     }
 
     /**
@@ -455,8 +514,15 @@ public final class RetoolDownloader {
         }
     }
 
-    /** The overall sync outcome - one {@link DirectoryResult} per {@link #SYNCED_DIRECTORIES} entry. */
-    public record Result(ImmutableList<DirectoryResult> directories) {
+    /**
+     * The overall sync outcome - one {@link DirectoryResult} per {@link #SYNCED_DIRECTORIES}
+     * entry, plus {@code effectiveBaseUrl}: the base actually used after {@link
+     * #resolveEffectiveBase()} - which may differ from the configured {@link #baseUrl} if
+     * upstream's {@code internal-config.json} retargeted it (issue #44 review round, finding 8:
+     * callers need this to surface a retarget to the user, since printing the configured base
+     * alone can silently name the wrong host).
+     */
+    public record Result(ImmutableList<DirectoryResult> directories, URI effectiveBaseUrl) {
 
         public boolean hasFailures() {
             return directories.stream()

--- a/core/src/test/java/io/github/datromtool/retool/RetoolDownloaderTest.java
+++ b/core/src/test/java/io/github/datromtool/retool/RetoolDownloaderTest.java
@@ -5,13 +5,16 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.security.MessageDigest;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
@@ -304,6 +307,95 @@ class RetoolDownloaderTest {
         assertEquals(1, dirResult.skipped());
         assertEquals(1, dirResult.failedFiles().size());
         assertEquals(dirResult.checked(), dirResult.downloaded() + dirResult.skipped() + dirResult.failedFiles().size());
+    }
+
+    // A1 (issue #44 step 2 gate finding): a non-HTTPS cloneListMetadataUrl override must be
+    // ignored - the sync keeps using the originally configured HTTPS base rather than following
+    // (or merely failing on) the insecure override. Code was already correct by inspection; this
+    // closes the coverage gap.
+    @Test
+    void nonHttpsCloneListMetadataUrlOverrideIsIgnored() throws IOException {
+        fetcher.stub(uri("config/internal-config.json"),
+                hashJson(Map.of("cloneListMetadataUrl", "http://insecure.test/other")));
+        fetcher.stub(uri("clonelists/hash.json"), hashJson(Map.of()));
+        fetcher.stub(uri("metadata/hash.json"), hashJson(Map.of()));
+
+        RetoolDownloader.Result result = downloader().sync();
+
+        assertTrue(fetcher.calls().contains(uri("clonelists/hash.json")),
+                "the original HTTPS base's hash.json must still be used when the override is rejected");
+        assertTrue(fetcher.calls().contains(uri("metadata/hash.json")),
+                "the original HTTPS base's hash.json must still be used when the override is rejected");
+        assertFalse(directoryResult(result, "clonelists").directorySkipped());
+        assertFalse(directoryResult(result, "metadata").directorySkipped());
+    }
+
+    // A2 (issue #44 step 2 gate finding): row 10 above only fails the FETCH, so atomicWrite's own
+    // write-stage failure/cleanup path (tmp file created and written successfully, then the
+    // Files.move itself fails) was never exercised - mutating that code away would not fail any
+    // existing test. Pinned here for real: the destination is pre-created as a non-empty
+    // directory, so a regular-file source can never atomically replace it via Files.move with
+    // ATOMIC_MOVE, on any of this project's CI platforms (POSIX rename()/Windows MoveFileEx both
+    // refuse to replace a directory with a file, regardless of emptiness) - forcing the actual
+    // catch-and-delete-the-tmp-file path to run after a successful fetch and a successful
+    // tmp-file write.
+    @Test
+    void atomicWriteCleansUpTempFileWhenTheMoveItselfFails() throws IOException {
+        byte[] content = "new content\n".getBytes(StandardCharsets.UTF_8);
+        Path localFile = cacheDir.resolve("clonelists").resolve("foo.json");
+        Files.createDirectories(localFile); // "foo.json" pre-exists as a DIRECTORY, not a file
+        Files.writeString(localFile.resolve("dummy.txt"), "not empty");
+
+        fetcher.stub(uri("clonelists/hash.json"), hashJson(Map.of("foo.json", sha256Hex(content))));
+        fetcher.stub(uri("metadata/hash.json"), hashJson(Map.of()));
+        fetcher.stub(uri("clonelists/foo.json"), content);
+
+        RetoolDownloader.Result result = downloader().sync();
+
+        assertTrue(Files.isDirectory(localFile),
+                "the pre-existing directory must be untouched since the move itself must fail");
+        assertTrue(Files.isRegularFile(localFile.resolve("dummy.txt")),
+                "directory contents must be untouched");
+        try (Stream<Path> entries = Files.list(cacheDir.resolve("clonelists"))) {
+            assertTrue(entries.noneMatch(p -> p.getFileName().toString().endsWith(".tmp")),
+                    "atomicWrite's catch block must delete the temp file when the move itself fails");
+        }
+        assertEquals(List.of("foo.json"), directoryResult(result, "clonelists").failedFiles(),
+                "a move failure must be recorded as a failed file, not a silent success");
+    }
+
+    // A3 (issue #44 step 2 gate finding): HttpFetcher previously read a response body fully via
+    // BodyHandlers.ofByteArray() before this class got any chance to check its size. readBounded
+    // is the extracted, pure enforcement logic (parameterized on maxBytes rather than hardcoding
+    // HttpFetcher's real 32MB cap) so it is unit-testable with a tiny cap and a cheap synthetic
+    // stream - no real network/socket, no actual multi-megabyte payload needed.
+    @Test
+    void readBoundedReturnsExactBytesWhenUnderCap() throws IOException {
+        byte[] data = "hello world".getBytes(StandardCharsets.UTF_8);
+        byte[] result = RetoolDownloader.HttpFetcher.readBounded(new ByteArrayInputStream(data), 1024, BASE);
+        assertArrayEquals(data, result);
+    }
+
+    @Test
+    void readBoundedThrowsClearExceptionWhenStreamExceedsCap() {
+        // Yields an effectively unbounded number of bytes without needing an actual
+        // multi-megabyte backing array - read(byte[], int, int) always fills the whole buffer.
+        InputStream unbounded = new InputStream() {
+            @Override
+            public int read() {
+                return 'a';
+            }
+
+            @Override
+            public int read(byte[] b, int off, int len) {
+                Arrays.fill(b, off, off + len, (byte) 'a');
+                return len;
+            }
+        };
+        IOException e = assertThrows(IOException.class,
+                () -> RetoolDownloader.HttpFetcher.readBounded(unbounded, 10, BASE));
+        assertTrue(e.getMessage().contains("10"), "error must name the cap that was exceeded, got: " + e.getMessage());
+        assertTrue(e.getMessage().contains(BASE.toString()), "error must name the URI, got: " + e.getMessage());
     }
 
     /**

--- a/core/src/test/java/io/github/datromtool/retool/RetoolDownloaderTest.java
+++ b/core/src/test/java/io/github/datromtool/retool/RetoolDownloaderTest.java
@@ -2,8 +2,11 @@ package io.github.datromtool.retool;
 
 import io.github.datromtool.SerializationHelper;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -399,6 +402,147 @@ class RetoolDownloaderTest {
                 () -> RetoolDownloader.HttpFetcher.readBounded(unbounded, 10, BASE));
         assertTrue(e.getMessage().contains("10"), "error must name the cap that was exceeded, got: " + e.getMessage());
         assertTrue(e.getMessage().contains(BASE.toString()), "error must name the URI, got: " + e.getMessage());
+    }
+
+    // --- CodeRabbit review round (PR #45), finding 1: a successful fetch whose bytes do not
+    // hash to the manifest's expected sha256 must be treated as failed and never persisted - a
+    // truncated/corrupted download must not be silently written and later trusted. ---
+
+    @Test
+    void corruptedDownloadHashMismatchIsRecordedFailedAndNotWritten() throws IOException {
+        byte[] expectedContent = "correct content\n".getBytes(StandardCharsets.UTF_8);
+        byte[] corruptedContent = "corrupted!\n".getBytes(StandardCharsets.UTF_8);
+        fetcher.stub(uri("clonelists/hash.json"), hashJson(Map.of("foo.json", sha256Hex(expectedContent))));
+        fetcher.stub(uri("metadata/hash.json"), hashJson(Map.of()));
+        fetcher.stub(uri("clonelists/foo.json"), corruptedContent);
+
+        RetoolDownloader.Result result = downloader().sync();
+
+        Path localFile = cacheDir.resolve("clonelists").resolve("foo.json");
+        assertFalse(Files.exists(localFile), "a hash-mismatched download must never be written to disk");
+        RetoolDownloader.DirectoryResult dirResult = directoryResult(result, "clonelists");
+        assertEquals(List.of("foo.json"), dirResult.failedFiles());
+        assertEquals(0, dirResult.downloaded());
+    }
+
+    @Test
+    void corruptedDownloadHashMismatchLeavesPreExistingFileUntouched() throws IOException {
+        // The existing local file's hash doesn't match either (forcing a re-download attempt),
+        // but the downloaded replacement is itself corrupted - the stale-but-intact local file
+        // must be left exactly as it was, never overwritten with worse (corrupted) data.
+        byte[] staleContent = "stale content\n".getBytes(StandardCharsets.UTF_8);
+        byte[] expectedContent = "correct content\n".getBytes(StandardCharsets.UTF_8);
+        byte[] corruptedContent = "corrupted!\n".getBytes(StandardCharsets.UTF_8);
+        Path localFile = cacheDir.resolve("clonelists").resolve("foo.json");
+        Files.createDirectories(localFile.getParent());
+        Files.write(localFile, staleContent);
+
+        fetcher.stub(uri("clonelists/hash.json"), hashJson(Map.of("foo.json", sha256Hex(expectedContent))));
+        fetcher.stub(uri("metadata/hash.json"), hashJson(Map.of()));
+        fetcher.stub(uri("clonelists/foo.json"), corruptedContent);
+
+        RetoolDownloader.Result result = downloader().sync();
+
+        assertArrayEquals(staleContent, Files.readAllBytes(localFile),
+                "a hash-mismatched download must leave the pre-existing file untouched");
+        assertEquals(List.of("foo.json"), directoryResult(result, "clonelists").failedFiles());
+    }
+
+    // --- CodeRabbit review round, finding 2: a manifest key the platform cannot even express as
+    // a path (e.g. a NUL byte) must not let an unchecked InvalidPathException escape syncFile -
+    // per syncDirectory's ExecutionException handling, an escaping unchecked exception there
+    // would take down the whole directory sync, not just the one bad entry. ---
+
+    @Test
+    void manifestKeyWithNulByteIsRecordedFailedWithoutAbortingTheDirectory() throws IOException {
+        String badName = "bad" + (char) 0 + "name.json";
+        byte[] goodContent = "good\n".getBytes(StandardCharsets.UTF_8);
+        fetcher.stub(uri("clonelists/hash.json"), hashJson(Map.of(
+                badName, sha256Hex("irrelevant".getBytes(StandardCharsets.UTF_8)),
+                "good.json", sha256Hex(goodContent))));
+        fetcher.stub(uri("metadata/hash.json"), hashJson(Map.of()));
+        fetcher.stub(uri("clonelists/good.json"), goodContent);
+
+        RetoolDownloader.Result result = downloader().sync();
+
+        RetoolDownloader.DirectoryResult dirResult = directoryResult(result, "clonelists");
+        assertEquals(List.of(badName), dirResult.failedFiles(),
+                "a NUL-byte name must be recorded failed, not escape as an unchecked InvalidPathException");
+        assertEquals(1, dirResult.downloaded(), "other manifest entries in the same directory must still sync");
+        assertArrayEquals(goodContent, Files.readAllBytes(cacheDir.resolve("clonelists").resolve("good.json")));
+    }
+
+    // --- CodeRabbit review round, finding 3: a Windows drive-relative shaped name ("C:payload")
+    // isn't caught by any existing shape check (no '/', no '\\', not ".."/".") - on Windows,
+    // Path#resolve treats a leading "X:" as drive-relative, resolving against that drive's
+    // current directory and escaping the cache directory entirely. Rejected by name shape
+    // regardless of which OS actually runs this test. ---
+
+    @Test
+    void windowsDriveRelativeFileNameIsRejected() throws IOException {
+        String badName = "C:payload.json";
+        byte[] content = "payload\n".getBytes(StandardCharsets.UTF_8);
+        fetcher.stub(uri("clonelists/hash.json"), hashJson(Map.of(badName, sha256Hex(content))));
+        fetcher.stub(uri("metadata/hash.json"), hashJson(Map.of()));
+
+        RetoolDownloader.Result result = downloader().sync();
+
+        RetoolDownloader.DirectoryResult dirResult = directoryResult(result, "clonelists");
+        assertEquals(List.of(badName), dirResult.failedFiles(),
+                "a drive-relative-shaped name must be rejected before any fetch/write is attempted");
+        assertEquals(0, dirResult.downloaded());
+        assertEquals(3, fetcher.calls().size(),
+                "only config/internal-config.json + the two hash.json manifests must be fetched - "
+                        + "never a per-file fetch for the rejected name, got calls: " + fetcher.calls());
+        try (Stream<Path> entries = Files.walk(cacheDir)) {
+            assertTrue(
+                    entries.filter(Files::isRegularFile).noneMatch(p -> p.getFileName().toString().contains("payload")),
+                    "no file must be written for a rejected drive-relative name");
+        }
+    }
+
+    // --- CodeRabbit review round, finding 5 (top-tier follow-up): the unsafe-file-name guard
+    // shipped with no dedicated coverage - deleting isUnsafeFileName entirely still left the full
+    // suite green. This battery pins every shape the guard must reject, each proven to never
+    // reach the network fetch at all (not merely "some later step also happens to fail"), and
+    // proven by mutation (see this class's Javadoc note / the PR handoff for the delete-and-
+    // restore run). ---
+
+    @ParameterizedTest
+    @ValueSource(strings = {"../../evil.json", "a/b.json", "/abs.json", "..\\win.json", "", ".", ".."})
+    void unsafeFileNameShapesAreRejectedBeforeAnyFetch(String badName) throws IOException {
+        byte[] content = "payload\n".getBytes(StandardCharsets.UTF_8);
+        fetcher.stub(uri("clonelists/hash.json"), hashJson(Map.of(badName, sha256Hex(content))));
+        fetcher.stub(uri("metadata/hash.json"), hashJson(Map.of()));
+
+        RetoolDownloader.Result result = downloader().sync();
+
+        RetoolDownloader.DirectoryResult dirResult = directoryResult(result, "clonelists");
+        assertEquals(List.of(badName), dirResult.failedFiles(),
+                "unsafe name '" + badName + "' must be recorded failed");
+        assertEquals(0, dirResult.downloaded());
+        assertEquals(3, fetcher.calls().size(),
+                "only config/internal-config.json + the two hash.json manifests must be fetched for '"
+                        + badName + "', got calls: " + fetcher.calls());
+    }
+
+    // --- Issue #44's own Verification section: "one explicitly-tagged integration check against
+    // the real endpoint, excluded from the default suite." Hits the real upstream data repository
+    // over the network - excluded from `mvn verify`'s default run via the root pom's surefire
+    // pluginManagement <excludedGroups>integration</excludedGroups> (verified separately that the
+    // default suite skips it and that `-Dgroups=integration` still runs and passes it). ---
+
+    @Tag("integration")
+    @Test
+    void realEndpointSyncsClonelistsAndMetadataWithoutFailures(@TempDir Path realCacheDir) {
+        RetoolDownloader downloader = new RetoolDownloader(
+                URI.create(RetoolDownloader.DEFAULT_BASE_URL), realCacheDir);
+
+        RetoolDownloader.Result result = downloader.sync();
+
+        assertFalse(result.hasFailures(), "real endpoint sync must complete without failures");
+        assertTrue(Files.isDirectory(realCacheDir.resolve("clonelists")));
+        assertTrue(Files.isDirectory(realCacheDir.resolve("metadata")));
     }
 
     /**

--- a/core/src/test/java/io/github/datromtool/retool/RetoolDownloaderTest.java
+++ b/core/src/test/java/io/github/datromtool/retool/RetoolDownloaderTest.java
@@ -1,0 +1,357 @@
+package io.github.datromtool.retool;
+
+import io.github.datromtool.SerializationHelper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.MessageDigest;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Coverage matrix rows 1-11 for issue #44 step 1's {@link RetoolDownloader}. No test touches the
+ * network - every case drives a {@link FakeFetcher} (see {@link RetoolDownloader}'s class
+ * Javadoc for why a fake was chosen over a real {@code com.sun.net.httpserver.HttpServer}
+ * socket).
+ */
+class RetoolDownloaderTest {
+
+    private static final URI BASE = URI.create("https://example.test/data");
+
+    @TempDir
+    Path cacheDir;
+
+    private FakeFetcher fetcher;
+
+    @BeforeEach
+    void setUp() {
+        fetcher = new FakeFetcher();
+        // No cloneListMetadataUrl override unless a test stubs one explicitly (row 9).
+        fetcher.stub(uri("config/internal-config.json"), "{}");
+    }
+
+    private static URI uri(String path) {
+        return URI.create(BASE + "/" + path);
+    }
+
+    private RetoolDownloader downloader() {
+        return new RetoolDownloader(BASE, cacheDir, fetcher, 4);
+    }
+
+    private static byte[] hashJson(Map<String, String> hashes) {
+        return SerializationHelper.getInstance().getJsonMapper().writeValueAsBytes(hashes);
+    }
+
+    private static String sha256Hex(byte[] bytes) {
+        try {
+            byte[] digest = MessageDigest.getInstance("SHA-256").digest(bytes);
+            StringBuilder sb = new StringBuilder(digest.length * 2);
+            for (byte b : digest) {
+                sb.append(String.format("%02x", b));
+            }
+            return sb.toString();
+        } catch (Exception e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    private RetoolDownloader.DirectoryResult directoryResult(RetoolDownloader.Result result, String directory) {
+        return result.directories().stream()
+                .filter(d -> d.directory().equals(directory))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("No result for directory " + directory));
+    }
+
+    // Row 1: unchanged local file (hash matches) -> NOT re-downloaded.
+    @Test
+    void unchangedFileIsNotReDownloaded() throws IOException {
+        byte[] content = "hello\n".getBytes(StandardCharsets.UTF_8);
+        Path localFile = cacheDir.resolve("clonelists").resolve("foo.json");
+        Files.createDirectories(localFile.getParent());
+        Files.write(localFile, content);
+
+        fetcher.stub(uri("clonelists/hash.json"), hashJson(Map.of("foo.json", sha256Hex(content))));
+        fetcher.stub(uri("metadata/hash.json"), hashJson(Map.of()));
+        URI fileUri = uri("clonelists/foo.json");
+
+        RetoolDownloader.Result result = downloader().sync();
+
+        assertFalse(fetcher.calls().contains(fileUri), "fetcher must not be called for an unchanged file");
+        RetoolDownloader.DirectoryResult dirResult = directoryResult(result, "clonelists");
+        assertEquals(1, dirResult.checked());
+        assertEquals(0, dirResult.downloaded());
+        assertEquals(1, dirResult.skipped());
+        assertTrue(dirResult.failedFiles().isEmpty());
+    }
+
+    // Row 2: changed local file -> re-downloaded, content replaced.
+    @Test
+    void changedFileIsReDownloadedAndReplaced() throws IOException {
+        Path localFile = cacheDir.resolve("clonelists").resolve("foo.json");
+        Files.createDirectories(localFile.getParent());
+        Files.write(localFile, "old content\n".getBytes(StandardCharsets.UTF_8));
+
+        byte[] newContent = "new content\n".getBytes(StandardCharsets.UTF_8);
+        fetcher.stub(uri("clonelists/hash.json"), hashJson(Map.of("foo.json", sha256Hex(newContent))));
+        fetcher.stub(uri("metadata/hash.json"), hashJson(Map.of()));
+        fetcher.stub(uri("clonelists/foo.json"), newContent);
+
+        RetoolDownloader.Result result = downloader().sync();
+
+        assertArrayEquals(newContent, Files.readAllBytes(localFile));
+        RetoolDownloader.DirectoryResult dirResult = directoryResult(result, "clonelists");
+        assertEquals(1, dirResult.downloaded());
+        assertEquals(0, dirResult.skipped());
+    }
+
+    // Row 3: absent local file -> downloaded.
+    @Test
+    void absentFileIsDownloaded() throws IOException {
+        byte[] content = "brand new\n".getBytes(StandardCharsets.UTF_8);
+        fetcher.stub(uri("clonelists/hash.json"), hashJson(Map.of("foo.json", sha256Hex(content))));
+        fetcher.stub(uri("metadata/hash.json"), hashJson(Map.of()));
+        fetcher.stub(uri("clonelists/foo.json"), content);
+
+        RetoolDownloader.Result result = downloader().sync();
+
+        Path localFile = cacheDir.resolve("clonelists").resolve("foo.json");
+        assertTrue(Files.isRegularFile(localFile));
+        assertArrayEquals(content, Files.readAllBytes(localFile));
+        assertEquals(1, directoryResult(result, "clonelists").downloaded());
+    }
+
+    // Row 4: a local file with CRLF line endings whose LF-normalized bytes hash to the published
+    // value is treated as UNCHANGED - the subtle upstream porting detail this class must pin.
+    @Test
+    void crlfLocalFileMatchingLfNormalizedHashIsTreatedAsUnchanged() throws IOException {
+        byte[] crlfContent = "line1\r\nline2\r\n".getBytes(StandardCharsets.UTF_8);
+        byte[] lfNormalized = "line1\nline2\n".getBytes(StandardCharsets.UTF_8);
+        Path localFile = cacheDir.resolve("clonelists").resolve("foo.json");
+        Files.createDirectories(localFile.getParent());
+        Files.write(localFile, crlfContent);
+
+        fetcher.stub(uri("clonelists/hash.json"), hashJson(Map.of("foo.json", sha256Hex(lfNormalized))));
+        fetcher.stub(uri("metadata/hash.json"), hashJson(Map.of()));
+        URI fileUri = uri("clonelists/foo.json");
+
+        RetoolDownloader.Result result = downloader().sync();
+
+        assertFalse(fetcher.calls().contains(fileUri), "CRLF file hashing to the LF-normalized value must be treated as unchanged");
+        assertEquals(1, directoryResult(result, "clonelists").skipped());
+        assertArrayEquals(crlfContent, Files.readAllBytes(localFile), "the local file itself must never be rewritten");
+    }
+
+    // Row 5: a filename with spaces and parentheses produces the exact expected percent-encoded
+    // URI - %20/%28/%29, no '+' (ruling out java.net.URLEncoder).
+    @Test
+    void fileNameWithSpacesAndParensIsPercentEncodedPerRfc3986() throws IOException {
+        String fileName = "Sony - PlayStation (Redump).json";
+        String expectedEncodedSegment = "Sony%20-%20PlayStation%20%28Redump%29.json";
+        byte[] content = "{}".getBytes(StandardCharsets.UTF_8);
+
+        fetcher.stub(uri("clonelists/hash.json"), hashJson(Map.of(fileName, sha256Hex(content))));
+        fetcher.stub(uri("metadata/hash.json"), hashJson(Map.of()));
+        URI expectedUri = uri("clonelists/" + expectedEncodedSegment);
+        fetcher.stub(expectedUri, content);
+
+        RetoolDownloader.Result result = downloader().sync();
+
+        assertTrue(fetcher.calls().contains(expectedUri), "expected exactly: " + expectedUri);
+        assertEquals(1, directoryResult(result, "clonelists").downloaded());
+        assertArrayEquals(content, Files.readAllBytes(cacheDir.resolve("clonelists").resolve(fileName)));
+    }
+
+    // Row 6: 404 on one file -> recorded failed, other files still downloaded, sync returns a
+    // result marking the failure.
+    @Test
+    void notFoundOnOneFileIsRecordedFailedWhileOthersStillDownload() throws IOException {
+        byte[] goodContent = "good\n".getBytes(StandardCharsets.UTF_8);
+        fetcher.stub(uri("clonelists/hash.json"), hashJson(Map.of(
+                "good.json", sha256Hex(goodContent),
+                "missing.json", sha256Hex("irrelevant".getBytes(StandardCharsets.UTF_8)))));
+        fetcher.stub(uri("metadata/hash.json"), hashJson(Map.of()));
+        fetcher.stub(uri("clonelists/good.json"), goodContent);
+        fetcher.notFound(uri("clonelists/missing.json"));
+
+        RetoolDownloader.Result result = downloader().sync();
+
+        RetoolDownloader.DirectoryResult dirResult = directoryResult(result, "clonelists");
+        assertEquals(2, dirResult.checked());
+        assertEquals(1, dirResult.downloaded());
+        assertEquals(List.of("missing.json"), dirResult.failedFiles());
+        assertArrayEquals(goodContent, Files.readAllBytes(cacheDir.resolve("clonelists").resolve("good.json")));
+        assertFalse(Files.exists(cacheDir.resolve("clonelists").resolve("missing.json")));
+        assertTrue(result.hasFailures());
+    }
+
+    // Row 7: missing/invalid hash.json for one directory -> that directory skipped, the other
+    // still processed.
+    @Test
+    void invalidHashJsonSkipsOnlyThatDirectory() throws IOException {
+        fetcher.stub(uri("clonelists/hash.json"), "not valid json".getBytes(StandardCharsets.UTF_8));
+        byte[] metaContent = "meta\n".getBytes(StandardCharsets.UTF_8);
+        fetcher.stub(uri("metadata/hash.json"), hashJson(Map.of("bar.json", sha256Hex(metaContent))));
+        fetcher.stub(uri("metadata/bar.json"), metaContent);
+
+        RetoolDownloader.Result result = downloader().sync();
+
+        RetoolDownloader.DirectoryResult clonelistsResult = directoryResult(result, "clonelists");
+        assertTrue(clonelistsResult.directorySkipped());
+        assertTrue(clonelistsResult.skipReason() != null && !clonelistsResult.skipReason().isBlank());
+        RetoolDownloader.DirectoryResult metadataResult = directoryResult(result, "metadata");
+        assertFalse(metadataResult.directorySkipped());
+        assertEquals(1, metadataResult.downloaded());
+        assertArrayEquals(metaContent, Files.readAllBytes(cacheDir.resolve("metadata").resolve("bar.json")));
+    }
+
+    // Row 8: non-HTTPS base URL -> rejected with a clear error.
+    @Test
+    void nonHttpsBaseUrlIsRejected() {
+        URI httpBase = URI.create("http://example.test/data");
+        IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
+                () -> new RetoolDownloader(httpBase, cacheDir, fetcher, 4));
+        assertTrue(e.getMessage().contains("HTTPS"));
+    }
+
+    // Row 9: cloneListMetadataUrl override in internal-config.json is honored.
+    @Test
+    void cloneListMetadataUrlOverrideIsHonored() throws IOException {
+        URI overrideBase = URI.create("https://override.test/other");
+        fetcher.stub(uri("config/internal-config.json"),
+                hashJson(Map.of("cloneListMetadataUrl", overrideBase.toString())));
+
+        URI overrideClonelistsHash = URI.create(overrideBase + "/clonelists/hash.json");
+        URI overrideMetadataHash = URI.create(overrideBase + "/metadata/hash.json");
+        fetcher.stub(overrideClonelistsHash, hashJson(Map.of()));
+        fetcher.stub(overrideMetadataHash, hashJson(Map.of()));
+        // Deliberately not stubbing the original BASE's per-directory hash.json endpoints: if the
+        // override were ignored, those fetches would fail and the directories would come back
+        // skipped, which the assertions below would catch.
+
+        RetoolDownloader.Result result = downloader().sync();
+
+        assertTrue(fetcher.calls().contains(overrideClonelistsHash));
+        assertTrue(fetcher.calls().contains(overrideMetadataHash));
+        assertFalse(directoryResult(result, "clonelists").directorySkipped());
+        assertFalse(directoryResult(result, "metadata").directorySkipped());
+    }
+
+    // Row 10: atomic write - a fetch that throws mid-directory leaves no partial file, and does
+    // not affect the other file in the same directory.
+    @Test
+    void midDirectoryFetchFailureLeavesNoPartialFile() throws IOException {
+        byte[] goodContent = "ok\n".getBytes(StandardCharsets.UTF_8);
+        fetcher.stub(uri("clonelists/hash.json"), hashJson(Map.of(
+                "a.json", sha256Hex(goodContent),
+                "b.json", sha256Hex("whatever".getBytes(StandardCharsets.UTF_8)))));
+        fetcher.stub(uri("metadata/hash.json"), hashJson(Map.of()));
+        fetcher.stub(uri("clonelists/a.json"), goodContent);
+        fetcher.failWithTransportError(uri("clonelists/b.json"));
+
+        RetoolDownloader.Result result = downloader().sync();
+
+        Path dirPath = cacheDir.resolve("clonelists");
+        assertArrayEquals(goodContent, Files.readAllBytes(dirPath.resolve("a.json")));
+        assertFalse(Files.exists(dirPath.resolve("b.json")));
+        try (Stream<Path> entries = Files.list(dirPath)) {
+            assertTrue(entries.noneMatch(p -> p.getFileName().toString().endsWith(".tmp")),
+                    "no orphaned temp file must remain after a failed download");
+        }
+        assertEquals(List.of("b.json"), directoryResult(result, "clonelists").failedFiles());
+    }
+
+    // Row 11: the result object reports accurate checked/downloaded/skipped/failed counts across
+    // a mixed directory (one unchanged, one absent, one 404).
+    @Test
+    void resultReportsAccurateCounts() throws IOException {
+        byte[] unchangedContent = "same\n".getBytes(StandardCharsets.UTF_8);
+        Path unchangedFile = cacheDir.resolve("clonelists").resolve("unchanged.json");
+        Files.createDirectories(unchangedFile.getParent());
+        Files.write(unchangedFile, unchangedContent);
+
+        byte[] newContent = "new\n".getBytes(StandardCharsets.UTF_8);
+        fetcher.stub(uri("clonelists/hash.json"), hashJson(Map.of(
+                "unchanged.json", sha256Hex(unchangedContent),
+                "absent.json", sha256Hex(newContent),
+                "missing.json", sha256Hex("x".getBytes(StandardCharsets.UTF_8)))));
+        fetcher.stub(uri("metadata/hash.json"), hashJson(Map.of()));
+        fetcher.stub(uri("clonelists/absent.json"), newContent);
+        fetcher.notFound(uri("clonelists/missing.json"));
+
+        RetoolDownloader.Result result = downloader().sync();
+
+        RetoolDownloader.DirectoryResult dirResult = directoryResult(result, "clonelists");
+        assertEquals(3, dirResult.checked());
+        assertEquals(1, dirResult.downloaded());
+        assertEquals(1, dirResult.skipped());
+        assertEquals(1, dirResult.failedFiles().size());
+        assertEquals(dirResult.checked(), dirResult.downloaded() + dirResult.skipped() + dirResult.failedFiles().size());
+    }
+
+    /**
+     * An in-memory {@link RetoolDownloader.Fetcher} test double, recording every {@link URI} it
+     * was asked to fetch and letting each test wire up per-URI responses/404s/transport failures
+     * with no real network or socket involved.
+     */
+    private static final class FakeFetcher implements RetoolDownloader.Fetcher {
+
+        private final Map<URI, byte[]> responses = new LinkedHashMap<>();
+        private final Set<URI> notFoundUris = new HashSet<>();
+        private final Set<URI> transportFailUris = new HashSet<>();
+        private final List<URI> calls = Collections.synchronizedList(new ArrayList<>());
+
+        void stub(URI uri, byte[] body) {
+            responses.put(uri, body);
+        }
+
+        void stub(URI uri, String body) {
+            stub(uri, body.getBytes(StandardCharsets.UTF_8));
+        }
+
+        void notFound(URI uri) {
+            notFoundUris.add(uri);
+        }
+
+        void failWithTransportError(URI uri) {
+            transportFailUris.add(uri);
+        }
+
+        List<URI> calls() {
+            return List.copyOf(calls);
+        }
+
+        @Override
+        public byte[] fetch(URI uri) throws IOException {
+            calls.add(uri);
+            if (notFoundUris.contains(uri)) {
+                throw new RetoolDownloader.HttpStatusException(uri, 404);
+            }
+            if (transportFailUris.contains(uri)) {
+                throw new IOException("simulated transport failure for " + uri);
+            }
+            byte[] body = responses.get(uri);
+            if (body == null) {
+                throw new IOException("No stub registered for " + uri);
+            }
+            return body;
+        }
+    }
+}

--- a/core/src/test/java/io/github/datromtool/retool/RetoolDownloaderTest.java
+++ b/core/src/test/java/io/github/datromtool/retool/RetoolDownloaderTest.java
@@ -330,17 +330,20 @@ class RetoolDownloaderTest {
         assertFalse(directoryResult(result, "metadata").directorySkipped());
     }
 
-    // A2 (issue #44 step 2 gate finding): row 10 above only fails the FETCH, so atomicWrite's own
-    // write-stage failure/cleanup path (tmp file created and written successfully, then the
-    // Files.move itself fails) was never exercised - mutating that code away would not fail any
-    // existing test. Pinned here for real: the destination is pre-created as a non-empty
-    // directory, so a regular-file source can never atomically replace it via Files.move with
-    // ATOMIC_MOVE, on any of this project's CI platforms (POSIX rename()/Windows MoveFileEx both
-    // refuse to replace a directory with a file, regardless of emptiness) - forcing the actual
-    // catch-and-delete-the-tmp-file path to run after a successful fetch and a successful
-    // tmp-file write.
+    // A2 (issue #44, step-2 gate finding): row 10 above only fails the FETCH, so nothing pinned
+    // what happens when a write to the destination fails after a successful fetch. This does.
+    //
+    // What it does NOT pin: that the write goes through a temp file and an ATOMIC_MOVE. A later
+    // gate proved that by mutation - reverting atomicWrite to a bare Files.write leaves this test
+    // green, because writing to a directory path fails identically either way. That is not a gap
+    // in the test so much as a property that cannot be observed from inside the process: the
+    // atomic move exists so that a process killed mid-write leaves the old file intact rather
+    // than a truncated one, and an in-process test cannot kill itself between the write and the
+    // move. What IS pinned here, and what mutation confirms: a failed write records the file as
+    // failed, leaves the pre-existing destination untouched, and leaves no .tmp residue behind
+    // (dropping the cleanup in atomicWrite's catch block does fail this test).
     @Test
-    void atomicWriteCleansUpTempFileWhenTheMoveItselfFails() throws IOException {
+    void failedWriteRecordsFailureAndLeavesNoTempFileBehind() throws IOException {
         byte[] content = "new content\n".getBytes(StandardCharsets.UTF_8);
         Path localFile = cacheDir.resolve("clonelists").resolve("foo.json");
         Files.createDirectories(localFile); // "foo.json" pre-exists as a DIRECTORY, not a file
@@ -353,15 +356,15 @@ class RetoolDownloaderTest {
         RetoolDownloader.Result result = downloader().sync();
 
         assertTrue(Files.isDirectory(localFile),
-                "the pre-existing directory must be untouched since the move itself must fail");
+                "the pre-existing destination must be untouched when the write fails");
         assertTrue(Files.isRegularFile(localFile.resolve("dummy.txt")),
                 "directory contents must be untouched");
         try (Stream<Path> entries = Files.list(cacheDir.resolve("clonelists"))) {
             assertTrue(entries.noneMatch(p -> p.getFileName().toString().endsWith(".tmp")),
-                    "atomicWrite's catch block must delete the temp file when the move itself fails");
+                    "a failed write must not leave a temp file behind");
         }
         assertEquals(List.of("foo.json"), directoryResult(result, "clonelists").failedFiles(),
-                "a move failure must be recorded as a failed file, not a silent success");
+                "a write failure must be recorded as a failed file, not a silent success");
     }
 
     // A3 (issue #44 step 2 gate finding): HttpFetcher previously read a response body fully via

--- a/core/src/test/java/io/github/datromtool/retool/RetoolDownloaderTest.java
+++ b/core/src/test/java/io/github/datromtool/retool/RetoolDownloaderTest.java
@@ -503,10 +503,16 @@ class RetoolDownloaderTest {
 
     // --- CodeRabbit review round, finding 5 (top-tier follow-up): the unsafe-file-name guard
     // shipped with no dedicated coverage - deleting isUnsafeFileName entirely still left the full
-    // suite green. This battery pins every shape the guard must reject, each proven to never
-    // reach the network fetch at all (not merely "some later step also happens to fail"), and
-    // proven by mutation (see this class's Javadoc note / the PR handoff for the delete-and-
-    // restore run). ---
+    // suite green. This battery pins every shape that must be rejected, each proven to never
+    // reach the network fetch at all (not merely "some later step also happens to fail").
+    //
+    // On what mutation actually proves here, precisely: deleting isUnsafeFileName flips four of
+    // these seven shapes ("a/b.json", "..\win.json", "" and "."). The other three stay green
+    // because resolveWithinCache's containment check catches them independently - which is the
+    // layering working as intended, not a hole. The converse does not hold: disabling only the
+    // containment check flips nothing, because the name guard already excludes every shape that
+    // could escape. That assert is deliberate belt-and-braces against a future name guard that
+    // misses something, and no test can currently distinguish it. ---
 
     @ParameterizedTest
     @ValueSource(strings = {"../../evil.json", "a/b.json", "/abs.json", "..\\win.json", "", ".", ".."})

--- a/pom.xml
+++ b/pom.xml
@@ -53,6 +53,12 @@
         <versions-maven-plugin.version>2.21.0</versions-maven-plugin.version>
         <maven-scm-provider-gitexe.version>2.2.1</maven-scm-provider-gitexe.version>
         <maven-scm-api.version>2.2.1</maven-scm-api.version>
+        <!-- Issue #44's Verification section: "one explicitly-tagged integration check against
+             the real endpoint, excluded from the default suite" - kept as a property (not a
+             literal in the surefire <configuration>) so `mvn test -Dtest.excludedGroups=` (empty)
+             still lets a caller opt into running it explicitly; -DexcludedGroups on its own
+             cannot override a literal <excludedGroups> value already set in this pom. -->
+        <test.excludedGroups>integration</test.excludedGroups>
         <!-- Maven plugins -->
         <maven-compiler-plugin.version>3.13.0</maven-compiler-plugin.version>
         <maven-surefire-plugin.version>3.5.6</maven-surefire-plugin.version>
@@ -189,6 +195,13 @@
                 <plugin>
                     <artifactId>maven-surefire-plugin</artifactId>
                     <version>${maven-surefire-plugin.version}</version>
+                    <configuration>
+                        <!-- Keeps `mvn verify`/`mvn test` fully offline by default
+                             (RetoolDownloaderTest#realEndpointSyncs... is @Tag("integration"));
+                             run it explicitly with `mvn test -Dtest.excludedGroups=
+                             -Dtest=RetoolDownloaderTest#realEndpointSyncsClonelistsAndMetadataWithoutFailures`. -->
+                        <excludedGroups>${test.excludedGroups}</excludedGroups>
+                    </configuration>
                 </plugin>
                 <plugin>
                     <artifactId>maven-assembly-plugin</artifactId>


### PR DESCRIPTION
Fixes #44

## What

DATROMTool can now obtain Retool community data the same way Retool itself does, so clone-list and metadata updates no longer depend on a DATROMTool release.

**`RetoolDownloader` (core).** Syncs the `clonelists` and `metadata` directories from `https://raw.githubusercontent.com/unexpectedpanda/retool-clonelists-metadata/main`, driven by each directory's `hash.json` manifest — which is both the change-detector and the file list, so nothing is enumerated remotely. A file is downloaded only when the sha256 of its **LF-normalized** local bytes differs from the published value; that normalization is upstream's own (it rewrites CRLF→LF before hashing), replicated here without touching the user's files. Honors `cloneListMetadataUrl` from the fetched `internal-config.json`, requires HTTPS (including for that override), percent-encodes file names per RFC 3986, caps response bodies while streaming, and writes atomically. A 404 on one file is recorded and the rest continue; transport errors get bounded retries.

**`datrom retool update [--base-url <url>] [--dir <cache>]`.** Explicit, opt-in network access — this is the only path that downloads anything. Reports per-directory checked/downloaded/skipped/failed counts plus failed names on stdout; exits 1 if anything failed. Cache defaults to `~/.DATROMTool/retool`.

**`1g1r` cache fallback.** With no `--clonelist`/`--retool-metadata` (or profile equivalent) and exactly one DAT, the cached directories are used if they exist and the existing header-name auto-match applies unchanged. No cache → today's behavior exactly. `1g1r` never downloads.

## Why this shape

Retool's own network access is opt-in (a hidden `--update` flag plus a prompt when data is missing); ordinary runs are fully offline. Keeping downloads to an explicit command matches that and avoids surprising a user mid-run. With multiple DATs the fallback simply does not apply rather than erroring, since the user never asked for it — unlike the explicit flags, which are rejected with >1 DAT because per-DAT resolution does not exist yet.

## Evidence

- Upstream mechanism verified against retool v2.4.9 **source**, not docs; the findings are recorded in #44 (URLs, manifest shape, hashing normalization, encoding rules, 404/retry policy).
- No network in the test suite: fetching goes through a one-method seam driven by an in-test fake, so the URI-construction and sync logic are exercised without sockets.
- Verifier gates mutation-tested the subtle behaviors: dropping LF normalization fails the CRLF test, making 404 fatal fails the continue-on-error tests, disabling the size cap OOMs the oversized-stream test, and removing the temp-file cleanup fails the failed-write test.
- The second gate caught a test that overclaimed — it survived reverting the atomic write — so it was renamed and re-documented to assert only what it pins; commit `09a0da5` explains why the atomicity guarantee itself is not observable in-process.
- Jar-level probes: with a populated cache and no flag, the Air Raiders fixture groups to one entry; with no cache, behavior is byte-identical to before.

🤖 Generated with [Claude Code](https://claude.com/claude-code), posted via @andrebrait's account on their behalf.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the `datrom retool update` command to download and refresh local clone-list and metadata caches.
  * Added configurable upstream URL and cache-directory options, with progress and download summaries.
  * Automatically uses cached Retool data for single-DAT operations when explicit paths are not provided.
  * Skips unchanged files and safely replaces updated files during synchronization.
* **Bug Fixes**
  * Improved handling of failed downloads without leaving partial files or disrupting other downloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->