### PR TITLE
core: bound every untrusted pattern, by depth as well as by reads

### DIFF
--- a/core/src/main/java/io/github/datromtool/GameFilterer.java
+++ b/core/src/main/java/io/github/datromtool/GameFilterer.java
@@ -1,5 +1,6 @@
 package io.github.datromtool;
 
+import io.github.datromtool.util.UntrustedPatterns;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.github.datromtool.data.Filter;
@@ -86,8 +87,7 @@ public final class GameFilterer {
     private boolean matchesAnyInclude(ParsedGame p) {
         return filter.getIncludes().stream()
                 .map(NameMatcher::getPattern)
-                .map(e -> e.matcher(p.getGame().getName()))
-                .anyMatch(Matcher::find);
+                .anyMatch(pattern -> UntrustedPatterns.find(pattern, p.getGame().getName()));
     }
 
     private static boolean matchesCategory(ParsedGame p, GameCategory category) {
@@ -152,8 +152,7 @@ public final class GameFilterer {
     private boolean filterExcludes(ParsedGame p) {
         boolean result = filter.getExcludes().stream()
                 .map(NameMatcher::getPattern)
-                .map(e -> e.matcher(p.getGame().getName()))
-                .noneMatch(Matcher::find);
+                .noneMatch(pattern -> UntrustedPatterns.find(pattern, p.getGame().getName()));
         result |= matchesAnyInclude(p);
         if (!result) {
             log.debug("Excludes filter removed '{}'", p.getGame().getName());
@@ -176,8 +175,7 @@ public final class GameFilterer {
             if (input.stream()
                     .map(ParsedGame::getGame)
                     .map(Game::getName)
-                    .map(excludePattern::matcher)
-                    .anyMatch(Matcher::find)) {
+                    .anyMatch(name -> UntrustedPatterns.find(excludePattern, name))) {
                 if (log.isDebugEnabled()) {
                     log.debug(
                             "Post-filter exclusions removed {}",

--- a/core/src/main/java/io/github/datromtool/data/NameMatcher.java
+++ b/core/src/main/java/io/github/datromtool/data/NameMatcher.java
@@ -1,5 +1,6 @@
 package io.github.datromtool.data;
 
+import io.github.datromtool.util.UntrustedPatterns;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
@@ -81,7 +82,7 @@ public final class NameMatcher {
         try {
             return switch (type) {
                 case LITERAL -> Pattern.compile(Pattern.quote(value));
-                case REGEX -> Pattern.compile(value);
+                case REGEX -> UntrustedPatterns.compile(value);
             };
         } catch (PatternSyntaxException e) {
             throw new IllegalArgumentException(

--- a/core/src/main/java/io/github/datromtool/retool/CloneListMatcher.java
+++ b/core/src/main/java/io/github/datromtool/retool/CloneListMatcher.java
@@ -11,6 +11,7 @@ import io.github.datromtool.domain.retool.NameType;
 import io.github.datromtool.domain.retool.VariantFilter;
 import io.github.datromtool.domain.retool.VariantGroup;
 import io.github.datromtool.domain.retool.VariantTitle;
+import io.github.datromtool.util.UntrustedPatterns;
 
 import javax.annotation.Nonnull;
 import java.util.Comparator;
@@ -116,15 +117,6 @@ public final class CloneListMatcher {
 
     private static final String ALL_OTHER_REGIONS = "All other regions";
 
-    /**
-     * How much of a game's name one clone list pattern may read before it is given up on. A
-     * clone list is community data a user points {@code --clonelist} at, and {@code
-     * java.util.regex} has no match timeout, so a catastrophically backtracking pattern would
-     * otherwise monopolize the run's thread (CWE-1333). Legitimate patterns read a small multiple
-     * of the name's length; this leaves three orders of magnitude of headroom.
-     */
-    private static final int MAX_PATTERN_CHARACTER_READS = 100_000;
-
     private static final Pattern PAREN_GROUP = Pattern.compile("\\([^()]+\\)");
     private static final Pattern WHITESPACE = Pattern.compile("\\s+");
     private static final Pattern LANGUAGE_GROUP =
@@ -150,18 +142,6 @@ public final class CloneListMatcher {
      * {@link VariantFilter.Results} override has been applied).
      */
     public record MatchResult(@Nonnull String group, int priority, boolean ignored) {
-    }
-
-    /**
-     * Thrown when a clone list pattern reads more of a game's name than
-     * {@link #MAX_PATTERN_CHARACTER_READS} allows, which means it is backtracking
-     * catastrophically (CWE-1333).
-     */
-    public static final class PatternBudgetExceededException extends RuntimeException {
-
-        PatternBudgetExceededException(String message) {
-            super(message);
-        }
     }
 
     /**
@@ -236,74 +216,10 @@ public final class CloneListMatcher {
         String searchTerm = title.searchTerm();
         return switch (title.nameType()) {
             case FULL -> fullName.equals(searchTerm);
-            case REGEX -> matchesBounded(searchTerm, fullName);
+            case REGEX -> UntrustedPatterns.matches(UntrustedPatterns.compile(searchTerm), fullName);
             case REGION_FREE -> regionFreeName(fullName).equals(searchTerm);
             case SHORT -> shortName(fullName).equals(shortName(searchTerm));
         };
-    }
-
-    /**
-     * Matches {@code regex} against a character source that stops the engine once it has read
-     * {@link #MAX_PATTERN_CHARACTER_READS} characters — the backtracking engine reads the input
-     * once per step, so the read count bounds the work regardless of how the pattern is written.
-     *
-     * @throws PatternBudgetExceededException naming the pattern that ran out of budget
-     */
-    private static boolean matchesBounded(String regex, String fullName) {
-        try {
-            return Pattern.compile(regex)
-                    .matcher(new BudgetedCharSequence(fullName, MAX_PATTERN_CHARACTER_READS))
-                    .matches();
-        } catch (BudgetExceeded e) {
-            throw new PatternBudgetExceededException(String.format(
-                    "Clone list pattern '%s' read more than %d characters of '%s' without "
-                            + "deciding: it backtracks catastrophically and was given up on",
-                    regex,
-                    MAX_PATTERN_CHARACTER_READS,
-                    fullName));
-        }
-    }
-
-    /** Internal signal, converted to a {@link PatternBudgetExceededException} by its only caller. */
-    private static final class BudgetExceeded extends RuntimeException {
-
-        BudgetExceeded() {
-            super(null, null, false, false);
-        }
-    }
-
-    private static final class BudgetedCharSequence implements CharSequence {
-
-        private final CharSequence delegate;
-        private int readsLeft;
-
-        BudgetedCharSequence(CharSequence delegate, int readsLeft) {
-            this.delegate = delegate;
-            this.readsLeft = readsLeft;
-        }
-
-        @Override
-        public char charAt(int index) {
-            if (--readsLeft < 0) {
-                throw new BudgetExceeded();
-            }
-            return delegate.charAt(index);
-        }
-
-        @Override
-        public int length() {
-            return delegate.length();
-        }
-
-        @Override
-        public CharSequence subSequence(int start, int end) {
-            return delegate.subSequence(start, end);
-        }
-
-        @Override
-        public String toString() {
-            return delegate.toString();
-        }
     }
 
     private MatchResult applyFilters(
@@ -339,7 +255,8 @@ public final class CloneListMatcher {
             return false;
         }
         if (conditions.matchString() != null
-                && !matchesBounded(conditions.matchString(), fullName)) {
+                && !UntrustedPatterns.matches(
+                        UntrustedPatterns.compile(conditions.matchString()), fullName)) {
             return false;
         }
         return conditions.regionOrder() == null || matchRegionOrder(conditions.regionOrder());

--- a/core/src/main/java/io/github/datromtool/util/UntrustedPatterns.java
+++ b/core/src/main/java/io/github/datromtool/util/UntrustedPatterns.java
@@ -1,0 +1,134 @@
+package io.github.datromtool.util;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+import javax.annotation.Nonnull;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static java.lang.String.format;
+
+/**
+ * Evaluates regular expressions that came from a file the user merely pointed the tool at — a
+ * Retool clone list, a patterns file, an {@code --exclude-regex}, a profile. {@code
+ * java.util.regex} has no match timeout and no depth limit, so such a pattern can otherwise
+ * monopolize or end the run (CWE-1333).
+ *
+ * <p>Two distinct failure modes, both handled here, because bounding one does not bound the other:
+ *
+ * <ul>
+ *   <li><b>Backtracking</b> burns time while re-reading the input, so a read budget bounds it.
+ *   <li><b>Depth</b> costs no reads at all: the engine recurses once per pattern node, so a long
+ *       flat pattern exhausts the stack having read almost nothing — measured at ~6,000 reads of
+ *       a 100,000 budget. Only catching the resulting {@link StackOverflowError} bounds that.
+ * </ul>
+ */
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class UntrustedPatterns {
+
+    /**
+     * How much of the input one pattern may read before it is given up on. Legitimate patterns
+     * read a small multiple of the input's length; this leaves three orders of magnitude of room.
+     */
+    public static final int MAX_CHARACTER_READS = 100_000;
+
+    private static final int PATTERN_EXCERPT_LENGTH = 120;
+
+    /** A pattern that could not be evaluated within its budget, or at all. */
+    public static final class RejectedPatternException extends RuntimeException {
+
+        RejectedPatternException(String message) {
+            super(message);
+        }
+    }
+
+    /** Compiles an untrusted pattern, rejecting one too deep for the engine to build. */
+    @Nonnull
+    public static Pattern compile(@Nonnull String regex) {
+        try {
+            return Pattern.compile(regex);
+        } catch (StackOverflowError e) {
+            throw rejected(regex, "is too deeply nested for the regular expression engine");
+        }
+    }
+
+    /** As {@link Matcher#matches()}, bounded. */
+    public static boolean matches(@Nonnull Pattern pattern, @Nonnull String input) {
+        return evaluate(pattern, input, true);
+    }
+
+    /** As {@link Matcher#find()}, bounded. */
+    public static boolean find(@Nonnull Pattern pattern, @Nonnull String input) {
+        return evaluate(pattern, input, false);
+    }
+
+    private static boolean evaluate(Pattern pattern, String input, boolean wholeInput) {
+        Matcher matcher = pattern.matcher(new BudgetedCharSequence(input, MAX_CHARACTER_READS));
+        try {
+            return wholeInput ? matcher.matches() : matcher.find();
+        } catch (BudgetExceeded e) {
+            throw rejected(
+                    pattern.pattern(),
+                    format(
+                            "read more than %d characters of '%s' without deciding: it backtracks "
+                                    + "catastrophically",
+                            MAX_CHARACTER_READS,
+                            input));
+        } catch (StackOverflowError e) {
+            // The stack unwinds fully before this runs: the engine holds no state of its own
+            // across a match, so giving up on this one pattern leaves the run usable.
+            throw rejected(pattern.pattern(), "exhausted the stack of the regular expression engine");
+        }
+    }
+
+    private static RejectedPatternException rejected(String regex, String reason) {
+        String excerpt = regex.length() > PATTERN_EXCERPT_LENGTH
+                ? regex.substring(0, PATTERN_EXCERPT_LENGTH) + "… (" + regex.length() + " characters)"
+                : regex;
+        return new RejectedPatternException(
+                format("Pattern '%s' %s, and was given up on", excerpt, reason));
+    }
+
+    /** Signals the read budget's exhaustion; never leaves this class. */
+    private static final class BudgetExceeded extends RuntimeException {
+
+        BudgetExceeded() {
+            super(null, null, false, false);
+        }
+    }
+
+    private static final class BudgetedCharSequence implements CharSequence {
+
+        private final CharSequence delegate;
+        private int readsLeft;
+
+        BudgetedCharSequence(CharSequence delegate, int readsLeft) {
+            this.delegate = delegate;
+            this.readsLeft = readsLeft;
+        }
+
+        @Override
+        public char charAt(int index) {
+            if (--readsLeft < 0) {
+                throw new BudgetExceeded();
+            }
+            return delegate.charAt(index);
+        }
+
+        @Override
+        public int length() {
+            return delegate.length();
+        }
+
+        @Override
+        public CharSequence subSequence(int start, int end) {
+            return delegate.subSequence(start, end);
+        }
+
+        @Override
+        public String toString() {
+            return delegate.toString();
+        }
+    }
+}

--- a/core/src/test/java/io/github/datromtool/UntrustedPatternTest.java
+++ b/core/src/test/java/io/github/datromtool/UntrustedPatternTest.java
@@ -1,0 +1,92 @@
+package io.github.datromtool;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import io.github.datromtool.data.Filter;
+import io.github.datromtool.data.NameMatcher;
+import io.github.datromtool.data.ParsedGame;
+import io.github.datromtool.data.PostFilter;
+import io.github.datromtool.data.RegionData;
+import io.github.datromtool.domain.datafile.logiqx.Game;
+import io.github.datromtool.retool.CloneListMatcher;
+import io.github.datromtool.data.SortingPreference;
+import io.github.datromtool.domain.retool.CloneList;
+import io.github.datromtool.domain.retool.CloneListDescription;
+import io.github.datromtool.domain.retool.NameType;
+import io.github.datromtool.domain.retool.VariantGroup;
+import io.github.datromtool.domain.retool.VariantTitle;
+import com.google.common.collect.ImmutableMap;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * A regex a user points the tool at — a clone list's searchTerm, an {@code --exclude-regex}, a
+ * patterns file, a profile — is untrusted input. Whatever it does to the engine must come back as
+ * an ordinary failure naming the offending pattern, never as an {@link Error} that unwinds the
+ * whole run.
+ *
+ * <p>The probe is depth, not backtracking: {@code java.util.regex} recurses as it matches, so a
+ * pattern can exhaust the stack having read a fraction of the read budget that bounds
+ * backtracking. The two failure modes need two different bounds.
+ */
+class UntrustedPatternTest {
+
+    /**
+     * Cheap to compile, but the engine recurses once per repetition while matching, so it
+     * exhausts the stack after ~20,000 characters — a fifth of the read budget that guards
+     * backtracking, which never fires here.
+     */
+    private static final String DEEP_PATTERN = "(a|b)*";
+    private static final String INPUT = "a".repeat(20_000);
+
+    private static ParsedGame gameNamed(String name) {
+        return ParsedGame.builder()
+                .game(Game.builder().name(name).description(name).build())
+                .regionData(new RegionData(ImmutableSet.of()))
+                .build();
+    }
+
+    @Test
+    void aPatternDeepEnoughToExhaustTheStackFailsAsAnExceptionWhenFiltering() {
+        Filter filter = Filter.builder()
+                .excludes(ImmutableSet.of(NameMatcher.regex(DEEP_PATTERN)))
+                .build();
+        GameFilterer filterer = new GameFilterer(filter, PostFilter.builder().build());
+
+        assertThrows(
+                RuntimeException.class,
+                () -> filterer.filter(ImmutableList.of(gameNamed(INPUT))),
+                "an exclude pattern that exhausts the engine must fail as an exception, not an Error");
+    }
+
+    @Test
+    void aPatternDeepEnoughToExhaustTheStackFailsAsAnExceptionWhenMatchingACloneList() {
+        CloneList cloneList = new CloneList(
+                new CloneListDescription("Test", "x", "1.0"),
+                ImmutableList.of(new VariantGroup(
+                        "Group",
+                        ImmutableList.of(),
+                        false,
+                        ImmutableList.of(new VariantTitle(
+                                DEEP_PATTERN,
+                                NameType.REGEX,
+                                1,
+                                ImmutableList.of(),
+                                false,
+                                false,
+                                ImmutableMap.of(),
+                                ImmutableList.of())),
+                        ImmutableList.of(),
+                        ImmutableList.of())));
+        CloneListMatcher matcher = new CloneListMatcher(
+                cloneList,
+                new RegionData(ImmutableSet.of()),
+                SortingPreference.builder().build());
+
+        assertThrows(
+                RuntimeException.class,
+                () -> matcher.match(gameNamed(INPUT)),
+                "a clone list pattern that exhausts the engine must fail as an exception, not an Error");
+    }
+}


### PR DESCRIPTION
Part of #75

## What

#43 bounded how much of the input a clone list pattern may read, on the reasoning that a backtracking engine reads the input once per step. That bounds backtracking, and nothing else: `java.util.regex` recurses as it matches, so a pattern can exhaust the stack having read a fraction of the budget. The resulting `StackOverflowError` was caught nowhere — `matchesBounded` caught only its own budget marker, `OneGameOneRom.generate` catches `Exception`, and `DatRomCommand.main` installs no handler — so the hostile pattern still ended the run, as a raw JVM trace.

The guard is now `UntrustedPatterns` in `core/util`, bounding **both** failure modes:

| Failure mode | Bound |
| --- | --- |
| backtracking — burns time re-reading the input | read budget (100 000 characters), unchanged from #43 |
| depth — costs almost no reads | `StackOverflowError` caught around compile and match |

Either way the caller gets a `RejectedPatternException` naming the pattern (excerpted, since a hostile pattern can be tens of kilobytes).

It is now used by every untrusted-regex source, not just clone lists:

| Source | Site |
| --- | --- |
| clone list `searchTerm` (nameType regex) and filter `matchString` | `CloneListMatcher` — its private copy of the machinery is deleted |
| `--include-regex`, `--exclude-regex`, `--includes-file`, `--excludes-file`, profile patterns | `NameMatcher.compile`, plus `GameFilterer`'s include / exclude / post-filter matching |

The category patterns `GameFilterer` owns are internal constants, not user input, and are left alone.

## The reviewer's repro was real but not testable as written

The finding came with `(a)`×6000 — a long flat pattern — overflowing at ~5.6% of the budget. Reproduced, but it sits on a boundary: at n=9000 the overflow lands sometimes in `Pattern.compile` (which `java.util.regex` converts into a `PatternSyntaxException`, already an ordinary exception) and sometimes at match time, depending on remaining stack. A test on that boundary would flake across machines and JDKs.

Re-probed for a deterministic case instead:

```
(a|b)*  n=20000   STACK-OVERFLOW at match
(a|b)*  n=50000   STACK-OVERFLOW at match
(a|b)* n=100000   STACK-OVERFLOW at match
```

Trivial to compile, overflows while matching, and reads only a fifth of the budget — so it demonstrates exactly the claim (depth is not bounded by reads) with no flake and no runaway thread.

## Red → green proof

Test file frozen byte-identical across both runs — `git hash-object core/src/test/java/io/github/datromtool/UntrustedPatternTest.java` = `4a3cea90ea4174642c185331eba978db288acc25` at red time and at green time.

RED, executed against untouched production code (`git stash push -- core/src/main`, run, `git stash pop`):

```
$ mvn -B -pl core -am test -Dtest=UntrustedPatternTest
[ERROR] Tests run: 2, Failures: 2, Errors: 0, Skipped: 0
[ERROR]   …FailsAsAnExceptionWhenFiltering:57         expected: <java.lang.RuntimeException> but was: <java.lang.StackOverflowError>
[ERROR]   …FailsAsAnExceptionWhenMatchingACloneList:87 expected: <java.lang.RuntimeException> but was: <java.lang.StackOverflowError>
```

GREEN, same tests, zero edits:

```
[INFO] Tests run: 55, Failures: 0, Errors: 0, Skipped: 0
  UntrustedPatternTest 2/2 · CloneListMatcherTest 17/17 · GameFiltererTest 36/36
```

One post-green edit, disclosed: the test class's Javadoc still described the reviewer's flat-pattern mechanism after the probe was retargeted; the comment was corrected and the suite re-run green. Committed hash `dfebabffdcbdba9b57c8922b3b38fa3ae63e9594`; no assertion changed.

`CloneListMatcherTest`'s existing backtracking rows stay green against the shared guard, which is what pins that the read budget survived the move.

## Gates

```
$ sh scripts/agent/run-gates.sh --diff origin/master
GATE PASS: mvn -B -q verify
GATES: PASS
```

## Deliberately not in this PR

#75 also records that `cli/src/main/resources/logback.xml` ships with its `STDERR` appender commented out, so even the clean failure message only reaches `datromtool.log` and never the console. That is a change to what every user sees on every run, not a bug fix, so it goes up separately rather than riding along here. The issue stays open for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of complex or deeply nested regular expressions.
  * Prevented problematic patterns from causing excessive processing or engine failures during game filtering and clone-list matching.
  * Added clearer rejection handling for unsafe regular expressions.

* **Tests**
  * Added coverage for deeply nested patterns and long input names to verify failures are handled safely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->