### PR TITLE
cli: tell the user when a scan came back incomplete

### DIFF
--- a/cli/src/main/java/io/github/datromtool/cli/command/ScanCommand.java
+++ b/cli/src/main/java/io/github/datromtool/cli/command/ScanCommand.java
@@ -21,6 +21,7 @@ import javax.annotation.Nullable;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.Callable;
@@ -139,7 +140,18 @@ public final class ScanCommand implements Callable<Integer> {
         } else {
             lines.forEach(System.out::println);
         }
-        return loggingListener.isErrors() ? 1 : 0;
+        if (!loggingListener.isErrors()) {
+            return 0;
+        }
+        // Scan failures are logged, and logback's CLI config deliberately has no console
+        // appender: one would interleave arbitrary lines into the reserved block the progress
+        // bar draws into (see CommandLineProgressBar#printOutOfBand). So say it once here, the
+        // way OneGameOneRomCommand does — after the bar is finished, and on stderr, since
+        // stdout carries the machine-readable report.
+        Path logFile = Paths.get("").toAbsolutePath().normalize().resolve("datromtool.log");
+        System.err.println("!!! Errors during execution detected: the report may be incomplete !!!");
+        System.err.printf("Check the generated log file for details: '%s'%n", logFile);
+        return 1;
     }
 
     AppConfig.FileScannerConfig resolveScannerConfig() {

--- a/cli/src/main/java/io/github/datromtool/cli/command/ScanCommand.java
+++ b/cli/src/main/java/io/github/datromtool/cli/command/ScanCommand.java
@@ -143,11 +143,9 @@ public final class ScanCommand implements Callable<Integer> {
         if (!loggingListener.isErrors()) {
             return 0;
         }
-        // Scan failures are logged, and logback's CLI config deliberately has no console
-        // appender: one would interleave arbitrary lines into the reserved block the progress
-        // bar draws into (see CommandLineProgressBar#printOutOfBand). So say it once here, the
-        // way OneGameOneRomCommand does — after the bar is finished, and on stderr, since
-        // stdout carries the machine-readable report.
+        // issue #75: failures only reach datromtool.log — a console appender would interleave
+        // into the block the progress bar draws into. Hence a notice here instead: after the
+        // bar is finished, and on stderr, since stdout carries the report.
         Path logFile = Paths.get("").toAbsolutePath().normalize().resolve("datromtool.log");
         System.err.println("!!! Errors during execution detected: the report may be incomplete !!!");
         System.err.printf("Check the generated log file for details: '%s'%n", logFile);

--- a/cli/src/test/java/io/github/datromtool/cli/command/ScanCommandTest.java
+++ b/cli/src/test/java/io/github/datromtool/cli/command/ScanCommandTest.java
@@ -42,6 +42,10 @@ class ScanCommandTest {
     private static final String KNOWN_MD5 = "25fb98425aea8268ba4e26c00eef4a00";
     private static final String KNOWN_SHA1 = "c502ca2c1cd3e7301028fe4f29ac51101c3866e7";
 
+    // The second line of the errored-scan notice; pinned separately from the first so a
+    // regression that misroutes only the log pointer cannot slip through.
+    private static final String LOG_FILE_NOTICE = "Check the generated log file for details:";
+
     private static int run(ScanCommand command, String... args) {
         CommandLine commandLine = new CommandLine(command);
         commandLine.parseArgs(args);
@@ -255,11 +259,15 @@ class ScanCommandTest {
         String stderr = capturedErr.toString();
         assertTrue(stderr.contains("Errors during execution detected"),
                 "stderr must announce that the scan hit errors, got:\n" + stderr);
-        assertTrue(stderr.contains("datromtool.log"),
+        assertTrue(stderr.contains(LOG_FILE_NOTICE),
                 "stderr must point at the log file holding the details, got:\n" + stderr);
-        // The report itself stays machine-readable: the notice belongs on stderr only.
+        assertTrue(stderr.contains("datromtool.log"),
+                "the log-file notice must name the log file itself, got:\n" + stderr);
+        // The report itself stays machine-readable: both notice lines belong on stderr only.
         assertFalse(stdout.contains("Errors during execution detected"),
                 "the error notice must not pollute the stdout report, got:\n" + stdout);
+        assertFalse(stdout.contains(LOG_FILE_NOTICE),
+                "the log-file notice must not pollute the stdout report, got:\n" + stdout);
     }
 
     // Row 11: a clean scan stays quiet — the notice is not an unconditional banner.
@@ -277,8 +285,11 @@ class ScanCommandTest {
         } finally {
             System.setErr(originalErr);
         }
-        assertFalse(capturedErr.toString().contains("Errors during execution detected"),
-                "a clean scan must not claim errors, got:\n" + capturedErr);
+        String stderr = capturedErr.toString();
+        assertFalse(stderr.contains("Errors during execution detected"),
+                "a clean scan must not claim errors, got:\n" + stderr);
+        assertFalse(stderr.contains(LOG_FILE_NOTICE),
+                "a clean scan must not send the user to the log file, got:\n" + stderr);
     }
 
     /**

--- a/cli/src/test/java/io/github/datromtool/cli/command/ScanCommandTest.java
+++ b/cli/src/test/java/io/github/datromtool/cli/command/ScanCommandTest.java
@@ -228,6 +228,59 @@ class ScanCommandTest {
         }
     }
 
+    // Row 10: an errored scan must say so on the terminal too (issue #75). Failures only ever
+    // reach datromtool.log — logback's CLI config has no console appender on purpose — so an
+    // exit code alone leaves an interactive user with no hint that the report is incomplete.
+    @Test
+    void erroredScanReportsFailuresOnStderr(@TempDir Path tempDir) throws IOException {
+        Files.write(tempDir.resolve("rom.bin"), new byte[16 * 1024]);
+        Path unlistable = Files.createDirectory(tempDir.resolve("unlistable"));
+        assumeTrue(makeUnlistable(unlistable), "this filesystem/user cannot make a directory unlistable");
+        ByteArrayOutputStream capturedErr = new ByteArrayOutputStream();
+        PrintStream originalErr = System.err;
+        System.setErr(new PrintStream(capturedErr));
+        String stdout;
+        try {
+            stdout = captureStdout(() -> assertEquals(
+                    1,
+                    run(new ScanCommand(), tempDir.toString(), "--out-mode", "json"),
+                    "a scan that could not list a subdirectory must not exit 0"));
+        } finally {
+            System.setErr(originalErr);
+            Files.setPosixFilePermissions(unlistable, Set.of(
+                    PosixFilePermission.OWNER_READ,
+                    PosixFilePermission.OWNER_WRITE,
+                    PosixFilePermission.OWNER_EXECUTE));
+        }
+        String stderr = capturedErr.toString();
+        assertTrue(stderr.contains("Errors during execution detected"),
+                "stderr must announce that the scan hit errors, got:\n" + stderr);
+        assertTrue(stderr.contains("datromtool.log"),
+                "stderr must point at the log file holding the details, got:\n" + stderr);
+        // The report itself stays machine-readable: the notice belongs on stderr only.
+        assertFalse(stdout.contains("Errors during execution detected"),
+                "the error notice must not pollute the stdout report, got:\n" + stdout);
+    }
+
+    // Row 11: a clean scan stays quiet — the notice is not an unconditional banner.
+    @Test
+    void cleanScanPrintsNoErrorNotice(@TempDir Path tempDir) throws IOException {
+        Files.write(tempDir.resolve("rom.bin"), new byte[16 * 1024]);
+        ByteArrayOutputStream capturedErr = new ByteArrayOutputStream();
+        PrintStream originalErr = System.err;
+        System.setErr(new PrintStream(capturedErr));
+        try {
+            captureStdout(() -> assertEquals(
+                    0,
+                    run(new ScanCommand(), tempDir.toString(), "--out-mode", "json"),
+                    "a clean scan must exit 0"));
+        } finally {
+            System.setErr(originalErr);
+        }
+        assertFalse(capturedErr.toString().contains("Errors during execution detected"),
+                "a clean scan must not claim errors, got:\n" + capturedErr);
+    }
+
     /**
      * Strips every permission bit and confirms the directory really became unlistable — it does
      * not on a filesystem without POSIX permissions, nor for a superuser.


### PR DESCRIPTION
## Why

Issue #75's remaining item asked for logback's `STDERR` appender to be re-enabled so error
messages reach the terminal. Enabling it is the wrong fix: `CommandLineProgressBar` draws
into a reserved cursor block (it moves the cursor up and down across a fixed set of rows —
`printOutOfBand` exists precisely so a stray line does not shift them), and with no usable
terminal the bar writes to `System.err` itself. A logback `ConsoleAppender` would interleave
arbitrary lines into that block and corrupt the display.

The real gap the item points at is narrower. `ScanCommand` returns exit 1 when the scanner
logged a failure, but prints nothing: the failures only reach `datromtool.log`, so an
interactive user gets a report that silently omits whatever could not be read, with no hint
beyond the exit code. `OneGameOneRomCommand` already handles this correctly — an end-of-run
notice on stderr, after the bar has finished drawing, pointing at the log file.
`dat check`, `dat convert` and `retool update` surface their own messages, so `scan` was the
only silent path.

## What changed

- `ScanCommand` prints the same notice as `one-game-one-rom`, on the same terms: only when
  errors were logged, on stderr (stdout carries the machine-readable report), and after the
  progress bar is done.
- `logback.xml` is untouched — the `STDERR` appender stays commented out, now for a documented
  reason rather than by omission.

## Tests

`ScanCommandTest`:

- `erroredScanReportsFailuresOnStderr` — a scan over a tree containing an unlistable
  subdirectory must exit 1 *and* announce the failure on stderr with the log-file path, while
  the stdout report stays clean.
- `cleanScanPrintsNoErrorNotice` — a clean scan prints no notice, so this cannot degrade into
  an unconditional banner.

Test-first proof, verified mechanically by `scripts/agent/verify-red-proof.sh`
(`FREEZE-OK` / `RED-OK` / `GREEN-OK` / `VERDICT: PASS`); the reproduction test is frozen at
`git hash-object 709b5ecbd84f6cdf4a82a760086e79006f72e55c` across the red and green runs.
Full reactor gates: `GATE PASS: mvn -B -q verify`.

Part of #75.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scan failure reporting with clear terminal notices.
  * Failure output now includes the location of the diagnostic log file (normalized path under the current working directory).
  * Successful scans are now quiet on error output.
  * Machine-readable scan results remain separated from diagnostic messages, preserving clean JSON output on success and failure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->