### PR TITLE
core: bound clone list pattern matching and honour ignored groups

### DIFF
--- a/cli/src/test/java/io/github/datromtool/cli/command/OneGameOneRomCommandCloneListFamilyTest.java
+++ b/cli/src/test/java/io/github/datromtool/cli/command/OneGameOneRomCommandCloneListFamilyTest.java
@@ -12,6 +12,8 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Review round fix: clone list group keys sharing a namespace with raw DAT parent names, and
@@ -80,6 +82,29 @@ class OneGameOneRomCommandCloneListFamilyTest {
                 matches,
                 "a clone list match on only the family's parent must still unify the whole "
                         + "DAT parent/clone family into exactly one 1G1R entry, got:\n" + output);
+    }
+
+    // (c): upstream's ignore flag "force removes the title from Retool's consideration" - an
+    // ignored title must be gone from the 1G1R output, not merely left on its DAT grouping
+    // (issue #43). "Mystery Quest (USA)" is the only member of its ignored group, so it would
+    // otherwise win outright and be listed; the unrelated "Adventure" must stay.
+    @Test
+    void ignoredGroupRemovesItsTitleFromTheOutput() {
+        OneGameOneRomCommand command = new OneGameOneRomCommand();
+        CommandLine commandLine = newCommandLine(command);
+        commandLine.parseArgs(
+                "--clonelist", fixture("retool/clonelists/mystery-quest-ignored.json").toString(),
+                fixture("datafiles/adventure-collision.dat").toString());
+
+        String output = runAndCaptureStdout(command, commandLine);
+
+        assertTrue(
+                output.contains("Adventure"),
+                "a game untouched by the clone list must still be listed, got:\n" + output);
+        assertFalse(
+                output.contains("Mystery Quest"),
+                "a title in a group flagged ignore must be removed from consideration "
+                        + "entirely, got:\n" + output);
     }
 
     // (b): a clone list group literally named the same as an unrelated, untagged DAT game must

--- a/cli/src/test/resources/retool/clonelists/mystery-quest-ignored.json
+++ b/cli/src/test/resources/retool/clonelists/mystery-quest-ignored.json
@@ -1,0 +1,22 @@
+{
+	"description": {
+		"name": "Ignored Group Test",
+		"lastUpdated": "2026-01-02 11:07:19",
+		"minimumVersion": "1.0.0"
+	},
+	"variants": [
+		{
+			"group": "Mystery Quest",
+			"ignore": true,
+			"titles": [
+				{"searchTerm": "Mystery Quest (USA)", "nameType": "full"}
+			]
+		},
+		{
+			"group": "Adventure Group",
+			"titles": [
+				{"searchTerm": "Adventure", "nameType": "full"}
+			]
+		}
+	]
+}

--- a/core/src/main/java/io/github/datromtool/command/OneGameOneRom.java
+++ b/core/src/main/java/io/github/datromtool/command/OneGameOneRom.java
@@ -211,12 +211,16 @@ public final class OneGameOneRom {
         RegionData regionData = SerializationHelper.getInstance().loadRegionData();
         CloneListMatcher matcher = new CloneListMatcher(cloneList, regionData, sortingPreference);
         ImmutableList<ParsedGame> matched = parsedGames.stream()
-                .map(g -> matcher.match(g)
-                        .map(mr -> g.toBuilder()
-                                .clonelistGroup(mr.group())
-                                .clonelistPriority(mr.priority())
-                                .build())
-                        .orElse(g))
+                .flatMap(g -> matcher.match(g)
+                        // An ignored group removes its titles from the run entirely, so the game
+                        // never reaches grouping, 1G1R selection, or the output.
+                        .map(mr -> mr.ignored()
+                                ? Stream.<ParsedGame>empty()
+                                : Stream.of(g.toBuilder()
+                                        .clonelistGroup(mr.group())
+                                        .clonelistPriority(mr.priority())
+                                        .build()))
+                        .orElseGet(() -> Stream.of(g)))
                 .collect(ImmutableList.toImmutableList());
         return unifyClonelistGroupsAcrossDatFamilies(matched);
     }

--- a/core/src/main/java/io/github/datromtool/retool/CloneListMatcher.java
+++ b/core/src/main/java/io/github/datromtool/retool/CloneListMatcher.java
@@ -116,6 +116,15 @@ public final class CloneListMatcher {
 
     private static final String ALL_OTHER_REGIONS = "All other regions";
 
+    /**
+     * How much of a game's name one clone list pattern may read before it is given up on. A
+     * clone list is community data a user points {@code --clonelist} at, and {@code
+     * java.util.regex} has no match timeout, so a catastrophically backtracking pattern would
+     * otherwise monopolize the run's thread (CWE-1333). Legitimate patterns read a small multiple
+     * of the name's length; this leaves three orders of magnitude of headroom.
+     */
+    private static final int MAX_PATTERN_CHARACTER_READS = 100_000;
+
     private static final Pattern PAREN_GROUP = Pattern.compile("\\([^()]+\\)");
     private static final Pattern WHITESPACE = Pattern.compile("\\s+");
     private static final Pattern LANGUAGE_GROUP =
@@ -140,25 +149,42 @@ public final class CloneListMatcher {
      * {@code PrioritySubComparator} should compare by (both after any matching
      * {@link VariantFilter.Results} override has been applied).
      */
-    public record MatchResult(@Nonnull String group, int priority) {
+    public record MatchResult(@Nonnull String group, int priority, boolean ignored) {
+    }
+
+    /**
+     * Thrown when a clone list pattern reads more of a game's name than
+     * {@link #MAX_PATTERN_CHARACTER_READS} allows, which means it is backtracking
+     * catastrophically (CWE-1333).
+     */
+    public static final class PatternBudgetExceededException extends RuntimeException {
+
+        PatternBudgetExceededException(String message) {
+            super(message);
+        }
     }
 
     /**
      * @return the match for {@code game}, or {@link Optional#empty()} if no variant title in the
      * clone list's {@code titles} (see class Javadoc for why {@code supersets}/
      * {@code compilations} are excluded) matched its full name. Groups are searched in file
-     * order; a group with {@code ignore=true} is skipped entirely (upstream: {@code ignore}
-     * "force removes the title from Retool's consideration").
+     * order; a match inside a group with {@code ignore=true} comes back
+     * {@link MatchResult#ignored()}, which drops the game from the run entirely (upstream:
+     * {@code ignore} "force removes the title from Retool's consideration" - "ignored titles are
+     * completely removed from Retool's consideration during processing"). Keeping such a title on
+     * its DAT grouping instead would leave it in the 1G1R output, where it can still win its
+     * group.
      */
     @Nonnull
     public Optional<MatchResult> match(@Nonnull ParsedGame game) {
         String fullName = game.getGame().getName();
         for (VariantGroup group : cloneList.variants()) {
-            if (group.ignore()) {
-                continue;
-            }
             Optional<VariantTitle> best = bestMatch(group, fullName);
             if (best.isPresent()) {
+                if (group.ignore()) {
+                    return Optional.of(
+                            new MatchResult(group.group(), best.get().priority(), true));
+                }
                 return Optional.of(applyFilters(group, best.get(), game, fullName));
             }
         }
@@ -210,10 +236,74 @@ public final class CloneListMatcher {
         String searchTerm = title.searchTerm();
         return switch (title.nameType()) {
             case FULL -> fullName.equals(searchTerm);
-            case REGEX -> Pattern.compile(searchTerm).matcher(fullName).matches();
+            case REGEX -> matchesBounded(searchTerm, fullName);
             case REGION_FREE -> regionFreeName(fullName).equals(searchTerm);
             case SHORT -> shortName(fullName).equals(shortName(searchTerm));
         };
+    }
+
+    /**
+     * Matches {@code regex} against a character source that stops the engine once it has read
+     * {@link #MAX_PATTERN_CHARACTER_READS} characters — the backtracking engine reads the input
+     * once per step, so the read count bounds the work regardless of how the pattern is written.
+     *
+     * @throws PatternBudgetExceededException naming the pattern that ran out of budget
+     */
+    private static boolean matchesBounded(String regex, String fullName) {
+        try {
+            return Pattern.compile(regex)
+                    .matcher(new BudgetedCharSequence(fullName, MAX_PATTERN_CHARACTER_READS))
+                    .matches();
+        } catch (BudgetExceeded e) {
+            throw new PatternBudgetExceededException(String.format(
+                    "Clone list pattern '%s' read more than %d characters of '%s' without "
+                            + "deciding: it backtracks catastrophically and was given up on",
+                    regex,
+                    MAX_PATTERN_CHARACTER_READS,
+                    fullName));
+        }
+    }
+
+    /** Internal signal, converted to a {@link PatternBudgetExceededException} by its only caller. */
+    private static final class BudgetExceeded extends RuntimeException {
+
+        BudgetExceeded() {
+            super(null, null, false, false);
+        }
+    }
+
+    private static final class BudgetedCharSequence implements CharSequence {
+
+        private final CharSequence delegate;
+        private int readsLeft;
+
+        BudgetedCharSequence(CharSequence delegate, int readsLeft) {
+            this.delegate = delegate;
+            this.readsLeft = readsLeft;
+        }
+
+        @Override
+        public char charAt(int index) {
+            if (--readsLeft < 0) {
+                throw new BudgetExceeded();
+            }
+            return delegate.charAt(index);
+        }
+
+        @Override
+        public int length() {
+            return delegate.length();
+        }
+
+        @Override
+        public CharSequence subSequence(int start, int end) {
+            return delegate.subSequence(start, end);
+        }
+
+        @Override
+        public String toString() {
+            return delegate.toString();
+        }
     }
 
     private MatchResult applyFilters(
@@ -238,7 +328,7 @@ public final class CloneListMatcher {
                 break;
             }
         }
-        return new MatchResult(effectiveGroup, effectivePriority);
+        return new MatchResult(effectiveGroup, effectivePriority, false);
     }
 
     private boolean conditionsMatch(VariantFilter.Conditions conditions, ParsedGame game, String fullName) {
@@ -249,7 +339,7 @@ public final class CloneListMatcher {
             return false;
         }
         if (conditions.matchString() != null
-                && !Pattern.compile(conditions.matchString()).matcher(fullName).matches()) {
+                && !matchesBounded(conditions.matchString(), fullName)) {
             return false;
         }
         return conditions.regionOrder() == null || matchRegionOrder(conditions.regionOrder());

--- a/core/src/test/java/io/github/datromtool/retool/CloneListMatcherTest.java
+++ b/core/src/test/java/io/github/datromtool/retool/CloneListMatcherTest.java
@@ -15,17 +15,20 @@ import io.github.datromtool.domain.retool.VariantGroup;
 import io.github.datromtool.domain.retool.VariantTitle;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import java.net.URISyntaxException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 
 import static io.github.datromtool.util.TestUtils.createGame;
 import static io.github.datromtool.util.TestUtils.getRegionByCode;
 import static io.github.datromtool.util.TestUtils.loadRegionData;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -291,8 +294,11 @@ class CloneListMatcherTest {
         assertEquals(1, japanLast.orElseThrow().priority());
     }
 
+    // Issue #43 item 2: a group flagged ignore does not merely go unmatched (which left its
+    // titles on their DAT grouping, still able to win the 1G1R output) - upstream removes them
+    // from consideration entirely, which the caller can only do if the match says so.
     @Test
-    void variantGroupWithIgnoreFlagIsSkipped() {
+    void variantGroupWithIgnoreFlagMarksItsTitleIgnored() {
         CloneList cloneList = new CloneList(
                 new CloneListDescription("Test", "x", "1.0"),
                 ImmutableList.of(new VariantGroup(
@@ -312,8 +318,99 @@ class CloneListMatcherTest {
                         ImmutableList.of())));
         CloneListMatcher m = matcher(cloneList, SortingPreference.builder().build());
 
-        assertFalse(m.match(gameNamed("Some Game (USA)")).isPresent());
+        CloneListMatcher.MatchResult result = m.match(gameNamed("Some Game (USA)"))
+                .orElseThrow(() -> new AssertionError(
+                        "a title inside an ignored group must still be recognised as matched"));
+        assertTrue(result.ignored(), "a match inside an ignored group must be flagged ignored");
+        assertEquals("Ignored Group", result.group());
     }
+
+    @Test
+    void variantGroupWithoutIgnoreFlagIsNotMarkedIgnored() {
+        CloneListMatcher m = matcher(
+                singleTitleCloneList(NameType.FULL, "Some Game (USA)"),
+                SortingPreference.builder().build());
+
+        assertFalse(
+                m.match(gameNamed("Some Game (USA)")).orElseThrow().ignored(),
+                "an ordinary match must not be flagged ignored");
+    }
+
+    /**
+     * A clone list is community data a user points {@code --clonelist} at, so its patterns are
+     * untrusted input (CWE-1333). A catastrophically backtracking pattern must be given up on
+     * with a message naming it, not evaluated until the run is over.
+     */
+    @Test
+    @Timeout(value = 20, unit = TimeUnit.SECONDS, threadMode = Timeout.ThreadMode.SEPARATE_THREAD)
+    void catastrophicallyBacktrackingSearchTermIsGivenUpOn() {
+        CloneListMatcher m = matcher(
+                singleTitleCloneList(NameType.REGEX, EVIL_PATTERN),
+                SortingPreference.builder().build());
+
+        RuntimeException thrown = assertThrows(
+                RuntimeException.class,
+                () -> m.match(gameNamed(HOSTILE_NAME)),
+                "an unbounded clone list pattern must be given up on, not run to exhaustion");
+        assertTrue(
+                thrown.getMessage().contains(EVIL_PATTERN),
+                () -> "the failure must name the offending pattern, got: " + thrown.getMessage());
+    }
+
+    /** The same protection on the other pattern a clone list can carry: a filter's matchString. */
+    @Test
+    @Timeout(value = 20, unit = TimeUnit.SECONDS, threadMode = Timeout.ThreadMode.SEPARATE_THREAD)
+    void catastrophicallyBacktrackingFilterMatchStringIsGivenUpOn() {
+        CloneList cloneList = new CloneList(
+                new CloneListDescription("Test", "x", "1.0"),
+                ImmutableList.of(new VariantGroup(
+                        "Group",
+                        ImmutableList.of(),
+                        false,
+                        ImmutableList.of(new VariantTitle(
+                                HOSTILE_NAME,
+                                NameType.FULL,
+                                1,
+                                ImmutableList.of(),
+                                false,
+                                false,
+                                ImmutableMap.of(),
+                                ImmutableList.of(new VariantFilter(
+                                        new VariantFilter.Conditions(
+                                                ImmutableList.of(),
+                                                ImmutableList.of(),
+                                                EVIL_PATTERN,
+                                                null),
+                                        new VariantFilter.Results(
+                                                null,
+                                                5,
+                                                ImmutableList.of(),
+                                                null,
+                                                null,
+                                                null,
+                                                ImmutableMap.of()))))),
+                        ImmutableList.of(),
+                        ImmutableList.of())));
+        CloneListMatcher m = matcher(cloneList, SortingPreference.builder().build());
+
+        RuntimeException thrown = assertThrows(
+                RuntimeException.class,
+                () -> m.match(gameNamed(HOSTILE_NAME)),
+                "an unbounded filter matchString must be given up on, not run to exhaustion");
+        assertTrue(
+                thrown.getMessage().contains(EVIL_PATTERN),
+                () -> "the failure must name the offending pattern, got: " + thrown.getMessage());
+    }
+
+    /**
+     * A pattern that backtracks exponentially, and a name it can never match. Not the textbook
+     * {@code (a+)+$}: current JDKs collapse nested single-character quantifiers, so that one
+     * returns instantly. Nested {@code .*} loops still explode — probed on this JDK, matching
+     * this pattern costs ~3.6 s at 29 characters and grows by ~10x per 4 more, so the 46-character
+     * name below is hours of CPU.
+     */
+    private static final String EVIL_PATTERN = "(.*a){15}";
+    private static final String HOSTILE_NAME = "a".repeat(45) + "!";
 
     private static CloneList singleTitleCloneList(NameType nameType, String searchTerm) {
         return new CloneList(


### PR DESCRIPTION
Fixes #43

Both items from the issue, since each is a few lines and they share the same test class.

## 1. Unbounded community regexes (CWE-1333)

`searchTerm` (nameType `regex`) and a filter's `matchString` come from clone list JSON a user points `--clonelist` at, and `java.util.regex` has no match timeout. Both sites now match against a `CharSequence` that stops the engine after `MAX_PATTERN_CHARACTER_READS` (100 000) character reads — the backtracking engine reads the input once per step, so the read count bounds the work no matter how the pattern is written — and a pattern that exhausts the budget raises `PatternBudgetExceededException` naming it. Legitimate patterns read a small multiple of the name's length, so the budget leaves ~3 orders of magnitude of headroom. No new dependency and no watchdog thread.

**The issue's stated reproduction no longer reproduces, so the test uses a different pattern.** `(a+)+$` against a long non-matching name returns in 0 ms on current JDKs, which collapse nested single-character quantifiers. Probed before writing the guard (JDK 26.0.1, `matches()` against `"a"*n + "!"`):

```
(a+)+$      len=29 -> false in     0 ms
(a+)+b      len=29 -> false in     0 ms
(a|aa)+$    len=27 -> false in     0 ms
(a*)*b      len=26 -> false in     0 ms
(.*a){15}   len=25 -> false in   339 ms
(.*a){15}   len=29 -> false in  3647 ms      <- ~10x per 4 more characters
```

Nested `.*` loops still explode, so the tests use `(.*a){15}` against a 46-character name — hours of CPU unguarded. That is what makes the RED run below a genuine timeout rather than an assertion failure.

## 2. `ignore` groups are skipped, not removed

`CloneListMatcher.match` skipped ignored groups entirely, so their titles fell through to DAT grouping and stayed in the 1G1R output, where they can still win. A match inside an ignored group now returns `MatchResult.ignored() == true`, and `OneGameOneRom.applyCloneList` drops the game before grouping, selection, or output — upstream's "ignored titles are completely removed from Retool's consideration during processing".

As you noted on the issue, no shipped clone list exercises this key (0 occurrences across all 97 upstream files), so this is spec conformance reachable through a hand-authored `--clonelist`, not a defect users hit today. It is included here because it is two lines on top of the same class.

`variantGroupWithIgnoreFlagIsSkipped` pinned the old behaviour and is replaced by `variantGroupWithIgnoreFlagMarksItsTitleIgnored` plus a not-ignored counterpart — an intentional semantics change, called out here rather than quietly rewritten.

## Red → green proof

Test files frozen byte-identical across both runs (`git hash-object`):

| File | Hash at red and at green |
| --- | --- |
| `core/src/test/java/io/github/datromtool/retool/CloneListMatcherTest.java` | `67ad7d6a7ea8cb5ed41695dc8947c9b033888091` |
| `cli/src/test/java/io/github/datromtool/cli/command/OneGameOneRomCommandCloneListFamilyTest.java` | `0d244adf63e2d6b5dfd5acee1885372b7714c7d6` |

RED, on untouched production code:

```
$ mvn -B -pl cli -am test -Dtest='CloneListMatcherTest,OneGameOneRomCommandCloneListFamilyTest'
[ERROR] Tests run: 16, Failures: 0, Errors: 2, Skipped: 0, Time elapsed: 40.34 s -- in CloneListMatcherTest
java.util.concurrent.TimeoutException: catastrophicallyBacktrackingSearchTermIsGivenUpOn() timed out after 20 seconds
java.util.concurrent.TimeoutException: catastrophicallyBacktrackingFilterMatchStringIsGivenUpOn() timed out after 20 seconds

$ mvn -B -pl cli -am test -Dtest='OneGameOneRomCommandCloneListFamilyTest'
[ERROR] Tests run: 3, Failures: 1, Errors: 0, Skipped: 0
[ERROR]   OneGameOneRomCommandCloneListFamilyTest.ignoredGroupRemovesItsTitleFromTheOutput:104
  a title in a group flagged ignore must be removed from consideration entirely, got: ...
```

GREEN, same tests, zero edits (the two ignore-semantics unit tests were added after this run, hence 17):

```
[INFO] Tests run: 17, Failures: 0, Errors: 0, Skipped: 0 -- in io.github.datromtool.retool.CloneListMatcherTest
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0 -- in OneGameOneRomCommandCloneListFamilyTest
```

## Gates

```
$ sh scripts/agent/run-gates.sh --diff origin/master
GATE PASS: mvn -B -q verify
GATES: PASS
```

## Coverage

| Row | Test |
| --- | --- |
| catastrophic `searchTerm` (nameType regex) is given up on, naming the pattern | `catastrophicallyBacktrackingSearchTermIsGivenUpOn` |
| catastrophic filter `matchString` — the other pattern site — is given up on | `catastrophicallyBacktrackingFilterMatchStringIsGivenUpOn` |
| ordinary regex/matchString matching still works (both branches unchanged) | the pre-existing `regexNameTypeMatches…` / `conditionalFilterMatchStringFiresOnlyOnRegexMatch` rows, still green |
| a match inside an ignored group is flagged ignored | `variantGroupWithIgnoreFlagMarksItsTitleIgnored` |
| a match outside one is not | `variantGroupWithoutIgnoreFlagIsNotMarkedIgnored` |
| the ignored title is gone from the real 1G1R output, end to end | `OneGameOneRomCommandCloneListFamilyTest.ignoredGroupRemovesItsTitleFromTheOutput` |

Both call sites of `Pattern.compile` on clone list data are converted (`matchesTitle`'s `REGEX` arm and `conditionsMatch`'s `matchString`); the class's three static patterns are its own, not clone list input, and are left alone. Per-match `Pattern.compile` remains — that is #41's territory, not this change's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
