### PR TITLE
domain: compare ROM headers by content

### DIFF
--- a/core/src/test/java/io/github/datromtool/domain/datafile/logiqx/RomTest.java
+++ b/core/src/test/java/io/github/datromtool/domain/datafile/logiqx/RomTest.java
@@ -1,0 +1,101 @@
+package io.github.datromtool.domain.datafile.logiqx;
+
+import com.google.common.collect.ImmutableList;
+import io.github.datromtool.SerializationHelper;
+import io.github.datromtool.domain.datafile.logiqx.enumerations.YesNo;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.ByteArrayInputStream;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.HexFormat;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A ROM's header is part of its value: two ROMs that describe the same dumped file must
+ * compare, hash, and round-trip as the same ROM regardless of which array instance holds
+ * the header bytes.
+ */
+class RomTest {
+
+    /** Four bytes so the last one is distinguishable from a truncated rendering. */
+    private static final byte[] NES_HEADER = {0x4E, 0x45, 0x53, 0x1A};
+
+    private static Rom romWithHeader(byte[] header) {
+        return new Rom(
+                "Some Game (USA).nes",
+                1024L,
+                header,
+                YesNo.NO,
+                "12345678",
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null);
+    }
+
+    @Test
+    void givenByteEqualHeadersInDistinctArrays_whenCompared_thenRomsAreEqual() {
+        Rom one = romWithHeader(NES_HEADER.clone());
+        Rom other = romWithHeader(NES_HEADER.clone());
+
+        assertNotEquals(
+                System.identityHashCode(one.header()),
+                System.identityHashCode(other.header()),
+                "test premise: the two headers must be distinct array instances");
+        assertEquals(one, other, "ROMs with byte-equal headers must be equal");
+        assertEquals(
+                one.hashCode(),
+                other.hashCode(),
+                "ROMs with byte-equal headers must share a hash code");
+    }
+
+    @Test
+    void givenDifferentHeaderContent_whenCompared_thenRomsAreNotEqual() {
+        Rom one = romWithHeader(NES_HEADER.clone());
+        Rom other = romWithHeader(new byte[]{0x4E, 0x45, 0x53, 0x1B});
+
+        assertNotEquals(one, other, "ROMs whose header bytes differ must not be equal");
+    }
+
+    @Test
+    void givenAHeaderedRom_whenRenderedAsText_thenTheHeaderContentIsVisible() {
+        String rendered = romWithHeader(NES_HEADER.clone()).toString();
+
+        assertTrue(
+                rendered.contains(Arrays.toString(NES_HEADER)),
+                () -> "toString must render header content, got: " + rendered);
+    }
+
+    @Test
+    void givenAHeaderedRomInADatafile_whenRoundTrippedThroughXml_thenTheHeaderSurvives(
+            @TempDir Path tempDir) throws Exception {
+        SerializationHelper helper = SerializationHelper.getInstance(tempDir);
+        Datafile datafile = Datafile.builder()
+                .games(ImmutableList.of(Game.builder()
+                        .name("Some Game (USA)")
+                        .description("Some Game (USA)")
+                        .roms(ImmutableList.of(romWithHeader(NES_HEADER.clone())))
+                        .build()))
+                .build();
+
+        byte[] xml = helper.getXmlMapper().writeValueAsBytes(datafile);
+        Datafile parsed = helper.loadXml(new ByteArrayInputStream(xml), Datafile.class);
+
+        byte[] parsedHeader = parsed.getGames().get(0).getRoms().get(0).header();
+        assertArrayEquals(
+                NES_HEADER,
+                parsedHeader,
+                () -> "header bytes must survive the round trip, wrote: " + new String(xml)
+                        + " read back: " + HexFormat.of().formatHex(parsedHeader));
+        assertEquals(datafile, parsed, "a round-tripped DAT must equal the one written");
+    }
+}

--- a/core/src/test/java/io/github/datromtool/domain/datafile/logiqx/RomTest.java
+++ b/core/src/test/java/io/github/datromtool/domain/datafile/logiqx/RomTest.java
@@ -8,10 +8,8 @@ import org.junit.jupiter.api.io.TempDir;
 
 import java.io.ByteArrayInputStream;
 import java.nio.file.Path;
-import java.util.Arrays;
-import java.util.HexFormat;
+import java.util.ArrayList;
 
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -24,9 +22,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class RomTest {
 
     /** Four bytes so the last one is distinguishable from a truncated rendering. */
-    private static final byte[] NES_HEADER = {0x4E, 0x45, 0x53, 0x1A};
+    private static final ImmutableList<Byte> NES_HEADER =
+            ImmutableList.of((byte) 0x4E, (byte) 0x45, (byte) 0x53, (byte) 0x1A);
 
-    private static Rom romWithHeader(byte[] header) {
+    private static Rom romWithHeader(ImmutableList<Byte> header) {
         return new Rom(
                 "Some Game (USA).nes",
                 1024L,
@@ -43,14 +42,14 @@ class RomTest {
     }
 
     @Test
-    void givenByteEqualHeadersInDistinctArrays_whenCompared_thenRomsAreEqual() {
-        Rom one = romWithHeader(NES_HEADER.clone());
-        Rom other = romWithHeader(NES_HEADER.clone());
+    void givenByteEqualHeadersInDistinctInstances_whenCompared_thenRomsAreEqual() {
+        Rom one = romWithHeader(copyOf(NES_HEADER));
+        Rom other = romWithHeader(copyOf(NES_HEADER));
 
         assertNotEquals(
                 System.identityHashCode(one.header()),
                 System.identityHashCode(other.header()),
-                "test premise: the two headers must be distinct array instances");
+                "test premise: the two headers must be distinct instances");
         assertEquals(one, other, "ROMs with byte-equal headers must be equal");
         assertEquals(
                 one.hashCode(),
@@ -60,18 +59,19 @@ class RomTest {
 
     @Test
     void givenDifferentHeaderContent_whenCompared_thenRomsAreNotEqual() {
-        Rom one = romWithHeader(NES_HEADER.clone());
-        Rom other = romWithHeader(new byte[]{0x4E, 0x45, 0x53, 0x1B});
+        Rom one = romWithHeader(NES_HEADER);
+        Rom other = romWithHeader(
+                ImmutableList.of((byte) 0x4E, (byte) 0x45, (byte) 0x53, (byte) 0x1B));
 
         assertNotEquals(one, other, "ROMs whose header bytes differ must not be equal");
     }
 
     @Test
     void givenAHeaderedRom_whenRenderedAsText_thenTheHeaderContentIsVisible() {
-        String rendered = romWithHeader(NES_HEADER.clone()).toString();
+        String rendered = romWithHeader(NES_HEADER).toString();
 
         assertTrue(
-                rendered.contains(Arrays.toString(NES_HEADER)),
+                rendered.contains(NES_HEADER.toString()),
                 () -> "toString must render header content, got: " + rendered);
     }
 
@@ -83,19 +83,23 @@ class RomTest {
                 .games(ImmutableList.of(Game.builder()
                         .name("Some Game (USA)")
                         .description("Some Game (USA)")
-                        .roms(ImmutableList.of(romWithHeader(NES_HEADER.clone())))
+                        .roms(ImmutableList.of(romWithHeader(NES_HEADER)))
                         .build()))
                 .build();
 
         byte[] xml = helper.getXmlMapper().writeValueAsBytes(datafile);
         Datafile parsed = helper.loadXml(new ByteArrayInputStream(xml), Datafile.class);
 
-        byte[] parsedHeader = parsed.getGames().get(0).getRoms().get(0).header();
-        assertArrayEquals(
+        ImmutableList<Byte> parsedHeader = parsed.getGames().get(0).getRoms().get(0).header();
+        assertEquals(
                 NES_HEADER,
                 parsedHeader,
-                () -> "header bytes must survive the round trip, wrote: " + new String(xml)
-                        + " read back: " + HexFormat.of().formatHex(parsedHeader));
+                () -> "header bytes must survive the round trip, wrote: " + new String(xml));
         assertEquals(datafile, parsed, "a round-tripped DAT must equal the one written");
+    }
+
+    /** A distinct instance holding the same bytes. */
+    private static ImmutableList<Byte> copyOf(ImmutableList<Byte> header) {
+        return ImmutableList.copyOf(new ArrayList<>(header));
     }
 }

--- a/domain/src/main/java/io/github/datromtool/domain/datafile/logiqx/Rom.java
+++ b/domain/src/main/java/io/github/datromtool/domain/datafile/logiqx/Rom.java
@@ -3,6 +3,7 @@ package io.github.datromtool.domain.datafile.logiqx;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonRootName;
+import com.google.common.collect.ImmutableList;
 import io.github.datromtool.domain.datafile.logiqx.enumerations.Status;
 import io.github.datromtool.domain.datafile.logiqx.enumerations.YesNo;
 import io.github.datromtool.domain.serialization.SpacedHexArrayDeserializer;
@@ -12,9 +13,6 @@ import tools.jackson.databind.annotation.JsonSerialize;
 import tools.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 
 import javax.annotation.Nonnull;
-
-import java.util.Arrays;
-import java.util.Objects;
 
 import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_DEFAULT;
 
@@ -33,10 +31,15 @@ public record Rom(
         @JacksonXmlProperty(isAttribute = true)
         Long size,
 
+        /**
+         * An immutable list rather than a {@code byte[]}: a record's generated equality
+         * compares an array component by identity, so two ROMs with the same header would
+         * not be equal. Headers are a handful of bytes, so boxing is irrelevant here.
+         */
         @JacksonXmlProperty(isAttribute = true)
         @JsonSerialize(using = SpacedHexArraySerializer.class)
         @JsonDeserialize(using = SpacedHexArrayDeserializer.class)
-        byte[] header,
+        ImmutableList<Byte> header,
 
         @Nonnull
         @JacksonXmlProperty(isAttribute = true)
@@ -73,64 +76,5 @@ public record Rom(
 
     public Rom(String name, Long size) {
         this(name, size, null, YesNo.NO, null, null, null, null, null, null, null, null);
-    }
-
-    // The generated record methods compare header by array identity, which makes two ROMs
-    // describing the same dumped file unequal. Header content is part of a ROM's value.
-
-    @Override
-    public boolean equals(Object obj) {
-        if (this == obj) {
-            return true;
-        }
-        return obj instanceof Rom other
-                && Objects.equals(name, other.name)
-                && Objects.equals(size, other.size)
-                && Arrays.equals(header, other.header)
-                && mia == other.mia
-                && Objects.equals(crc, other.crc)
-                && Objects.equals(md5, other.md5)
-                && Objects.equals(sha1, other.sha1)
-                && Objects.equals(sha256, other.sha256)
-                && Objects.equals(merge, other.merge)
-                && status == other.status
-                && Objects.equals(date, other.date)
-                && Objects.equals(serial, other.serial);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(
-                name,
-                size,
-                Arrays.hashCode(header),
-                mia,
-                crc,
-                md5,
-                sha1,
-                sha256,
-                merge,
-                status,
-                date,
-                serial);
-    }
-
-    @Override
-    public String toString() {
-        return ("Rom[name=%s, size=%s, header=%s, mia=%s, crc=%s, md5=%s, sha1=%s, sha256=%s, "
-                + "merge=%s, status=%s, date=%s, serial=%s]")
-                .formatted(
-                        name,
-                        size,
-                        Arrays.toString(header),
-                        mia,
-                        crc,
-                        md5,
-                        sha1,
-                        sha256,
-                        merge,
-                        status,
-                        date,
-                        serial);
     }
 }

--- a/domain/src/main/java/io/github/datromtool/domain/datafile/logiqx/Rom.java
+++ b/domain/src/main/java/io/github/datromtool/domain/datafile/logiqx/Rom.java
@@ -13,6 +13,9 @@ import tools.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 
 import javax.annotation.Nonnull;
 
+import java.util.Arrays;
+import java.util.Objects;
+
 import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_DEFAULT;
 
 @JsonInclude(NON_DEFAULT)
@@ -70,5 +73,64 @@ public record Rom(
 
     public Rom(String name, Long size) {
         this(name, size, null, YesNo.NO, null, null, null, null, null, null, null, null);
+    }
+
+    // The generated record methods compare header by array identity, which makes two ROMs
+    // describing the same dumped file unequal. Header content is part of a ROM's value.
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        return obj instanceof Rom other
+                && Objects.equals(name, other.name)
+                && Objects.equals(size, other.size)
+                && Arrays.equals(header, other.header)
+                && mia == other.mia
+                && Objects.equals(crc, other.crc)
+                && Objects.equals(md5, other.md5)
+                && Objects.equals(sha1, other.sha1)
+                && Objects.equals(sha256, other.sha256)
+                && Objects.equals(merge, other.merge)
+                && status == other.status
+                && Objects.equals(date, other.date)
+                && Objects.equals(serial, other.serial);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(
+                name,
+                size,
+                Arrays.hashCode(header),
+                mia,
+                crc,
+                md5,
+                sha1,
+                sha256,
+                merge,
+                status,
+                date,
+                serial);
+    }
+
+    @Override
+    public String toString() {
+        return ("Rom[name=%s, size=%s, header=%s, mia=%s, crc=%s, md5=%s, sha1=%s, sha256=%s, "
+                + "merge=%s, status=%s, date=%s, serial=%s]")
+                .formatted(
+                        name,
+                        size,
+                        Arrays.toString(header),
+                        mia,
+                        crc,
+                        md5,
+                        sha1,
+                        sha256,
+                        merge,
+                        status,
+                        date,
+                        serial);
     }
 }

--- a/domain/src/main/java/io/github/datromtool/domain/serialization/SpacedHexArrayDeserializer.java
+++ b/domain/src/main/java/io/github/datromtool/domain/serialization/SpacedHexArrayDeserializer.java
@@ -1,5 +1,7 @@
 package io.github.datromtool.domain.serialization;
 
+import com.google.common.collect.ImmutableList;
+import com.google.common.primitives.Bytes;
 import org.apache.commons.codec.DecoderException;
 import org.apache.commons.codec.binary.Hex;
 import org.apache.commons.lang3.StringUtils;
@@ -8,17 +10,18 @@ import tools.jackson.databind.DeserializationContext;
 import tools.jackson.databind.ValueDeserializer;
 import tools.jackson.databind.exc.InvalidFormatException;
 
-public final class SpacedHexArrayDeserializer extends ValueDeserializer<byte[]> {
+public final class SpacedHexArrayDeserializer extends ValueDeserializer<ImmutableList<Byte>> {
 
     @Override
-    public byte[] deserialize(JsonParser p, DeserializationContext ctxt) {
+    public ImmutableList<Byte> deserialize(JsonParser p, DeserializationContext ctxt) {
         String valueAsString = p.getValueAsString();
         try {
             if (valueAsString != null) {
-                return Hex.decodeHex(StringUtils.deleteWhitespace(valueAsString));
+                return ImmutableList.copyOf(
+                        Bytes.asList(Hex.decodeHex(StringUtils.deleteWhitespace(valueAsString))));
             }
         } catch (DecoderException e) {
-            InvalidFormatException ife = InvalidFormatException.from(p, "Invalid spaced hex string", valueAsString, byte[].class);
+            InvalidFormatException ife = InvalidFormatException.from(p, "Invalid spaced hex string", valueAsString, ImmutableList.class);
             ife.initCause(e);
             throw ife;
         }

--- a/domain/src/main/java/io/github/datromtool/domain/serialization/SpacedHexArraySerializer.java
+++ b/domain/src/main/java/io/github/datromtool/domain/serialization/SpacedHexArraySerializer.java
@@ -1,21 +1,26 @@
 package io.github.datromtool.domain.serialization;
 
+import com.google.common.collect.ImmutableList;
+import com.google.common.primitives.Bytes;
 import tools.jackson.core.JsonGenerator;
 import tools.jackson.databind.SerializationContext;
 import tools.jackson.databind.ValueSerializer;
 
 import java.util.HexFormat;
 
-public final class SpacedHexArraySerializer extends ValueSerializer<byte[]> {
+public final class SpacedHexArraySerializer extends ValueSerializer<ImmutableList<Byte>> {
 
     private static final HexFormat SPACED_UPPER_CASE = HexFormat.ofDelimiter(" ").withUpperCase();
 
     @Override
-    public void serialize(byte[] value, JsonGenerator gen, SerializationContext serializers) {
+    public void serialize(
+            ImmutableList<Byte> value,
+            JsonGenerator gen,
+            SerializationContext serializers) {
         if (value == null) {
             gen.writeNull();
         } else {
-            gen.writeString(SPACED_UPPER_CASE.formatHex(value));
+            gen.writeString(SPACED_UPPER_CASE.formatHex(Bytes.toArray(value)));
         }
     }
 }

--- a/domain/src/main/java/io/github/datromtool/domain/serialization/SpacedHexArraySerializer.java
+++ b/domain/src/main/java/io/github/datromtool/domain/serialization/SpacedHexArraySerializer.java
@@ -1,31 +1,21 @@
 package io.github.datromtool.domain.serialization;
 
-import org.apache.commons.codec.binary.Hex;
 import tools.jackson.core.JsonGenerator;
 import tools.jackson.databind.SerializationContext;
 import tools.jackson.databind.ValueSerializer;
 
+import java.util.HexFormat;
+
 public final class SpacedHexArraySerializer extends ValueSerializer<byte[]> {
+
+    private static final HexFormat SPACED_UPPER_CASE = HexFormat.ofDelimiter(" ").withUpperCase();
 
     @Override
     public void serialize(byte[] value, JsonGenerator gen, SerializationContext serializers) {
         if (value == null) {
             gen.writeNull();
         } else {
-            String hexString = Hex.encodeHexString(value).toUpperCase();
-            if (hexString.length() == 2) {
-                gen.writeString(hexString);
-            } else {
-                StringBuilder output = new StringBuilder(hexString.length() + hexString.length() / 2 - 1);
-                for (int i = 0; i < hexString.length() - 2; i += 2) {
-                    if (i > 0) {
-                        output.append(' ');
-                    }
-                    output.append(hexString.charAt(i));
-                    output.append(hexString.charAt(i + 1));
-                }
-                gen.writeString(output.toString());
-            }
+            gen.writeString(SPACED_UPPER_CASE.formatHex(value));
         }
     }
 }


### PR DESCRIPTION
Fixes #35

## What

`Rom` is a record with a `byte[] header` component, so the generated `equals`/`hashCode` compared the header **by array identity**: two ROMs describing the same dumped file were unequal and hashed differently, and any `Datafile` equality check silently depended on which array instance held the bytes.

The fix is to drop the array, not to paper over it: `header` is now an `ImmutableList<Byte>`, so the record's generated `equals`/`hashCode`/`toString` are content-based by construction and there is nothing to keep in sync as components are added. Headers are a handful of bytes, so the boxing is irrelevant; the scanner and detector hot paths keep their `byte[]` buffers. The first commit contains the hand-written `equals`/`hashCode`/`toString` this replaces — it is kept so the red→green proof below stays attached to the code it was executed against.

The round-trip test the issue asked for also caught a second, unreported defect on the same path: `SpacedHexArraySerializer` dropped the last byte of every header longer than one byte — its loop ran to `hexString.length() - 2`, so a 4-byte header serialized as `header="4E 45 53"`. Headers therefore never survived a DAT round trip regardless of equality. The hand-rolled loop is replaced with `HexFormat.ofDelimiter(" ").withUpperCase()`.

The house rule this came out of ("no arrays as fields of a value type", with the hot-path exception) landed separately on `master` in `.agents/context/lang-java.md` (6eedba6), per the dev-only class in `.agents/policy/git.md`.

## Red → green proof

Test file frozen byte-identical across both runs — `git hash-object core/src/test/java/io/github/datromtool/domain/datafile/logiqx/RomTest.java` = `4434c705b5abcb0b0c091bfe87f7d6db79927af1` at red time and at green time.

RED, on untouched production code (`mvn -B -pl core -am test -Dtest=RomTest`):

```
[ERROR] Tests run: 4, Failures: 3, Errors: 0, Skipped: 0
[ERROR]   RomTest.givenAHeaderedRomInADatafile_whenRoundTrippedThroughXml_thenTheHeaderSurvives:94
  header bytes must survive the round trip, wrote: <rom name="Some Game (USA).nes" size="1024" header="4E 45 53" .../>
  read back: 4e4553 ==> array lengths differ, expected: <4> but was: <3>
[ERROR]   RomTest.givenByteEqualHeadersInDistinctArrays_whenCompared_thenRomsAreEqual:54
  ROMs with byte-equal headers must be equal ==> expected: <Rom[... header=[B@f1a45f8 ...]> but was: <Rom[... header=[B@5edf2821 ...]>
[ERROR]   RomTest.givenAHeaderedRom_whenRenderedAsText_thenTheHeaderContentIsVisible:73
  toString must render header content, got: Rom[... header=[B@5c9ac4cc ...]
```

GREEN, same tests, zero edits:

```
Tests run: 4, Failures: 0, Errors: 0, Skipped: 0 -- in io.github.datromtool.domain.datafile.logiqx.RomTest
```

The second commit is a behaviour-preserving refactor of the same fix, so the tests move from `byte[]` fixtures to list fixtures and stay green (`Tests run: 4, Failures: 0`); their assertions are unchanged in substance and still fail if the component goes back to an array.

## Gates

```
$ sh scripts/agent/run-gates.sh --diff origin/master     # both commits
GATE PASS: mvn -B -q verify
GATES: PASS
```

## Coverage

| Row | Test |
| --- | ---- |
| byte-equal headers in distinct instances compare equal and hash equal | `givenByteEqualHeadersInDistinctInstances_whenCompared_thenRomsAreEqual` |
| differing header bytes still compare unequal (the other side of the branch) | `givenDifferentHeaderContent_whenCompared_thenRomsAreNotEqual` |
| header content is visible in the rendered ROM | `givenAHeaderedRom_whenRenderedAsText_thenTheHeaderContentIsVisible` |
| a headered ROM survives an XML round trip, and the round-tripped DAT equals the original | `givenAHeaderedRomInADatafile_whenRoundTrippedThroughXml_thenTheHeaderSurvives` |

`Rom.header` was the only array-typed record component in the model, and its serdes pair (`SpacedHexArraySerializer`/`SpacedHexArrayDeserializer`) has no other user. The other array-carrying types (`BinaryTest`, `LogicalTest`) are Lombok `@Value` classes, whose generated `equals` already uses `Arrays.equals`; their `HexArraySerializer` delegates straight to `Hex.encodeHexString` and never had the truncation bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
