### PR TITLE
core: report archives that cannot be read

### DIFF
--- a/core/src/main/java/io/github/datromtool/io/FileScanner.java
+++ b/core/src/main/java/io/github/datromtool/io/FileScanner.java
@@ -324,6 +324,12 @@ public final class FileScanner {
                             file,
                             archiveType,
                             e);
+                    // The entries this archive would have contributed are missing from the
+                    // report, and the fallback below hashes the archive file itself instead —
+                    // neither is a complete scan of it.
+                    for (Listener listener : listeners) {
+                        listener.reportFailure(index, file, "Could not read the archive", e);
+                    }
                 }
             }
             if (!scanned || fileScannerParameters.getAlsoScanArchives().contains(archiveType)) {

--- a/core/src/test/java/io/github/datromtool/io/FileScannerErrorSignalTest.java
+++ b/core/src/test/java/io/github/datromtool/io/FileScannerErrorSignalTest.java
@@ -14,6 +14,8 @@ import java.nio.file.Path;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
@@ -121,6 +123,21 @@ class FileScannerErrorSignalTest {
         assertTrue(
                 Thread.interrupted(),
                 "the interrupt must be handed back to the caller, not swallowed");
+    }
+
+    @Test
+    void givenAnArchiveThatCannotBeRead_whenScanning_thenTheFailureIsReported(@TempDir Path tempDir)
+            throws IOException {
+        // Named like an archive, but its content is not one: the archive reader fails, and the
+        // entries it would have contributed are missing from the report.
+        Files.write(tempDir.resolve("broken.zip"), "not really a zip file".getBytes(UTF_8));
+        FileScannerLoggingListener listener = new FileScannerLoggingListener();
+
+        scannerWith(listener).scan(ImmutableList.of(tempDir));
+
+        assertTrue(
+                listener.isErrors(),
+                "an archive that could not be read must not look like a complete scan of it");
     }
 
     /**


### PR DESCRIPTION
Fixes #74

## What

`FileScanner.scanFile` caught every exception from the archive readers and only logged it. No listener was told, so `FileScannerLoggingListener.isErrors()` stayed `false` and `datrom scan` exited 0 on a scan that had silently lost every entry of that archive — and, because `scanned` stayed `false`, the next branch hashed the whole archive file as if it were a plain ROM, putting a hash in the report that matches nothing the user has.

The failure now goes to the listener on the scanning thread's own index (a real thread index here, not #37's `NO_THREAD` sentinel — this runs on a worker). The fallback scan stays: hashing the file as a plain ROM is the right outcome for something that merely looks like an archive by extension, and now it comes with the failure recorded rather than hidden.

This is the swallow point #37 did not cover: that change fixed the listing stage and result collection, this is the per-file archive stage.

## Red → green proof

Test file frozen byte-identical across both runs — `git hash-object core/src/test/java/io/github/datromtool/io/FileScannerErrorSignalTest.java` = `cc4b55829b5d2bbc5019e71f726e8669e5e7d62e` at red time and at green time.

RED, on untouched production code:

```
$ mvn -B -pl core -am test -Dtest=FileScannerErrorSignalTest
[ERROR] Tests run: 4, Failures: 1, Errors: 0, Skipped: 0
[ERROR]   FileScannerErrorSignalTest.givenAnArchiveThatCannotBeRead_whenScanning_thenTheFailureIsReported:138
  an archive that could not be read must not look like a complete scan of it ==> expected: <true> but was: <false>
```

GREEN, same test, zero edits:

```
[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0 -- in io.github.datromtool.io.FileScannerErrorSignalTest
```

The fixture is a real corrupt archive — a file named `broken.zip` whose content is not a zip — so the failure comes through the production surface (commons-compress rejecting it), not from an injected exception.

## Gates

```
$ sh scripts/agent/run-gates.sh --diff origin/master
GATE PASS: mvn -B -q verify
GATES: PASS
```

## Coverage

The new row joins the three from #37 in the same class, so `FileScannerErrorSignalTest` now covers every swallow point the reviewer found: listing a root, listing a subtree, collecting a worker's results, and reading an archive.

Found during an independent adversarial review of the merged #37 fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
