### PR TITLE
core: pin every shape a ROM header can take through a round trip

### DIFF
--- a/core/src/test/java/io/github/datromtool/domain/datafile/logiqx/RomTest.java
+++ b/core/src/test/java/io/github/datromtool/domain/datafile/logiqx/RomTest.java
@@ -3,16 +3,25 @@ package io.github.datromtool.domain.datafile.logiqx;
 import com.google.common.collect.ImmutableList;
 import io.github.datromtool.SerializationHelper;
 import io.github.datromtool.domain.datafile.logiqx.enumerations.YesNo;
+import io.github.datromtool.util.XMLValidator;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.api.io.TempDir;
 
 import java.io.ByteArrayInputStream;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.stream.Stream;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.params.provider.Arguments.argumentSet;
 
 /**
  * A ROM's header is part of its value: two ROMs that describe the same dumped file must
@@ -46,9 +55,9 @@ class RomTest {
         Rom one = romWithHeader(copyOf(NES_HEADER));
         Rom other = romWithHeader(copyOf(NES_HEADER));
 
-        assertNotEquals(
-                System.identityHashCode(one.header()),
-                System.identityHashCode(other.header()),
+        assertNotSame(
+                one.header(),
+                other.header(),
                 "test premise: the two headers must be distinct instances");
         assertEquals(one, other, "ROMs with byte-equal headers must be equal");
         assertEquals(
@@ -75,27 +84,55 @@ class RomTest {
                 () -> "toString must render header content, got: " + rendered);
     }
 
-    @Test
-    void givenAHeaderedRomInADatafile_whenRoundTrippedThroughXml_thenTheHeaderSurvives(
+    static Stream<Arguments> headerShapes() {
+        return Stream.of(
+                argumentSet("no header at all", null, null),
+                argumentSet("an empty header", ImmutableList.of(), ""),
+                argumentSet("a single byte", ImmutableList.of((byte) 0x1A), "1A"),
+                argumentSet("several bytes", NES_HEADER, "4E 45 53 1A"),
+                argumentSet(
+                        "a byte a text format would have to escape",
+                        ImmutableList.of((byte) 0x0A, (byte) 0x0D),
+                        "0A 0D"));
+    }
+
+    @ParameterizedTest
+    @MethodSource("headerShapes")
+    void givenARomInADatafile_whenRoundTrippedThroughXml_thenItsHeaderSurvives(
+            ImmutableList<Byte> header,
+            String expectedAttributeText,
             @TempDir Path tempDir) throws Exception {
         SerializationHelper helper = SerializationHelper.getInstance(tempDir);
         Datafile datafile = Datafile.builder()
                 .games(ImmutableList.of(Game.builder()
                         .name("Some Game (USA)")
                         .description("Some Game (USA)")
-                        .roms(ImmutableList.of(romWithHeader(NES_HEADER)))
+                        .roms(ImmutableList.of(romWithHeader(header)))
                         .build()))
                 .build();
 
         byte[] xml = helper.getXmlMapper().writeValueAsBytes(datafile);
+        String written = new String(xml, UTF_8);
         Datafile parsed = helper.loadXml(new ByteArrayInputStream(xml), Datafile.class);
 
-        ImmutableList<Byte> parsedHeader = parsed.getGames().get(0).getRoms().get(0).header();
+        if (expectedAttributeText == null) {
+            assertFalse(
+                    written.contains("header="),
+                    () -> "a ROM without a header must not emit the attribute, wrote: " + written);
+        } else {
+            assertTrue(
+                    written.contains("header=\"" + expectedAttributeText + "\""),
+                    () -> "the header attribute must be written as spaced upper-case hex, wrote: "
+                            + written);
+        }
         assertEquals(
-                NES_HEADER,
-                parsedHeader,
-                () -> "header bytes must survive the round trip, wrote: " + new String(xml));
+                header,
+                parsed.getGames().get(0).getRoms().get(0).header(),
+                () -> "header bytes must survive the round trip, wrote: " + written);
         assertEquals(datafile, parsed, "a round-tripped DAT must equal the one written");
+        // The same check every other DAT round-trip test in the repo makes: what we emit must
+        // still be a valid Logiqx document.
+        XMLValidator.validateLogiqxDat(xml);
     }
 
     /** A distinct instance holding the same bytes. */


### PR DESCRIPTION
Fixes #77

## What

Test-only. Three review findings against #35's coverage, all of them "verified by hand during review, pinned by nothing":

1. The equality premise asserted `assertNotEquals(System.identityHashCode(a), System.identityHashCode(b))`. Identity hash codes are not guaranteed distinct, so that was a proxy for the thing meant — now `assertNotSame`.
2. The round trip never called `XMLValidator.validateLogiqxDat`, which every other DAT round-trip test in the repo uses. A schema-invalid `header` emission would have passed.
3. Only a four-byte header was round-tripped, and only the parsed value was asserted — never the attribute text as written.

The round trip is now a matrix over the shapes a header can take, each asserting the emitted attribute text *and* the parsed value, and each validating the emitted document against the Logiqx schema:

| Shape | Emitted |
| --- | --- |
| absent | no `header=` attribute at all |
| empty | `header=""` |
| one byte | `header="1A"` (unspaced, as the old serializer's special case also did) |
| several bytes | `header="4E 45 53 1A"` |
| bytes a text format would have to escape (`0x0A`, `0x0D`) | `header="0A 0D"` |

## Behaviour-preserving, so no red run

Per `.agents/policy/testing.md`'s first principle, this is the refactor/prep case: it pins *existing* behaviour as an oracle and stays green across the change. There is no production change in this PR, so there is nothing that could have failed before it.

```
$ mvn -B -pl core -am test -Dtest=RomTest
[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0 -- in RomTest
```

## Gates

```
$ sh scripts/agent/run-gates.sh --diff origin/master
GATE PASS: mvn -B -q verify
GATES: PASS
```

## Still open, deliberately

The issue also asks whether spaced upper-case hex is what real No-Intro DATs actually put in `header=`. No fixture in the tree carries the attribute and the Logiqx DTD/XSD declare it as unconstrained `CDATA`, so nothing here can settle it — these tests pin what the tool currently emits, which is the most that can be pinned without a real sample. If a real DAT says otherwise, the serializer and this matrix change together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
