### PR TITLE
core: report scan failures that happen outside a scanning thread

### DIFF
--- a/cli/src/main/java/io/github/datromtool/cli/progressbar/CommandLineProgressBar.java
+++ b/cli/src/main/java/io/github/datromtool/cli/progressbar/CommandLineProgressBar.java
@@ -270,6 +270,12 @@ public final class CommandLineProgressBar implements FileScanner.Listener, FileC
 
     @Override
     public void reportFailure(int thread, Path path, String message, Throwable cause) {
+        if (thread == FileScanner.Listener.NO_THREAD) {
+            // Listing failures and interrupted result collection belong to no scanner line:
+            // there is no LineData slot to update, so they get a plain line.
+            writer.printf("FAILED: %s ('%s')%n", message, path);
+            return;
+        }
         reportFailure(thread, path, null, message, cause);
     }
 

--- a/cli/src/test/java/io/github/datromtool/cli/command/ScanCommandTest.java
+++ b/cli/src/test/java/io/github/datromtool/cli/command/ScanCommandTest.java
@@ -12,14 +12,18 @@ import tools.jackson.dataformat.yaml.YAMLMapper;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.PrintStream;
+import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.nio.file.attribute.PosixFilePermission;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 /**
  * Coverage matrix for issue #17's {@code scan} subcommand.
@@ -204,6 +208,43 @@ class ScanCommandTest {
         }
         assertEquals(2, exitCode, "missing DIR parameter must exit with code 2, stderr was:\n" + capturedErr);
     }
+    // Row 9: a scan that could not list part of the tree reports a truncated report through its
+    // exit code instead of passing it off as a complete one (issue #37).
+    @Test
+    void unlistableSubdirectoryMakesScanExitNonZero(@TempDir Path tempDir) throws IOException {
+        Files.write(tempDir.resolve("rom.bin"), new byte[16 * 1024]);
+        Path unlistable = Files.createDirectory(tempDir.resolve("unlistable"));
+        assumeTrue(makeUnlistable(unlistable), "this filesystem/user cannot make a directory unlistable");
+        try {
+            captureStdout(() -> assertEquals(
+                    1,
+                    run(new ScanCommand(), tempDir.toString(), "--out-mode", "json"),
+                    "a scan that could not list a subdirectory must not exit 0"));
+        } finally {
+            Files.setPosixFilePermissions(unlistable, Set.of(
+                    PosixFilePermission.OWNER_READ,
+                    PosixFilePermission.OWNER_WRITE,
+                    PosixFilePermission.OWNER_EXECUTE));
+        }
+    }
+
+    /**
+     * Strips every permission bit and confirms the directory really became unlistable — it does
+     * not on a filesystem without POSIX permissions, nor for a superuser.
+     */
+    private static boolean makeUnlistable(Path directory) {
+        try {
+            Files.setPosixFilePermissions(directory, Set.of());
+        } catch (UnsupportedOperationException | IOException e) {
+            return false;
+        }
+        try (DirectoryStream<Path> ignored = Files.newDirectoryStream(directory)) {
+            return false;
+        } catch (IOException expected) {
+            return true;
+        }
+    }
+
     @Test
     void progressOutputStaysPinnedToStderr() {
         // jline writes progress at file-descriptor level, bypassing System.setOut capture,

--- a/core/src/main/java/io/github/datromtool/io/FileScanner.java
+++ b/core/src/main/java/io/github/datromtool/io/FileScanner.java
@@ -140,6 +140,9 @@ public final class FileScanner {
 
     public interface Listener {
 
+        /** Thread index for a failure that belongs to no scanning thread. */
+        int NO_THREAD = 0;
+
         void reportListing(Path path);
 
         void reportFinishedListing(int amount);
@@ -154,6 +157,11 @@ public final class FileScanner {
 
         void reportSkip(int thread, Path path, String message);
 
+        /**
+         * @param thread the 1-based scanning thread the failure happened on, or
+         *               {@link #NO_THREAD} for a failure outside any scanning thread (listing a
+         *               directory, or collecting a worker's results).
+         */
         void reportFailure(int thread, Path path, String message, Throwable cause);
 
         void reportFinish(int thread, Path path);
@@ -163,7 +171,7 @@ public final class FileScanner {
     }
 
     @AllArgsConstructor
-    private final static class AppendingFileVisitor extends SimpleFileVisitor<Path> {
+    private final class AppendingFileVisitor extends SimpleFileVisitor<Path> {
 
         private final Consumer<FileMetadata> onVisited;
 
@@ -179,7 +187,14 @@ public final class FileScanner {
         @Override
         public FileVisitResult visitFileFailed(Path file, IOException exc) {
             log.warn("Failed to scan '{}'", file, exc);
+            reportFailure(file, "Could not list", exc);
             return FileVisitResult.SKIP_SUBTREE;
+        }
+    }
+
+    private void reportFailure(Path path, String message, Throwable cause) {
+        for (Listener listener : listeners) {
+            listener.reportFailure(Listener.NO_THREAD, path, message, cause);
         }
     }
 
@@ -203,6 +218,7 @@ public final class FileScanner {
                     Files.walkFileTree(directory, new AppendingFileVisitor(pathsBuilder::add));
                 } catch (Exception e) {
                     log.error("Could not scan '{}'", directory, e);
+                    reportFailure(directory, "Could not list the directory", e);
                 }
             }
             ImmutableList<FileMetadata> paths = pathsBuilder.build();
@@ -213,10 +229,10 @@ public final class FileScanner {
             }
             ImmutableList<Result> results = paths.stream()
                     .sorted(FILE_SIZE_DESCENDING_COMPARATOR)
-                    .map(fm -> executorService.submit(() -> scanFile(fm)))
+                    .map(fm -> new ScanTask(fm.getPath(), executorService.submit(() -> scanFile(fm))))
                     .collect(ImmutableList.toImmutableList())
                     .stream()
-                    .flatMap(FileScanner::streamResults)
+                    .flatMap(this::streamResults)
                     .collect(ImmutableList.toImmutableList());
             for (Listener listener : listeners) {
                 listener.reportAllFinished();
@@ -230,11 +246,20 @@ public final class FileScanner {
         }
     }
 
-    private static <T> Stream<T> streamResults(Future<ImmutableList<T>> future) {
+    private record ScanTask(Path path, Future<ImmutableList<Result>> future) {
+    }
+
+    private Stream<Result> streamResults(ScanTask task) {
         try {
-            return future.get().stream();
+            return task.future().get().stream();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            log.error("Interrupted while collecting the results of '{}'", task.path(), e);
+            reportFailure(task.path(), "Interrupted while collecting the scan results", e);
+            return Stream.empty();
         } catch (Exception e) {
             log.error("Unexpected exception thrown", e);
+            reportFailure(task.path(), "Could not collect the scan results", e);
             return Stream.empty();
         }
     }

--- a/core/src/test/java/io/github/datromtool/io/FileScannerErrorSignalTest.java
+++ b/core/src/test/java/io/github/datromtool/io/FileScannerErrorSignalTest.java
@@ -1,0 +1,186 @@
+package io.github.datromtool.io;
+
+import com.google.common.collect.ImmutableList;
+import io.github.datromtool.config.AppConfig;
+import io.github.datromtool.io.logging.FileScannerLoggingListener;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+/**
+ * A scan that could not look at everything it was pointed at must not be reportable as a
+ * complete one: the caller (the {@code scan} command's exit code, later the GUI) can only
+ * distinguish a complete report from a truncated one if the failure reaches a listener.
+ */
+class FileScannerErrorSignalTest {
+
+    @AfterEach
+    void clearInterruptFlag() {
+        Thread.interrupted();
+    }
+
+    private static FileScanner scannerWith(FileScanner.Listener... listeners) {
+        return new FileScanner(
+                AppConfig.FileScannerConfig.builder().build(),
+                ImmutableList.of(),
+                ImmutableList.of(),
+                ImmutableList.copyOf(listeners));
+    }
+
+    /**
+     * Strips every permission bit and confirms the directory really became unlistable — it does
+     * not on a filesystem without POSIX permissions, nor for a superuser.
+     */
+    private static boolean makeUnlistable(Path directory) {
+        try {
+            Files.setPosixFilePermissions(directory, Set.of());
+        } catch (UnsupportedOperationException | IOException e) {
+            return false;
+        }
+        try (DirectoryStream<Path> ignored = Files.newDirectoryStream(directory)) {
+            return false;
+        } catch (IOException expected) {
+            return true;
+        }
+    }
+
+    private static void restorePermissions(Path directory) throws IOException {
+        try {
+            Files.setPosixFilePermissions(directory, Set.of(
+                    java.nio.file.attribute.PosixFilePermission.OWNER_READ,
+                    java.nio.file.attribute.PosixFilePermission.OWNER_WRITE,
+                    java.nio.file.attribute.PosixFilePermission.OWNER_EXECUTE));
+        } catch (UnsupportedOperationException e) {
+            // nothing to restore on a filesystem that never applied them
+        }
+    }
+
+    @Test
+    void givenARootThatCannotBeListed_whenScanning_thenTheFailureIsReported(@TempDir Path tempDir) {
+        Path missingRoot = tempDir.resolve("not-there");
+        FileScannerLoggingListener listener = new FileScannerLoggingListener();
+
+        ImmutableList<FileScanner.Result> results =
+                scannerWith(listener).scan(ImmutableList.of(missingRoot));
+
+        assertTrue(results.isEmpty(), "nothing is scannable under a root that cannot be listed");
+        assertTrue(
+                listener.isErrors(),
+                "a root that could not be listed must not look like an empty, successful scan");
+    }
+
+    @Test
+    void givenASubdirectoryThatCannotBeListed_whenScanning_thenTheFailureIsReported(
+            @TempDir Path tempDir) throws IOException {
+        Path unlistable = Files.createDirectory(tempDir.resolve("unlistable"));
+        Files.write(unlistable.resolve("rom.bin"), new byte[64 * 1024]);
+        assumeTrue(
+                makeUnlistable(unlistable),
+                "this filesystem/user cannot make a directory unlistable");
+        FileScannerLoggingListener listener = new FileScannerLoggingListener();
+
+        try {
+            scannerWith(listener).scan(ImmutableList.of(tempDir));
+
+            assertTrue(
+                    listener.isErrors(),
+                    "a subtree that could not be listed must not be silently skipped");
+        } finally {
+            restorePermissions(unlistable);
+        }
+    }
+
+    @Test
+    void givenTheCallingThreadIsInterrupted_whenCollectingResults_thenTheFailureIsReported(
+            @TempDir Path tempDir) throws IOException {
+        Files.write(tempDir.resolve("rom.bin"), new byte[64 * 1024]);
+        FileScannerLoggingListener listener = new FileScannerLoggingListener();
+        InterruptingListener interrupting = new InterruptingListener();
+
+        ImmutableList<FileScanner.Result> results;
+        try {
+            results = scannerWith(listener, interrupting).scan(ImmutableList.of(tempDir));
+        } finally {
+            interrupting.release();
+        }
+
+        assertTrue(results.isEmpty(), "an interrupted scan collects no results");
+        assertTrue(
+                listener.isErrors(),
+                "an interrupted scan must not look like a successful, empty one");
+        assertTrue(
+                Thread.interrupted(),
+                "the interrupt must be handed back to the caller, not swallowed");
+    }
+
+    /**
+     * Interrupts the scanning caller and holds the worker thread, so result collection is
+     * genuinely interrupted instead of racing a future that already completed.
+     */
+    private static final class InterruptingListener implements FileScanner.Listener {
+
+        private final CountDownLatch holdWorker = new CountDownLatch(1);
+
+        void release() {
+            holdWorker.countDown();
+        }
+
+        @Override
+        public void reportTotalItems(int totalItems) {
+            // Runs on the scanning caller, right before the results are collected.
+            Thread.currentThread().interrupt();
+        }
+
+        @Override
+        public void reportStart(int thread, Path path, long bytes) {
+            // Runs on the worker: keep its future incomplete until the test releases it.
+            try {
+                holdWorker.await();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        }
+
+        @Override
+        public void reportListing(Path path) {
+        }
+
+        @Override
+        public void reportFinishedListing(int amount) {
+        }
+
+        @Override
+        public void init(int numThreads) {
+        }
+
+        @Override
+        public void reportBytesRead(int thread, long bytes) {
+        }
+
+        @Override
+        public void reportSkip(int thread, Path path, String message) {
+        }
+
+        @Override
+        public void reportFailure(int thread, Path path, String message, Throwable cause) {
+        }
+
+        @Override
+        public void reportFinish(int thread, Path path) {
+        }
+
+        @Override
+        public void reportAllFinished() {
+        }
+    }
+}


### PR DESCRIPTION
Fixes #37

## What

`FileScanner` swallowed three failure classes, so a truncated scan was indistinguishable from a complete one and `datrom scan` exited 0 on it:

- `AppendingFileVisitor.visitFileFailed` — logged a WARN and returned `SKIP_SUBTREE`;
- the `walkFileTree` catch — logged an ERROR, so an unreadable root produced an empty scan that looked successful;
- `streamResults` — swallowed everything from `Future.get()`, including `InterruptedException`, and returned an empty stream (the interrupt was dropped as well).

All three now report through the existing `Listener.reportFailure`, using a new `Listener.NO_THREAD` index that marks a failure belonging to no scanning thread — so `FileScannerLoggingListener.isErrors()` (and with it the `scan` exit code, and later the GUI status) sees them. `streamResults` restores the interrupt for the caller. `CommandLineProgressBar` prints `NO_THREAD` failures on a plain line, since they own no thread line to update.

No new listener method: the existing callback carries the report, so no implementor has to be taught a new one.

## Red → green proof

Test files frozen byte-identical across both runs (`git hash-object`):

| File | Hash at red and at green |
| --- | --- |
| `core/src/test/java/io/github/datromtool/io/FileScannerErrorSignalTest.java` | `18ad6f286900980aa67b5e0a492e73e4985b2bb1` |
| `cli/src/test/java/io/github/datromtool/cli/command/ScanCommandTest.java` | `cbb4ccdc76e0682c56e6f5830adb9c788e4eb992` |

RED, on untouched production code:

```
$ mvn -B -pl core -am test -Dtest=FileScannerErrorSignalTest
[ERROR] Tests run: 3, Failures: 3, Errors: 0, Skipped: 0
[ERROR]   ...givenARootThatCannotBeListed_whenScanning_thenTheFailureIsReported:77
  a root that could not be listed must not look like an empty, successful scan ==> expected: <true> but was: <false>
[ERROR]   ...givenASubdirectoryThatCannotBeListed_whenScanning_thenTheFailureIsReported:95
  a subtree that could not be listed must not be silently skipped ==> expected: <true> but was: <false>
[ERROR]   ...givenTheCallingThreadIsInterrupted_whenCollectingResults_thenTheFailureIsReported:118
  an interrupted scan must not look like a successful, empty one ==> expected: <true> but was: <false>

$ mvn -B -pl cli -am test -Dtest=ScanCommandTest#unlistableSubdirectoryMakesScanExitNonZero
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0
[ERROR]   ScanCommandTest.unlistableSubdirectoryMakesScanExitNonZero:219
  a scan that could not list a subdirectory must not exit 0 ==> expected: <1> but was: <0>
```

GREEN, same tests, zero edits:

```
$ mvn -B -pl cli -am test -Dtest='FileScannerErrorSignalTest,ScanCommandTest'
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0 -- in io.github.datromtool.io.FileScannerErrorSignalTest
[INFO] Tests run: 13, Failures: 0, Errors: 0, Skipped: 0 -- in io.github.datromtool.cli.command.ScanCommandTest
```

## Gates

```
$ sh scripts/agent/run-gates.sh --diff origin/master
GATE PASS: mvn -B -q verify
GATES: PASS
```

## Coverage

| Swallow point | Test |
| --- | --- |
| `visitFileFailed` (a subtree that cannot be listed) | `givenASubdirectoryThatCannotBeListed_whenScanning_thenTheFailureIsReported` |
| `walkFileTree` catch (a root that cannot be walked) | `givenARootThatCannotBeListed_whenScanning_thenTheFailureIsReported` |
| `streamResults` (interrupted result collection, plus the interrupt being restored) | `givenTheCallingThreadIsInterrupted_whenCollectingResults_thenTheFailureIsReported` |
| the `scan` exit code riding on top | `ScanCommandTest.unlistableSubdirectoryMakesScanExitNonZero` |

Both `FileScanner.Listener` implementations are covered: `FileScannerLoggingListener` (asserted through `isErrors()`) and `CommandLineProgressBar` (exercised end-to-end by the CLI row, which would otherwise index `threadLineData[-1]`).

The two permission-dependent tests self-skip via `assumeTrue` when the filesystem has no POSIX permissions or the user is a superuser — the helper strips every bit and then *confirms* the directory really became unlistable rather than assuming it. The interrupt test holds the worker on a latch so result collection is genuinely interrupted instead of racing a future that already completed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
