### PR TITLE
cli: keep a thread-less failure from shifting the progress bar

### DIFF
--- a/cli/src/main/java/io/github/datromtool/cli/progressbar/CommandLineProgressBar.java
+++ b/cli/src/main/java/io/github/datromtool/cli/progressbar/CommandLineProgressBar.java
@@ -272,11 +272,34 @@ public final class CommandLineProgressBar implements FileScanner.Listener, FileC
     public void reportFailure(int thread, Path path, String message, Throwable cause) {
         if (thread == FileScanner.Listener.NO_THREAD) {
             // Listing failures and interrupted result collection belong to no scanner line:
-            // there is no LineData slot to update, so they get a plain line.
-            writer.printf("FAILED: %s ('%s')%n", sanitizeForTerminal(message), sanitizeForTerminal(String.valueOf(path)));
+            // there is no LineData slot to update, so they get a line of their own.
+            printOutOfBand(format(
+                    "FAILED: %s ('%s')",
+                    sanitizeForTerminal(message),
+                    sanitizeForTerminal(String.valueOf(path))));
             return;
         }
         reportFailure(thread, path, null, message, cause);
+    }
+
+    /**
+     * Writes a line that belongs to none of the bar's rows. Every other draw path returns the
+     * cursor to where it found it; this one has no row of its own, so it re-opens the block the
+     * bar draws into afterwards. Without that, each such line shifts every later row down by one.
+     */
+    private synchronized void printOutOfBand(String text) {
+        if (threadLineData == null) {
+            // Before init(): nothing is reserved yet and plain lines are the norm here.
+            writer.printf("%s%n", text);
+            return;
+        }
+        Ansi ansi = ansi().reset().a(text).eraseLine().a(NEW_LINE);
+        for (int i = 0; i <= numThreads; i++) {
+            ansi.eraseLine();
+            ansi.a(NEW_LINE);
+        }
+        ansi.cursorUpLine(numThreads + 1);
+        writer.print(ansi);
     }
 
     @Override

--- a/cli/src/test/java/io/github/datromtool/cli/progressbar/CommandLineProgressBarCursorTest.java
+++ b/cli/src/test/java/io/github/datromtool/cli/progressbar/CommandLineProgressBarCursorTest.java
@@ -1,0 +1,87 @@
+package io.github.datromtool.cli.progressbar;
+
+import io.github.datromtool.io.FileScanner;
+import org.jline.terminal.Terminal;
+import org.jline.terminal.TerminalBuilder;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The bar draws into a fixed block of rows and every draw returns the cursor to the top of it. A
+ * failure that belongs to no scanning thread has no row of its own: it takes one line for itself
+ * — that is what the user reads — and must then re-open the block, so the rows the bar draws into
+ * still start where the cursor is. Without that, every later thread line renders one row off,
+ * once per failure.
+ */
+class CommandLineProgressBarCursorTest {
+
+    private static final int THREADS = 2;
+
+    /** jansi renders these as cursor-next-line and cursor-previous-line. */
+    private static final Pattern LINE_MOVE = Pattern.compile("\\[(\\d+)([EF])");
+
+    /**
+     * Rows the cursor ends up below where it started: newlines and cursor-next-line move down,
+     * cursor-previous-line moves back up.
+     */
+    private static int netRowsMoved(String rendered) {
+        int net = 0;
+        for (int i = 0; i < rendered.length(); i++) {
+            if (rendered.charAt(i) == '\n') {
+                net++;
+            }
+        }
+        Matcher matcher = LINE_MOVE.matcher(rendered);
+        while (matcher.find()) {
+            int amount = Integer.parseInt(matcher.group(1));
+            net += matcher.group(2).equals("E") ? amount : -amount;
+        }
+        return net;
+    }
+
+    @Test
+    void aThreadLessFailureLeavesTheCursorWhereItFoundIt() throws Exception {
+        ByteArrayOutputStream captured = new ByteArrayOutputStream();
+        try (Terminal terminal = TerminalBuilder.builder()
+                .dumb(true)
+                .streams(new ByteArrayInputStream(new byte[0]), captured)
+                .build()) {
+            CommandLineProgressBar bar =
+                    new CommandLineProgressBar(terminal, "Scanning", "Scanning input...");
+            bar.init(THREADS);
+            bar.reportTotalItems(THREADS);
+            bar.reportStart(1, Path.of("rom.bin"), 1024L);
+            terminal.flush();
+            captured.reset();
+
+            bar.reportFailure(
+                    FileScanner.Listener.NO_THREAD,
+                    Path.of("unreadable"),
+                    "Could not list the directory",
+                    new java.io.IOException("boom"));
+            terminal.flush();
+        }
+
+        String rendered = captured.toString(StandardCharsets.UTF_8);
+        assertTrue(
+                rendered.contains("Could not list the directory"),
+                () -> "test premise: the failure must be reported to the user, got:\n" + rendered);
+        assertEquals(
+                1,
+                netRowsMoved(rendered),
+                () -> "the failure must take exactly its own row, got:\n" + rendered);
+        assertTrue(
+                rendered.contains("[" + (THREADS + 1) + "F"),
+                () -> "the bar must re-open its " + (THREADS + 1) + "-row block after the line, "
+                        + "so later thread lines still land on their own rows, got:\n" + rendered);
+    }
+}


### PR DESCRIPTION
Fixes #76

## What

`CommandLineProgressBar` draws into a fixed block of rows, and every draw path in the class returns the cursor to the top of that block. The thread-less failure line added in #37 was a bare `writer.printf(...)`: it moved the cursor down a row and never came back, so every later thread line rendered one row further off — once per failure — and it wrote outside the lock the other draw paths hold, so it could interleave mid-sequence with a worker's ANSI output.

The line now takes one row for itself (that is what the user reads) and then re-opens the block, inside the same `synchronized` as the rest. Before `init()` it still prints plainly: nothing is reserved at that point, which is exactly where the existing listing messages write.

## Red → green proof

Test file frozen byte-identical across both runs — `git hash-object cli/src/test/java/io/github/datromtool/cli/progressbar/CommandLineProgressBarCursorTest.java` = `b29527408bf881556cd8bf6b2a469e8dbf2d6447` at red time and at green time.

RED, executed against untouched production code (`git stash push -- cli/src/main`, run, `git stash pop`):

```
$ mvn -B -pl cli -am test -Dtest=CommandLineProgressBarCursorTest
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0
[ERROR]   CommandLineProgressBarCursorTest.aThreadLessFailureLeavesTheCursorWhereItFoundIt:82
  the bar must re-open its 3-row block after the line, so later thread lines still land on their own rows
```

GREEN, same test, zero edits:

```
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0 -- in CommandLineProgressBarCursorTest
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0 -- in CommandLineProgressBarSanitizationTest
[INFO] Tests run: 13, Failures: 0, Errors: 0, Skipped: 0 -- in ScanCommandTest
```

The test renders through a real jline terminal and reads the ANSI stream back: it counts newlines and cursor-line moves to assert the failure takes exactly its own row, then asserts the block is re-opened. It asserts the message is present first, so neither check can pass on an empty capture.

A note on how that assertion got its shape: the first version demanded *zero* net movement, which the fix could never satisfy — the message legitimately consumes a row. That was a wrong premise in the test, corrected before the red run recorded above; the invariant that actually matters is that the block is re-opened underneath it.

## Gates

```
$ sh scripts/agent/run-gates.sh --diff origin/master
GATE PASS: mvn -B -q verify
GATES: PASS
```

Found during an independent adversarial review of the merged #37 fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
