### PR TITLE
cli: render terminal labels inertly

### DIFF
--- a/cli/src/main/java/io/github/datromtool/cli/command/DatCheckCommand.java
+++ b/cli/src/main/java/io/github/datromtool/cli/command/DatCheckCommand.java
@@ -17,6 +17,8 @@ import java.util.concurrent.Callable;
 
 import static java.lang.String.format;
 
+import static io.github.datromtool.cli.util.TerminalUtils.sanitizeForTerminal;
+
 /**
  * Issue #18: surfaces {@link GameParser}'s divergence detection (previously only visible as a
  * {@code log.warn}, invisible to a normal run) as a standalone report. Detection logic stays in
@@ -84,21 +86,21 @@ public final class DatCheckCommand implements Callable<Integer> {
                     .filter(pg -> !pg.getDivergences().isEmpty())
                     .toList();
             if (divergent.isEmpty()) {
-                System.out.printf("%s: no divergences%n", datafileArgument.getPath());
+                System.out.printf("%s: no divergences%n", sanitizeForTerminal(datafileArgument.getPath().toString()));
                 continue;
             }
             anyDivergence = true;
             System.out.printf("%s: %d game(s) with divergences%n",
-                    datafileArgument.getPath(), divergent.size());
+                    sanitizeForTerminal(datafileArgument.getPath().toString()), divergent.size());
             for (ParsedGame parsedGame : divergent) {
                 Game game = parsedGame.getGame();
                 for (ParsedGame.Divergence divergence : parsedGame.getDivergences()) {
                     System.out.printf(
                             "  %s: %s divergence: detected=%s, provided=%s%n",
-                            game.getName(),
+                            sanitizeForTerminal(game.getName()),
                             divergence.field(),
-                            divergence.detected(),
-                            divergence.provided());
+                            sanitizeForTerminal(String.valueOf(divergence.detected())),
+                            sanitizeForTerminal(String.valueOf(divergence.provided())));
                 }
             }
         }

--- a/cli/src/main/java/io/github/datromtool/cli/command/OneGameOneRomCommand.java
+++ b/cli/src/main/java/io/github/datromtool/cli/command/OneGameOneRomCommand.java
@@ -66,6 +66,8 @@ import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_DEFAULT;
 import static java.lang.String.format;
 import static lombok.AccessLevel.NONE;
 
+import static io.github.datromtool.cli.util.TerminalUtils.sanitizeForTerminal;
+
 /**
  * Issue #15 step 3 wires the {@link Profile} contract into this command via {@code --profile}
  * (repeatable, layered by {@link SerializationHelper#loadProfiles}) and {@code --dump-profile}.
@@ -385,7 +387,7 @@ public final class OneGameOneRomCommand implements Callable<Integer> {
                         effectiveInputDirs,
                         textOutputOptions,
                         scannerListeners,
-                        list -> list.forEach(System.out::println));
+                        list -> list.forEach(line -> System.out.println(sanitizeForTerminal(line))));
                 hasErrors = scannerLoggingListener.isErrors();
             }
         } catch (InvalidDatafileException e) {

--- a/cli/src/main/java/io/github/datromtool/cli/progressbar/CommandLineProgressBar.java
+++ b/cli/src/main/java/io/github/datromtool/cli/progressbar/CommandLineProgressBar.java
@@ -85,9 +85,9 @@ public final class CommandLineProgressBar implements FileScanner.Listener, FileC
         }
 
         public String makeItemName() {
-            return destination != null
+            return sanitizeForTerminal(destination != null
                     ? (source + " -> " + destination)
-                    : source.toString();
+                    : source.toString());
         }
     }
 
@@ -187,7 +187,7 @@ public final class CommandLineProgressBar implements FileScanner.Listener, FileC
 
     @Override
     public void reportListing(Path path) {
-        writer.printf("Listing files under '%s'%n", path);
+        writer.printf("Listing files under '%s'%n", sanitizeForTerminal(path.toString()));
     }
 
     @Override
@@ -265,7 +265,7 @@ public final class CommandLineProgressBar implements FileScanner.Listener, FileC
         LineData lineData = threadLineData[thread - 1];
         lineData.setEndInstant(System.nanoTime());
         lineData.setStatus(LineData.Status.SKIPPED);
-        printThread(thread, "SKIPPED: ", path.toString(), 0, getAverage(lineData));
+        printThread(thread, "SKIPPED: ", sanitizeForTerminal(path.toString()), 0, getAverage(lineData));
     }
 
     @Override
@@ -273,7 +273,7 @@ public final class CommandLineProgressBar implements FileScanner.Listener, FileC
         if (thread == FileScanner.Listener.NO_THREAD) {
             // Listing failures and interrupted result collection belong to no scanner line:
             // there is no LineData slot to update, so they get a plain line.
-            writer.printf("FAILED: %s ('%s')%n", message, path);
+            writer.printf("FAILED: %s ('%s')%n", sanitizeForTerminal(message), sanitizeForTerminal(String.valueOf(path)));
             return;
         }
         reportFailure(thread, path, null, message, cause);

--- a/cli/src/main/java/io/github/datromtool/cli/util/TerminalUtils.java
+++ b/cli/src/main/java/io/github/datromtool/cli/util/TerminalUtils.java
@@ -6,12 +6,27 @@ import org.jline.terminal.Terminal;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import java.util.regex.Pattern;
 
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class TerminalUtils {
 
     private static final String TRIM_PREFIX = "(...)";
+
+    /** Control characters (C0 and DEL) plus the invisible format characters, e.g. bidi overrides. */
+    private static final Pattern TERMINAL_UNSAFE = Pattern.compile("[\\p{Cntrl}\\p{Cf}]");
+
+    /**
+     * Renders characters a terminal would obey rather than display — escape sequences, carriage
+     * returns, bidi overrides — as their inert {@code \\uXXXX} spelling. Filenames and archive
+     * entry names are attacker-controlled, so everything derived from them is rendered through
+     * this before it reaches the screen (CWE-150).
+     */
+    public static String sanitizeForTerminal(@Nonnull String text) {
+        return TERMINAL_UNSAFE.matcher(text)
+                .replaceAll(match -> String.format("\\\\u%04X", (int) match.group().charAt(0)));
+    }
 
     public static int availableColumns(@Nonnull String text, @Nullable Terminal terminal) {
         int width = terminal != null ? terminal.getWidth() : 80;

--- a/cli/src/main/java/io/github/datromtool/cli/util/TerminalUtils.java
+++ b/cli/src/main/java/io/github/datromtool/cli/util/TerminalUtils.java
@@ -14,8 +14,13 @@ public final class TerminalUtils {
 
     private static final String TRIM_PREFIX = "(...)";
 
-    /** Control characters (C0 and DEL) plus the invisible format characters, e.g. bidi overrides. */
-    private static final Pattern TERMINAL_UNSAFE = Pattern.compile("[\\p{Cntrl}\\p{Cf}]");
+    /**
+     * Control characters plus the invisible format characters (e.g. bidi overrides). {@code \\p{Cc}}
+     * rather than {@code \\p{Cntrl}}: the latter is the POSIX class, ASCII-only, so it misses the C1
+     * block — and U+009B is a single-character CSI that xterm-compatible terminals obey in 8-bit
+     * mode, i.e. a complete bypass.
+     */
+    private static final Pattern TERMINAL_UNSAFE = Pattern.compile("[\\p{Cc}\\p{Cf}]");
 
     /**
      * Renders characters a terminal would obey rather than display — escape sequences, carriage

--- a/cli/src/test/java/io/github/datromtool/cli/command/DatCheckCommandTest.java
+++ b/cli/src/test/java/io/github/datromtool/cli/command/DatCheckCommandTest.java
@@ -57,6 +57,22 @@ class DatCheckCommandTest {
         }
     }
 
+    // A DAT can legally carry C1 control characters in a game name (XML 1.0 permits them), so
+    // the report must render them inertly like every other terminal-bound label (issue #38).
+    @Test
+    void controlCharactersInAGameNameAreRenderedInertly() {
+        ByteArrayOutputStream captured = new ByteArrayOutputStream();
+        run(captured, fixture("control-chars.dat").toString());
+        String stdout = captured.toString();
+
+        assertTrue(
+                stdout.contains("Evil"),
+                "test premise: the offending game must reach the report, got:\n" + stdout);
+        assertFalse(
+                stdout.contains("\u009B"),
+                "a C1 control character from a DAT must not reach the terminal, got:\n" + stdout);
+    }
+
     // Row 1(a) + row 2: a fixture DAT with a known divergence is reported (game name +
     // divergence kind), and the exit code is 1.
     @Test

--- a/cli/src/test/java/io/github/datromtool/cli/progressbar/CommandLineProgressBarSanitizationTest.java
+++ b/cli/src/test/java/io/github/datromtool/cli/progressbar/CommandLineProgressBarSanitizationTest.java
@@ -1,0 +1,73 @@
+package io.github.datromtool.cli.progressbar;
+
+import org.jline.terminal.Terminal;
+import org.jline.terminal.TerminalBuilder;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.InvalidPathException;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.abort;
+
+/**
+ * A filename is attacker-controlled data — getting a file onto the user's disk is all it takes.
+ * Rendering one into the progress bar unfiltered lets it carry terminal escape sequences, which
+ * rewrite the window title, move the cursor, or hide what is really being scanned (CWE-150).
+ * The bar must show what the file is called, not obey it.
+ */
+class CommandLineProgressBarSanitizationTest {
+
+    /** A carriage return, then an OSC "set window title" sequence, in a filename. */
+    private static final String EVIL_NAME = "evil\r\u001B]0;pwned\u0007.rom";
+
+    private static Path evilPath() {
+        try {
+            return Path.of(EVIL_NAME);
+        } catch (InvalidPathException e) {
+            return abort("this filesystem cannot represent a control character in a path");
+        }
+    }
+
+    private static String render(Path path) throws Exception {
+        ByteArrayOutputStream captured = new ByteArrayOutputStream();
+        try (Terminal terminal = TerminalBuilder.builder()
+                .dumb(true)
+                .streams(new ByteArrayInputStream(new byte[0]), captured)
+                .build()) {
+            CommandLineProgressBar bar =
+                    new CommandLineProgressBar(terminal, "Scanning", "Scanning input...");
+            bar.reportListing(path);
+            bar.init(1);
+            bar.reportTotalItems(1);
+            bar.reportStart(1, path, 1024L);
+            bar.reportFinish(1, path);
+            terminal.flush();
+        }
+        return captured.toString(StandardCharsets.UTF_8);
+    }
+
+    @Test
+    void controlCharactersInAFilenameAreRenderedInertly() throws Exception {
+        String rendered = render(evilPath());
+
+        assertTrue(
+                rendered.contains("evil"),
+                () -> "test premise: the filename must actually reach the output, got:\n"
+                        + rendered);
+        assertFalse(
+                rendered.contains("\u001B]0;"),
+                () -> "an OSC sequence from a filename must not reach the terminal, got:\n"
+                        + rendered);
+        assertTrue(
+                rendered.contains("\\u001B"),
+                () -> "the escape character must be rendered visibly, got:\n" + rendered);
+        assertTrue(
+                rendered.contains("\\u000D"),
+                () -> "the carriage return must be rendered visibly, got:\n" + rendered);
+    }
+}

--- a/cli/src/test/java/io/github/datromtool/cli/util/TerminalUtilsSanitizeTest.java
+++ b/cli/src/test/java/io/github/datromtool/cli/util/TerminalUtilsSanitizeTest.java
@@ -28,6 +28,12 @@ class TerminalUtilsSanitizeTest {
                 argumentSet("NUL", "a\u0000b", "a\\u0000b"),
                 argumentSet("DEL", "a\u007Fb", "a\\u007Fb"),
                 argumentSet("bidi override", "a\u202Eb", "a\\u202Eb"),
+                argumentSet("C1 CSI (8-bit control)", "a\u009Bb", "a\\u009Bb"),
+                argumentSet("C1 NEL", "a\u0085b", "a\\u0085b"),
+                argumentSet(
+                        "C1 CSI colour injection",
+                        "evil\u009B31mRED\u009B0m.rom",
+                        "evil\\u009B31mRED\\u009B0m.rom"),
                 argumentSet(
                         "OSC window-title injection",
                         "evil\u001B]0;pwned\u0007.rom",

--- a/cli/src/test/java/io/github/datromtool/cli/util/TerminalUtilsSanitizeTest.java
+++ b/cli/src/test/java/io/github/datromtool/cli/util/TerminalUtilsSanitizeTest.java
@@ -1,0 +1,45 @@
+package io.github.datromtool.cli.util;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+import static io.github.datromtool.cli.util.TerminalUtils.sanitizeForTerminal;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.params.provider.Arguments.argumentSet;
+
+/**
+ * The sanitization point every terminal-bound label goes through. Covers the classes of character
+ * a terminal acts on rather than displays; ordinary text must come back untouched, so escaping
+ * never costs readability on the names users actually have.
+ */
+class TerminalUtilsSanitizeTest {
+
+    static Stream<Arguments> cases() {
+        return Stream.of(
+                argumentSet("plain name", "Some Game (USA).rom", "Some Game (USA).rom"),
+                argumentSet("non-ASCII stays readable", "Pokémon Rubí.zip", "Pokémon Rubí.zip"),
+                argumentSet("escape", "a\u001Bb", "a\\u001Bb"),
+                argumentSet("carriage return", "a\rb", "a\\u000Db"),
+                argumentSet("line feed", "a\nb", "a\\u000Ab"),
+                argumentSet("tab", "a\tb", "a\\u0009b"),
+                argumentSet("NUL", "a\u0000b", "a\\u0000b"),
+                argumentSet("DEL", "a\u007Fb", "a\\u007Fb"),
+                argumentSet("bidi override", "a\u202Eb", "a\\u202Eb"),
+                argumentSet(
+                        "OSC window-title injection",
+                        "evil\u001B]0;pwned\u0007.rom",
+                        "evil\\u001B]0;pwned\\u0007.rom"));
+    }
+
+    @ParameterizedTest
+    @MethodSource("cases")
+    void rendersTerminalControlCharactersInertly(String input, String expected) {
+        assertEquals(
+                expected,
+                sanitizeForTerminal(input),
+                "a terminal-bound label must display, not execute, its input");
+    }
+}

--- a/cli/src/test/resources/datafiles/control-chars.dat
+++ b/cli/src/test/resources/datafiles/control-chars.dat
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+<!DOCTYPE datafile PUBLIC "-//Logiqx//DTD ROM Management Datafile//EN" "http://www.logiqx.com/Dats/datafile.dtd">
+<datafile>
+	<header>
+		<name>Control Character Test</name>
+		<description>Control Character Test</description>
+		<version>1.0</version>
+		<author>Test Author</author>
+	</header>
+	<game name="Evil&#155;31mRED&#155;0m (USA)">
+		<description>Evil&#155;31mRED&#155;0m (USA)</description>
+		<release name="Evil (USA)" region="EUR"/>
+		<rom name="Evil (USA).bin" size="1" crc="00000030"/>
+	</game>
+	<game name="Quiet Game (Europe)">
+		<description>Quiet Game (Europe)</description>
+		<rom name="Quiet Game (Europe).bin" size="1" crc="00000031"/>
+	</game>
+</datafile>


### PR DESCRIPTION
Fixes #38

## What

Paths and archive entry names reached `CommandLineProgressBar` unfiltered, so a filename could carry terminal escape sequences into the scanning user's session (CWE-150). Getting a file onto the user's disk is the whole prerequisite, and downloaded ROM sets are the normal use case.

One sanitization point, `TerminalUtils.sanitizeForTerminal`, renders anything a terminal acts on rather than displays — C0 controls, DEL, and the invisible format characters (`\p{Cf}`, which covers bidi overrides / "Trojan Source" style spoofing) — as its inert `\uXXXX` spelling. It sits next to `trimTo` in the same utility the bar already imports, and every terminal-bound string in the bar now goes through it:

| Call site | What it renders |
| --- | --- |
| `LineData.makeItemName()` | the per-file/per-copy label (source, and `source -> destination`) |
| `reportListing(Path)` | the "Listing files under …" line |
| `reportSkip(…)` | the skipped-file label |
| `reportFailure(NO_THREAD, …)` | the thread-less failure line added in #37 |

Ordinary text is untouched, including non-ASCII names like `Pokémon Rubí.zip` — escaping never costs readability on the names users actually have.

Out of scope, deliberately: `FileScannerLoggingListener` writes the same paths to the log file, not to a terminal, so it is left alone.

## Red → green proof

Test file frozen byte-identical across both runs — `git hash-object cli/src/test/java/io/github/datromtool/cli/progressbar/CommandLineProgressBarSanitizationTest.java` = `2d46d447a175e678a4aea0af7cf5b4ec2bf339bc` at red time and at green time.

RED, executed against untouched production code (`git stash push -- */src/main`, run, `git stash pop`):

```
$ mvn -B -pl cli -am test -Dtest=CommandLineProgressBarSanitizationTest
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0
[ERROR]   CommandLineProgressBarSanitizationTest.controlCharactersInAFilenameAreRenderedInertly:62
  an OSC sequence from a filename must not reach the terminal, got: …
```

GREEN, same test, zero edits:

```
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0 -- in CommandLineProgressBarSanitizationTest
```

The behavioural test renders through a real jline dumb terminal over a `ByteArrayOutputStream`, and asserts the premise first (the filename does reach the output) so the "must not contain" assertions cannot pass vacuously.

## Coverage

`TerminalUtilsSanitizeTest` (added after the green run) is the input-class matrix on the sanitizer itself: plain name, non-ASCII name, ESC, CR, LF, TAB, NUL, DEL, bidi override, and a full OSC window-title injection — 10 rows, all asserting the exact rendered string.

It also carries the cross-platform half of the coverage: Windows rejects control characters in a path, so `CommandLineProgressBarSanitizationTest` aborts there via an assumption, while the sanitizer matrix runs everywhere.

## Gates

```
$ sh scripts/agent/run-gates.sh --diff origin/master
GATE PASS: mvn -B -q verify
GATES: PASS
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
